### PR TITLE
Documentation, field naming throughout d_a_bomb_static.cpp

### DIFF
--- a/include/d/actor/d_a_bomb.h
+++ b/include/d/actor/d_a_bomb.h
@@ -188,7 +188,7 @@ private:
     /* 0x6E4 */ daBomb_fuseSparksEcallBack mSparks;
     /* 0x6F0 */ u8 field_0x6F0;
     /* 0x6F1 */ u8 field_0x6F1;
-    /* 0x6F2 */ u8 field_0x6F2;
+    /* 0x6F2 */ u8 mBombFire;
     /* 0x6F3 */ u8 field_0x6F3;
     /* 0x6F4 */ u8 field_0x6F4;
     /* 0x6F5 */ u8 field_0x6F5;

--- a/include/d/actor/d_a_bomb2.h
+++ b/include/d/actor/d_a_bomb2.h
@@ -197,7 +197,7 @@ namespace daBomb2 {
         /* 0x6CC */ cXyz field_0x6CC;
         /* 0x6D8 */ cXyz field_0x6D8;
         /* 0x6E4 */ Env_c mEnv;
-        /* 0x738 */ int field_0x738;
+        /* 0x738 */ int mBombTimer;
         /* 0x73C */ int field_0x73C;
         /* 0x740 */ u8 field_0x740;
         /* 0x741 */ u8 field_0x741;

--- a/src/d/actor/d_a_bomb2.cpp
+++ b/src/d/actor/d_a_bomb2.cpp
@@ -24,7 +24,7 @@ namespace daBomb2 {
             /* 0x00 */ const char* resName;
             /* 0x04 */ u32 heapSize;
             /* 0x08 */ s16 field_0x8;
-            /* 0x0A */ s16 field_0xA;
+            /* 0x0A */ s16 field_0xA; // Appears to be the bomb timer cap
             /* 0x0C */ f32 gravity;
             /* 0x10 */ f32 maxFallSpeed;
             /* 0x14 */ f32 field_0x14;
@@ -618,7 +618,7 @@ namespace daBomb2 {
     }
 
     void Act_c::set_nut_exp_interval() {
-        if(mBombTimer > attr().field_0xA) { // attr().field_0xA appears to be the bomb timer cap
+        if(mBombTimer > attr().field_0xA) {
             mBombTimer = attr().field_0xA;
 
             f32 frame = 0x87 - attr().field_0xA;
@@ -626,7 +626,7 @@ namespace daBomb2 {
             mBrk0.getFrameCtrl()->setFrame(frame);
         }
     }
-    // runs mBrk0.play twice if the timer is less than 0x87
+
     void Act_c::anm_play() {
         if(mBombTimer + 1 <= 0x87) {
             mBck0.play();
@@ -882,7 +882,7 @@ namespace daBomb2 {
     bool Act_c::chk_exp_bg() {
         return chk_exp_bg_nut();
     }
-    //counts down the bomb timer by 1, then checks if it has expired. returns true and runs eff_explode if the timer expired, otherwise returns false
+
     bool Act_c::chk_exp_timer() {
         bool ret = false;
         if(mBombTimer > 0 && --mBombTimer == 0) {

--- a/src/d/actor/d_a_bomb2.cpp
+++ b/src/d/actor/d_a_bomb2.cpp
@@ -396,7 +396,7 @@ namespace daBomb2 {
         current.pos = home.pos;
         init_mtx();
 
-        field_0x738 = attr().field_0x8;
+        mBombTimer = attr().field_0x8;
         field_0x740 = 0;
         field_0x741 = 0;
         field_0x742 = 0;
@@ -618,17 +618,17 @@ namespace daBomb2 {
     }
 
     void Act_c::set_nut_exp_interval() {
-        if(field_0x738 > attr().field_0xA) {
-            field_0x738 = attr().field_0xA;
+        if(mBombTimer > attr().field_0xA) { // attr().field_0xA appears to be the bomb timer cap
+            mBombTimer = attr().field_0xA;
 
             f32 frame = 0x87 - attr().field_0xA;
             mBck0.getFrameCtrl()->setFrame(frame);
             mBrk0.getFrameCtrl()->setFrame(frame);
         }
     }
-
+    // runs mBrk0.play twice if the timer is less than 0x87
     void Act_c::anm_play() {
-        if(field_0x738 + 1 <= 0x87) {
+        if(mBombTimer + 1 <= 0x87) {
             mBck0.play();
             mBrk0.play();
         }
@@ -844,7 +844,7 @@ namespace daBomb2 {
     }
 
     bool Act_c::chk_exp_cc() {
-        if(field_0x738 > 0) {
+        if(mBombTimer > 0) {
             return chk_exp_cc_nut();
         }
 
@@ -882,10 +882,10 @@ namespace daBomb2 {
     bool Act_c::chk_exp_bg() {
         return chk_exp_bg_nut();
     }
-
+    //counts down the bomb timer by 1, then checks if it has expired. returns true and runs eff_explode if the timer expired, otherwise returns false
     bool Act_c::chk_exp_timer() {
         bool ret = false;
-        if(field_0x738 > 0 && --field_0x738 == 0) {
+        if(mBombTimer > 0 && --mBombTimer == 0) {
             eff_explode();
             ret = true;
         }
@@ -1066,7 +1066,7 @@ namespace daBomb2 {
         mSph.OffCoSPrmBit(CO_SPRM_SET);
         mSph.OnAtSPrmBit(AT_SPRM_SET);
         fopAcM_cancelCarryNow(this);
-        field_0x738 = 0;
+        mBombTimer = 0;
         field_0x73C = 4;
         dComIfGp_getVibration().StartShock(7, -0x21, cXyz(0.0f, 1.0f, 0.0f));
     }

--- a/src/d/actor/d_a_bomb3.inc
+++ b/src/d/actor/d_a_bomb3.inc
@@ -1026,9 +1026,9 @@ void daBomb_c::waitState_bomtyu() {
     cLib_chaseF(&mScale.x, 1.0f, 0.05f);
     cLib_chaseF(&mScale.y, 1.0f, 0.05f);
     cLib_chaseF(&mScale.z, 1.0f, 0.05f);
-    if(field_0x6F2) {
+    if(mBombFire) {
         setFuseEffect();
-        field_0x6F2 = 0;
+        mBombFire = 0;
         field_0x6F4 = 1;
         change_state(STATE_1);
     }

--- a/src/d/d_a_bomb_static.cpp
+++ b/src/d/d_a_bomb_static.cpp
@@ -34,7 +34,7 @@ void daBomb_c::setBombCheck_Flag() {
 void daBomb_c::setBombFire_ON() {
     _prm_chk_version();
 
-    field_0x6F2 = true;
+    mBombFire = true;
 }
 
 /* 80068068-800680CC       .text setBombNoHit__8daBomb_cFv */

--- a/src/d/d_a_bomb_static.cpp
+++ b/src/d/d_a_bomb_static.cpp
@@ -158,12 +158,12 @@ void daBomb2::Act_c::remove_fuse_effect() {
 
 /* 80068488-80068490       .text set_time__Q27daBomb25Act_cFi */
 void daBomb2::Act_c::set_time(int time) {
-    field_0x738 = time;
+    mBombTimer = time;
 }
 
 /* 80068490-80068498       .text get_time__Q27daBomb25Act_cCFv */
 int daBomb2::Act_c::get_time() const {
-    return field_0x738;
+    return mBombTimer;
 }
 
 /* 80068498-800684A0       .text chk_eat__Q27daBomb25Act_cCFv */


### PR DESCRIPTION
As stated in the title, this changes an undocumented field of daBomb_c to a properly labelled one based on the function name daBomb_c::setBombFire_ON