### PR TITLE
arrow, tag_ret, obj_Ygush00, kytag06, nh: all OK

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -429,7 +429,7 @@ config.libs = [
             Object(NonMatching, "d/actor/d_a_ib.cpp"),
             Object(NonMatching, "d/actor/d_a_item.cpp"),
             Object(Matching,    "d/actor/d_a_itembase.cpp"),
-            Object(NonMatching, "d/actor/d_a_nh.cpp"),
+            Object(Matching,    "d/actor/d_a_nh.cpp"),
             Object(NonMatching, "d/actor/d_a_npc_fa1.cpp"),
             Object(NonMatching, "d/actor/d_a_obj_search.cpp"),
             Object(NonMatching, "d/actor/d_a_player.cpp"),

--- a/configure.py
+++ b/configure.py
@@ -198,11 +198,11 @@ cflags_rel = [
 
 
 # Helper function for single-object RELs
-def Rel(status, rel_name, cpp_name):
+def Rel(status, rel_name, cpp_name, extra_cflags=[]):
     return {
         "lib": rel_name,
         "mw_version": "GC/1.3.2",
-        "cflags": cflags_rel,
+        "cflags": cflags_rel + extra_cflags,
         "host": True,
         "objects": [
             Object(status, cpp_name),
@@ -211,8 +211,8 @@ def Rel(status, rel_name, cpp_name):
 
 
 # Helper function for actor RELs
-def ActorRel(status, rel_name):
-    return Rel(status, rel_name, f"d/actor/{rel_name}.cpp")
+def ActorRel(status, rel_name, extra_cflags=[]):
+    return Rel(status, rel_name, f"d/actor/{rel_name}.cpp", extra_cflags=extra_cflags)
 
 
 # Helper function for JSystem libraries
@@ -414,7 +414,7 @@ config.libs = [
             Object(NonMatching, "d/d_snap.cpp"),
             Object(Matching,    "d/d_point_wind.cpp"),
             Object(NonMatching, "d/actor/d_a_agb.cpp"),
-            Object(NonMatching, "d/actor/d_a_arrow.cpp"),
+            Object(Matching,    "d/actor/d_a_arrow.cpp", cflags=[*cflags_framework, "-sym off"]),
             Object(NonMatching, "d/actor/d_a_bg.cpp"),
             Object(NonMatching, "d/actor/d_a_bomb.cpp"),
             Object(NonMatching, "d/actor/d_a_bomb2.cpp"),
@@ -1239,7 +1239,7 @@ config.libs = [
     ActorRel(NonMatching, "d_a_kytag03"),
     ActorRel(NonMatching, "d_a_kytag04"),
     ActorRel(NonMatching, "d_a_kytag05"),
-    ActorRel(NonMatching, "d_a_kytag06"),
+    ActorRel(Matching,    "d_a_kytag06"),
     ActorRel(NonMatching, "d_a_kytag07"),
     ActorRel(NonMatching, "d_a_lamp"),
     ActorRel(NonMatching, "d_a_lod_bg"),
@@ -1250,7 +1250,7 @@ config.libs = [
     ActorRel(NonMatching, "d_a_msw"),
     ActorRel(NonMatching, "d_a_mtoge"),
     ActorRel(NonMatching, "d_a_obj_AjavW"),
-    ActorRel(NonMatching, "d_a_obj_Ygush00"),
+    ActorRel(Matching,    "d_a_obj_Ygush00", extra_cflags=["-sym off"]),
     ActorRel(NonMatching, "d_a_obj_akabe"),
     ActorRel(NonMatching, "d_a_obj_barrel"),
     ActorRel(NonMatching, "d_a_obj_barrel2"),
@@ -1292,7 +1292,7 @@ config.libs = [
     ActorRel(NonMatching, "d_a_pirate_flag"),
     ActorRel(NonMatching, "d_a_race_item"),
     ActorRel(NonMatching, "d_a_rd"),
-    ActorRel(Matching, "d_a_rectangle"),
+    ActorRel(Matching,    "d_a_rectangle"),
     ActorRel(NonMatching, "d_a_salvage"),
     ActorRel(NonMatching, "d_a_sbox"),
     ActorRel(NonMatching, "d_a_sk"),
@@ -1602,7 +1602,7 @@ config.libs = [
     ActorRel(NonMatching, "d_a_tag_etc"),
     ActorRel(NonMatching, "d_a_tag_island"),
     ActorRel(NonMatching, "d_a_tag_kf1"),
-    ActorRel(NonMatching, "d_a_tag_ret"),
+    ActorRel(Matching,    "d_a_tag_ret", extra_cflags=["-sym off"]),
     ActorRel(NonMatching, "d_a_tag_volcano"),
     ActorRel(NonMatching, "d_a_title"),
     ActorRel(NonMatching, "d_a_tn"),

--- a/include/JSystem/JParticle/JPAEmitter.h
+++ b/include/JSystem/JParticle/JPAEmitter.h
@@ -73,6 +73,12 @@ public:
     void setGlobalRTMatrix(MtxP mtx) {
         JPASetRMtxTVecfromMtx(mtx, mGlobalRotation, mGlobalTranslation);
     }
+    void setGlobalTranslation(f32 x, f32 y, f32 z) { mGlobalTranslation.set(x, y, z); }
+    void setGlobalParticleScale(const JGeometry::TVec3<float>& scale) {
+        mGlobalScale.set(scale);
+        mGlobalScale2D.set(scale);
+    }
+    void setMaxFrame(s32 maxFrame) { mMaxFrame = maxFrame; }
 
     void stopCreateParticle() { setStatus(JPAEmtrStts_StopEmit); }
 

--- a/include/SSystem/SComponent/c_lib.h
+++ b/include/SSystem/SComponent/c_lib.h
@@ -87,7 +87,7 @@ inline T cLib_maxLimit(T val, T max) {
 
 template <typename T>
 T cLib_calcTimer(T* value) {
-    if (*value != 0) {
+    if ((s32)*value != 0) {
         *value = *value - 1;
     }
     return *value;

--- a/include/SSystem/SComponent/c_lib.h
+++ b/include/SSystem/SComponent/c_lib.h
@@ -86,16 +86,16 @@ inline T cLib_maxLimit(T val, T max) {
 }
 
 template <typename T>
+T cLib_getRndValue(T min, T range) {
+    return (T)(min + cM_rndF((f32)range));
+}
+
+template <typename T>
 T cLib_calcTimer(T* value) {
     if ((s32)*value != 0) {
         *value = *value - 1;
     }
     return *value;
-}
-
-template <typename T>
-T cLib_getRndValue(T min, T range) {
-    return (T)(min + cM_rndF((f32)range));
 }
 
 void MtxInit(void);

--- a/include/d/actor/d_a_arrow.h
+++ b/include/d/actor/d_a_arrow.h
@@ -33,9 +33,9 @@ public:
     void arrowShooting();
     void arrowUseMp();
     void ShieldReflect();
-    void check_water_in();
+    bool check_water_in();
     BOOL changeArrowMp();
-    void changeArrowType();
+    daArrow_c* changeArrowType();
     void changeArrowTypeNotReady();
     void setRoomInfo();
     void setKeepMatrix();
@@ -79,7 +79,7 @@ public:
     /* 0x360 */ dCcD_Stts mStts;
     /* 0x39C */ dCcD_Cps mCps;
     /* 0x4D4 */ dCcD_Sph mSph;
-    /* 0x600 */ u8 field_0x600[0x601 - 0x600];
+    /* 0x600 */ bool field_0x600;
     /* 0x601 */ u8 mArrowType;
     /* 0x602 */ s16 field_0x602;
     /* 0x604 */ s16 field_0x604;
@@ -111,7 +111,7 @@ public:
     /* 0x6A0 */ s32 field_0x6a0;
     /* 0x6A4 */ s32 mInWaterTimer;
     /* 0x6A8 */ cXyz field_0x6a8;
-    /* 0x6B4 */ u8 field_0x6B4[0x6E4 - 0x6B4];
+    /* 0x6B4 */ Mtx field_0x6b4;
     /* 0x6E4 */ u8 field_0x6e4;
     /* 0x6E5 */ u8 field_0x6E5[0x6E6 - 0x6E5];
     /* 0x6E6 */ csXyz field_0x6e6;

--- a/include/d/actor/d_a_player.h
+++ b/include/d/actor/d_a_player.h
@@ -100,7 +100,7 @@ public:
     virtual void getGroundY() = 0;
     virtual void getTactMusic() const;
     virtual void getTactTimerCancel() const;
-    virtual void checkPlayerGuard() const;
+    virtual BOOL checkPlayerGuard() const;
     virtual void getGrabMissActor();
     virtual u32 checkPlayerFly() const;
     virtual void checkFrontRoll() const;

--- a/include/d/actor/d_a_player_link.h
+++ b/include/d/actor/d_a_player_link.h
@@ -490,7 +490,7 @@ public:
     void setDamageEmitter();
     void endFlameDamageEmitter();
     void endDamageEmitter();
-    void setItemWaterEffect(fopAc_ac_c*, int, int);
+    static u32 setItemWaterEffect(fopAc_ac_c*, int, int);
     void getDemoLookActor();
     void setTinkleCeiverModel();
     void setTalismanModel();
@@ -1010,7 +1010,7 @@ public:
     virtual void getGroundY();
     virtual void getTactMusic() const;
     virtual void getTactTimerCancel() const;
-    virtual void checkPlayerGuard() const;
+    virtual BOOL checkPlayerGuard() const;
     virtual void getGrabMissActor();
     virtual u32 checkPlayerFly() const;
     virtual void checkFrontRoll() const;

--- a/include/d/d_bg_s.h
+++ b/include/d/d_bg_s.h
@@ -52,7 +52,10 @@ public:
 public:
     cBgS() {}
 
-    bool GetTriPla(cBgS_PolyInfo&) const;
+    cM3dGPla* GetTriPla(cBgS_PolyInfo&) const;
+    cM3dGPla* i_GetTriPla(cBgS_PolyInfo& polyInfo) const {
+        return GetTriPla(polyInfo.GetBgIndex(), polyInfo.GetPolyIndex());
+    }
     bool Regist(cBgW*, u32, void*);
     int Release(cBgW*);
     bool LineCross(cBgS_LinChk*);
@@ -101,8 +104,8 @@ public:
     void GetLinkNo(cBgS_PolyInfo&);
     int GetWallCode(cBgS_PolyInfo&);
     int GetSpecialCode(cBgS_PolyInfo&);
-    void GetAttributeCodeDirect(cBgS_PolyInfo&);
-    void GetAttributeCode(cBgS_PolyInfo&);
+    s32 GetAttributeCodeDirect(cBgS_PolyInfo&);
+    s32 GetAttributeCode(cBgS_PolyInfo&);
     void GetGroundCode(cBgS_PolyInfo&);
     void GetPolyId2(int, int, int, u32, u32);
     int GetCamMoveBG(cBgS_PolyInfo&);

--- a/include/d/d_bg_s_lin_chk.h
+++ b/include/d/d_bg_s_lin_chk.h
@@ -12,7 +12,7 @@ public:
         SetPolyPassChk(GetPolyPassChkInfo());
         SetGrpPassChk(GetGrpPassChkInfo());
     }
-    /* 80077D64 */ void Set(cXyz const* pi_start, cXyz const* pi_end, fopAc_ac_c const*);
+    /* 80077D64 */ void Set(cXyz* pi_start, cXyz* pi_end, fopAc_ac_c*);
 
     /* 80077CDC */ virtual ~dBgS_LinChk() {}
 

--- a/include/d/d_com_inf_game.h
+++ b/include/d/d_com_inf_game.h
@@ -193,9 +193,10 @@ public:
     s16 getItemMagicCount() { return mItemMagicCount; }
     void setItemMagicCount(s16 magic) { mItemMagicCount += magic; }
 
-    void setItemLifeCount(f32 num) {
-        mItemLifeCount += num;
-    }
+    void setItemLifeCount(f32 num) { mItemLifeCount += num; }
+    
+    s16 getItemArrowNumCount() { return mItemArrowNumCount; }
+    void setItemArrowNumCount(s16 num) { mItemArrowNumCount += num; }
 
     u8 checkMesgCancelButton() { return field_0x4949; }
 
@@ -1147,6 +1148,14 @@ inline s16 dComIfGp_getItemMagicCount() {
 
 inline void dComIfGp_setItemMagicCount(s16 magic) {
     g_dComIfG_gameInfo.play.setItemMagicCount(magic);
+}
+
+inline s16 dComIfGp_getItemArrowNumCount() {
+    return g_dComIfG_gameInfo.play.getItemArrowNumCount();
+}
+
+inline void dComIfGp_getItemArrowNumCount(s16 num) {
+    return g_dComIfG_gameInfo.play.setItemArrowNumCount(num);
 }
 
 inline u8 dComIfGp_checkMesgCancelButton() {

--- a/include/d/d_jnt_hit.h
+++ b/include/d/d_jnt_hit.h
@@ -15,6 +15,13 @@ public:
 
 class JntHit_c {
 public:
+    void CreateInit();
+    void CylHitPosAngleOffset(cXyz*, csXyz*, cXyz*, csXyz*, cXyz, cXyz, float);
+    void Cyl2HitPosAngleOffset(cXyz*, csXyz*, cXyz*, csXyz*, cXyz, cXyz, float);
+    void SphHitPosAngleOffset(cXyz*, csXyz*, cXyz*, csXyz*, cXyz, float);
+    void HitBufferUpdate(int*, cXyz*, int, csXyz*, cXyz*);
+    s32 searchJntHitPosAngleOffset(cXyz*, csXyz*, cXyz*, csXyz*);
+    
     J3DModel* getModel() { return mpModel; }
     
     /* 0x00 */ __jnt_hit_data_c* mpHitData;

--- a/include/d/d_kankyo.h
+++ b/include/d/d_kankyo.h
@@ -405,6 +405,7 @@ void dKy_Sound_init();
 void dKy_change_colpat(u8 param_0);
 u8 dKy_pship_existense_chk();
 void dKy_Itemgetcol_chg_move();
+void dKy_arrowcol_chg_on(cXyz*, int);
 void dKy_arrowcol_chg_move();
 void dKy_setLight_init();
 void GxXFog_set();

--- a/src/d/actor/d_a_kytag06.cpp
+++ b/src/d/actor/d_a_kytag06.cpp
@@ -74,11 +74,11 @@ static int daKytag06_Create(fopAc_ac_c* i_this) {
 }
 
 static actor_method_class l_daKytag06_Method = {
-    (process_method_func)daKytag06_Execute,
-    (process_method_func)daKytag06_Draw,
-    (process_method_func)daKytag06_IsDelete,
-    (process_method_func)daKytag06_Delete,
     (process_method_func)daKytag06_Create,
+    (process_method_func)daKytag06_Delete,
+    (process_method_func)daKytag06_Execute,
+    (process_method_func)daKytag06_IsDelete,
+    (process_method_func)daKytag06_Draw,
 };
 
 extern actor_process_profile_definition g_profile_KYTAG06 = {

--- a/src/d/actor/d_a_nh.cpp
+++ b/src/d/actor/d_a_nh.cpp
@@ -334,8 +334,8 @@ BOOL daNh_c::searchPlayer() {
     f32 playerDistDelta = mPlayerDist - playerDist;
     mPlayerDist = playerDist;
     if (playerDelta.absXZ() > 0.001f && playerDist < 600.0f && playerDistDelta > l_HIO.prm.mMinFrightenSpeed) {
-        // Player is nearby and moving closer. The Forest Firefly becomes frightened and tries to head home.
-        setAction(&returnAction, NULL);
+        // Player is nearby and moving closer. The Forest Firefly becomes frightened and tries to escape.
+        setAction(&escapeAction, NULL);
         return TRUE;
     }
     
@@ -562,12 +562,12 @@ BOOL daNh_c::draw() {
     if (mat) {
         J3DTevBlock* tevBlock = mat->getTevBlock();
         if (tevBlock) {
-            GXColorS10* color = tevBlock->getTevColor(1);
+            GXColorS10* color = &tevBlock->getTevColor(1)->mColor;
             if (color) {
                 mGlowAlpha = ((color->r + color->g + color->b) / 3) >> 2;
             }
             
-            GXColor* kColor = tevBlock->getTevKColor(3);
+            GXColor* kColor = &tevBlock->getTevKColor(3)->mColor;
             if (kColor) {
                 kColor->a = mAlpha;
             }


### PR DESCRIPTION
I switched arrow, tag_ret, and ygush to use the `-sym off` compiler flag. This might not be exactly what the original developers did but I think it's worth doing temporarily for the sake of making them match until someone figures out what MWCC is doing with implicit destructors.
