### PR TITLE
d_bg_s constructors

### DIFF
--- a/include/SSystem/SComponent/c_bg_s_chk.h
+++ b/include/SSystem/SComponent/c_bg_s_chk.h
@@ -8,7 +8,7 @@ struct cBgD_Vtx_t : public Vec {};
 
 class cBgS_GrpPassChk {
 public:
-    virtual ~cBgS_GrpPassChk();
+    virtual ~cBgS_GrpPassChk() {}
 };
 
 class cBgS_PolyPassChk;

--- a/include/SSystem/SComponent/c_bg_s_gnd_chk.h
+++ b/include/SSystem/SComponent/c_bg_s_gnd_chk.h
@@ -8,11 +8,13 @@
 class cBgS_GndChk : public cBgS_Chk, public cBgS_PolyInfo {
 public:
     cBgS_GndChk();
-    void SetPos(cXyz const*);
+    void SetPos(cXyz const* pos) {
+        m_pos = *pos;
+    }
     void SetPos(Vec const*);
     void PreCheck();
 
-    virtual ~cBgS_GndChk();
+    virtual ~cBgS_GndChk() {}
 
     f32 GetNowY() const { return mNowY; }
     void SetNowY(f32 y) { mNowY = y; }

--- a/include/SSystem/SComponent/c_bg_s_poly_info.h
+++ b/include/SSystem/SComponent/c_bg_s_poly_info.h
@@ -13,7 +13,7 @@ private:
     /* 0x08 */ unsigned int mActorId;
 
 public:
-    cBgS_PolyInfo();
+    cBgS_PolyInfo() {}
     void ClearPi() {
         mPolyIndex = -1;
         mBgIndex = 0x100;
@@ -26,7 +26,7 @@ public:
     void SetPolyIndex(int);
     bool ChkBgIndex() const;
 
-    virtual ~cBgS_PolyInfo();
+    virtual ~cBgS_PolyInfo() {}
 
     u16 GetPolyIndex() const { return mPolyIndex; }
     u16 GetBgIndex() const { return mBgIndex; }

--- a/include/d/d_bg_s_acch.h
+++ b/include/d/d_bg_s_acch.h
@@ -206,6 +206,6 @@ public:
     }
 
     /* 80BB336C */ virtual ~dBgS_ObjAcch() {}
-};
+};  // Size: 0x1C4
 
 #endif /* D_BG_D_BG_S_ACCH_H */

--- a/include/d/d_bg_s_chk.h
+++ b/include/d/d_bg_s_chk.h
@@ -6,11 +6,11 @@
 
 class dBgS_Chk : public dBgS_PolyPassChk, public dBgS_GrpPassChk {
 public:
-    dBgS_Chk();
-    cBgS_PolyPassChk* GetPolyPassChkInfo();
-    cBgS_GrpPassChk* GetGrpPassChkInfo();
+    dBgS_Chk() {}
+    cBgS_PolyPassChk* GetPolyPassChkInfo() { return (cBgS_PolyPassChk*)this; }
+    cBgS_GrpPassChk* GetGrpPassChkInfo() { return (cBgS_GrpPassChk*)this; }
 
-    virtual ~dBgS_Chk();
+    virtual ~dBgS_Chk() {}
 };  // Size: 0x14
 
 STATIC_ASSERT(sizeof(dBgS_Chk) == 0x14);

--- a/include/d/d_bg_s_gnd_chk.h
+++ b/include/d/d_bg_s_gnd_chk.h
@@ -6,8 +6,11 @@
 
 class dBgS_GndChk : public cBgS_GndChk, public dBgS_Chk {
 public:
-    /* 8007757C */ dBgS_GndChk();
-    /* 800775F0 */ virtual ~dBgS_GndChk();
+    /* 8007757C */ dBgS_GndChk() {
+        this->SetPolyPassChk(this->GetPolyPassChkInfo());
+        this->SetGrpPassChk(this->GetGrpPassChkInfo());
+    }
+    /* 800775F0 */ virtual ~dBgS_GndChk() {}
 };  // Size: 0x54
 
 STATIC_ASSERT(sizeof(dBgS_GndChk) == 0x54);
@@ -22,7 +25,7 @@ class dBgS_ObjGndChk : public dBgS_GndChk {
 public:
     dBgS_ObjGndChk() { SetObj(); }
 
-    /* 8001E020 */ virtual ~dBgS_ObjGndChk();
+    /* 8001E020 */ virtual ~dBgS_ObjGndChk() {}
 };
 
 class dBgS_ObjGndChk_Wtr : public dBgS_ObjGndChk {
@@ -41,9 +44,9 @@ public:
 
 class dBgS_ObjGndChk_All : public dBgS_ObjGndChk {
 public:
-    /* 800778E8 */ virtual ~dBgS_ObjGndChk_All();
+    /* 800778E8 */ virtual ~dBgS_ObjGndChk_All() {}
 
-    dBgS_ObjGndChk_All() { /* OnAll(); */ }
+    dBgS_ObjGndChk_All() { OnAll(); }
 };
 
 class dBgS_CamGndChk : public dBgS_GndChk {

--- a/include/d/d_bg_s_grp_pass_chk.h
+++ b/include/d/d_bg_s_grp_pass_chk.h
@@ -7,13 +7,13 @@ class dBgS_GrpPassChk : public cBgS_GrpPassChk {
 public:
     enum {
         /* 0x1 */ NORMAL_GRP = 1,
-        /* 0x2 */ WATER_GRP,
-        /* 0x3 */ FULL_GRP
+        /* 0x2 */ WATER_GRP = 2,
+        /* 0x3 */ FULL_GRP = NORMAL_GRP | WATER_GRP | 4 | 8,
     };
 
-    /* 80077BA0 */ dBgS_GrpPassChk();
+    /* 80077BA0 */ dBgS_GrpPassChk() { mGrp = NORMAL_GRP; }
 
-    /* 80077BC4 */ virtual ~dBgS_GrpPassChk();
+    /* 80077BC4 */ virtual ~dBgS_GrpPassChk() {}
 
     void OnWaterGrp() { mGrp |= WATER_GRP; }
     void OnSpl() { mGrp |= WATER_GRP; }

--- a/include/d/d_bg_s_poly_pass_chk.h
+++ b/include/d/d_bg_s_poly_pass_chk.h
@@ -5,7 +5,7 @@
 
 class cBgS_PolyPassChk {
 public:
-    virtual ~cBgS_PolyPassChk();
+    virtual ~cBgS_PolyPassChk() {}
 
     /* 0x4 */ u8 mbObjThrough;
     /* 0x5 */ u8 mbCamThrough;
@@ -18,8 +18,16 @@ public:
 
 class dBgS_PolyPassChk : public cBgS_PolyPassChk {
 public:
-    dBgS_PolyPassChk();
-    virtual ~dBgS_PolyPassChk();
+    dBgS_PolyPassChk() {
+        mbObjThrough = 0;
+        mbCamThrough = 0;
+        mbLinkThrough = 0;
+        mbArrowsAndLightThrough = 0;
+        mbBombThrough = 0;
+        mbBoomerangThrough = 0;
+        mbHookshotThrough = 0;
+    }
+    virtual ~dBgS_PolyPassChk() {}
 
     void SetObj() { mbObjThrough = 1; }
 };


### PR DESCRIPTION
dBgS_ObjGndChk_All and its many parent classes now construct/destruct correctly (e.g. when passed to GroundCross)