### PR TITLE
Small but important fix for m_DoExt_McaMorf

### DIFF
--- a/include/m_Do/m_Do_ext.h
+++ b/include/m_Do/m_Do_ext.h
@@ -245,7 +245,7 @@ public:
     void play(Vec *, u32, u8);
     void stopZelAnime();
 
-    u32 pad[0x50]; // J3DMtxCalcMaya
+    u32 pad[0x13]; // J3DMtxCalcMaya
     /* 0x50 */ J3DModel* mpModel;
     /* 0x54 */ J3DAnmTransform* mpAnm;
     /* 0x58 */ J3DFrameCtrl mFrameCtrl;

--- a/include/m_Do/m_Do_ext.h
+++ b/include/m_Do/m_Do_ext.h
@@ -245,7 +245,7 @@ public:
     void play(Vec *, u32, u8);
     void stopZelAnime();
 
-    u32 pad[0x13]; // J3DMtxCalcMaya
+    u8 pad[0x4C]; // J3DMtxCalcMaya
     /* 0x50 */ J3DModel* mpModel;
     /* 0x54 */ J3DAnmTransform* mpAnm;
     /* 0x58 */ J3DFrameCtrl mFrameCtrl;


### PR DESCRIPTION
A typo led to `m_DoExt_McaMorf` having 0x50 *integer*s for padding instead of 0x50 *bytes*. This PR fixes that, as well as removing 4 bytes of padding for what I assume is the vtable pointer.