### PR TITLE
Standard Library Headers

### DIFF
--- a/include/JSystem/JUtility/JUTConsole.h
+++ b/include/JSystem/JUtility/JUTConsole.h
@@ -4,8 +4,7 @@
 #include "JSystem/JGadget/linklist.h"
 #include "JSystem/JKernel/JKRDisposer.h"
 #include "JSystem/JUtility/JUTFont.h"
-#include "__va_arg.h"
-#include "dolphin/types.h"
+#include "stdarg.h"
 
 class JUTConsole : public JKRDisposer {
 public:

--- a/include/JSystem/JUtility/JUTDirectPrint.h
+++ b/include/JSystem/JUtility/JUTDirectPrint.h
@@ -2,7 +2,7 @@
 #define JUTDIRECTPRINT_H
 
 #include "JSystem/JUtility/TColor.h"
-#include "__va_arg.h"
+#include "stdarg.h"
 
 
 namespace std {

--- a/include/JSystem/JUtility/JUTException.h
+++ b/include/JSystem/JUtility/JUTException.h
@@ -3,10 +3,9 @@
 
 #include "JSystem/JKernel/JKRThread.h"
 #include "JSystem/JUtility/JUTGamePad.h"
-#include "__va_arg.h"
+#include "stdarg.h"
 #include "dolphin/gx/GXEnum.h"
 #include "dolphin/os/OSError.h"
-#include "dolphin/types.h"
 #include "global.h"
 
 typedef struct _GXRenderModeObj GXRenderModeObj;

--- a/include/dolphin/os/OS.h
+++ b/include/dolphin/os/OS.h
@@ -1,7 +1,7 @@
 #ifndef OS_H_
 #define OS_H_
 
-#include "__va_arg.h"
+#include "stdarg.h"
 #include "dolphin/dvd/dvd.h"
 
 #include "dolphin/os/OSAlarm.h"

--- a/include/m_Do/m_Do_printf.h
+++ b/include/m_Do/m_Do_printf.h
@@ -1,7 +1,7 @@
 #ifndef M_DO_M_DO_PRINTF_H
 #define M_DO_M_DO_PRINTF_H
 
-#include "__va_arg.h"
+#include "stdarg.h"
 #include "m_Do/m_Do_main.h"
 
 extern "C" {

--- a/src/JSystem/JAudio/JAIBasic.cpp
+++ b/src/JSystem/JAudio/JAIBasic.cpp
@@ -13,6 +13,7 @@
 #include "JSystem/JKernel/JKRArchive.h"
 #include "JSystem/JKernel/JKRSolidHeap.h"
 #include "JSystem/JUtility/JUTAssert.h"
+#include "stdio.h"
 #include "string.h"
 
 namespace JAIInitData = JAInter::InitData;

--- a/src/JSystem/JAudio/JAIInitData.cpp
+++ b/src/JSystem/JAudio/JAIInitData.cpp
@@ -13,6 +13,7 @@
 #include "JSystem/JAudio/JASSystemHeap.h"
 #include "JSystem/JKernel/JKRSolidHeap.h"
 #include "JSystem/JUtility/JUTAssert.h"
+#include "stdio.h"
 #include "string.h"
 
 u32* JAInter::InitData::aafPointer;

--- a/src/JSystem/JUtility/JUTDbPrint.cpp
+++ b/src/JSystem/JUtility/JUTDbPrint.cpp
@@ -8,8 +8,7 @@
 #include "JSystem/JKernel/JKRHeap.h"
 #include "JSystem/JUtility/JUTVideo.h"
 #include "stdio.h"
-#include "__va_arg.h"
-#include "dolphin/types.h"
+#include "stdarg.h"
 
 /* 802C328C-802C32D4       .text __ct__10JUTDbPrintFP7JUTFontP7JKRHeap */
 JUTDbPrint::JUTDbPrint(JUTFont* pFont, JKRHeap* pHeap) {

--- a/src/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Include/stdarg.h
+++ b/src/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Include/stdarg.h
@@ -1,0 +1,6 @@
+#ifndef _MSL_COMMON_STDARG_H
+#define _MSL_COMMON_STDARG_H
+
+#include "__va_arg.h"
+
+#endif /* _MSL_COMMON_STDARG_H */

--- a/src/d/actor/d_a_bg.cpp
+++ b/src/d/actor/d_a_bg.cpp
@@ -20,7 +20,7 @@
 #include "JSystem/JKernel/JKRExpHeap.h"
 #include "JSystem/JKernel/JKRSolidHeap.h"
 #include "JSystem/JUtility/JUTAssert.h"
-#include "printf.h"
+#include "stdio.h"
 
 /* 800D8434-800D8478       .text setArcName__6daBg_cFv */
 const char* daBg_c::setArcName() {

--- a/src/d/d_place_name.cpp
+++ b/src/d/d_place_name.cpp
@@ -17,7 +17,7 @@
 #include "JSystem/J2DGraph/J2DOrthoGraph.h"
 #include "JSystem/J2DGraph/J2DPane.h"
 #include "JSystem/J2DGraph/J2DScreen.h"
-#include "printf.h"
+#include "stdio.h"
 
 enum { dPn_stage_max_e = 19 };
 

--- a/src/d/d_s_logo.cpp
+++ b/src/d/d_s_logo.cpp
@@ -25,7 +25,7 @@
 #include "dolphin/vi/vi.h"
 #include "dolphin/os/OS.h"
 #include "string.h"
-#include "printf.h"
+#include "stdio.h"
 
 class dScnLogo_c : public scene_class {
 public:

--- a/src/d/d_s_room.cpp
+++ b/src/d/d_s_room.cpp
@@ -19,8 +19,7 @@
 #include "m_Do/m_Do_dvd_thread.h"
 #include "JSystem/JKernel/JKRHeap.h"
 #include "JSystem/JKernel/JKRExpHeap.h"
-#include "string.h"
-#include "printf.h"
+#include "stdio.h"
 
 class room_of_scene_class : public scene_class {
 public:


### PR DESCRIPTION
Use standard library headers instead of `__va_arg.h` and `printf.h`