### PR TITLE
d_a_obj_eskban

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1522,7 +1522,7 @@ config.libs = [
     ActorRel(Matching,    "d_a_obj_eayogn"),
     ActorRel(NonMatching, "d_a_obj_ebomzo"),
     ActorRel(NonMatching, "d_a_obj_ekskz"),
-    ActorRel(NonMatching, "d_a_obj_eskban"),
+    ActorRel(NonMatching, "d_a_obj_eskban", extra_cflags=['-pragma "nosyminline on"']),
     ActorRel(Matching,    "d_a_obj_ferris", extra_cflags=['-pragma "nosyminline on"']),
     ActorRel(NonMatching, "d_a_obj_figure"),
     ActorRel(NonMatching, "d_a_obj_firewall"),

--- a/include/d/actor/d_a_obj_eskban.h
+++ b/include/d/actor/d_a_obj_eskban.h
@@ -3,26 +3,70 @@
 
 #include "f_op/f_op_actor.h"
 
+#include "d/d_a_obj.h"
+#include "d/d_bg_s_movebg_actor.h"
+#include "d/d_particle.h"
+
 namespace daObjEskban {
-    class Act_c : public fopAc_ac_c {
+
+    static const int DESTROY_VIBRATION_LEN = 35;
+    static const int DESTROY_VIBRATION_SHOCK_FRAME_IDX = 28;
+    static const int DESTROY_SMOKE_ANM_LEN = 20;
+
+    class Act_c : public dBgS_MoveBgActor {
     public:
-        void prm_get_swSave() const {}
-    
-        void CreateHeap();
-        s32 Create();
-        void Mthd_Create();
-        BOOL Delete();
-        void Mthd_Delete();
+        static const char M_arcname[7];
+        static const char M_evname[7];
+        static Mtx M_tmp_mtx;
+
+        enum Prm_e {
+            PRM_SWSAVE_W = 0x08,
+            PRM_SWSAVE_S = 0x00,
+        };
+        s32 param_get_swSave() const {
+            return daObj::PrmAbstract<Prm_e>(this, PRM_SWSAVE_W, PRM_SWSAVE_S);
+        }
+
+        enum actor_state {
+            ST_WAIT = 0,
+            ST_DESTROYED = 1,
+            ST_CUTSCENING = 2,
+            ST_VIBRATING = 3,
+            ST_SMOKING = 4,
+        };
+
+        Act_c();
+
+        int CreateHeap();
+        int Create();
+        s32 Mthd_Create();
+        int Delete();
+        BOOL Mthd_Delete();
         void set_mtx();
         void init_mtx();
         void eff_m_break(unsigned short, unsigned short);
         void eff_b_break(unsigned short);
         void daObjEskban_effect_set();
-        void Execute(float(**)[3][4]);
-        BOOL Draw();
-    
+        int Execute(Mtx**);
+        int Draw();
+
     public:
-        /* Place member variables here */
+        /* 0x2C4 Act_c vtable */
+        /* 0x2C8 */ dPa_smokeEcallBack* M_smoke;  // name used in assert
+        /* 0x2CC */ cXyz mSmokePos;
+        /* 0x2D8 */ request_of_phase_process_class mPhs;
+        /* 0x2E0 */ J3DModel* mpModel;
+        /* 0x2E4 */ dCcD_Stts mCheckStts;
+        /* 0x320 */ dCcD_Cyl mCheckCyl;
+        /* 0x450 */ dCcD_Stts mCameraStts;
+        /* 0x48C */ dCcD_Cyl mCameraCyl;
+        /* 0x5BC */ u32 mActorID;
+        /* 0x5C0 */ dCcD_Stts mCheckSphStts;
+        /* 0x5FC */ dCcD_Sph mCheckSph;
+        /* 0x728 */ s32 mActorState;
+        /* 0x72C */ s32 mRemainingSmokeAnm;
+        /* 0x730 */ s32 mRemainingVibration;
+        /* 0x734 */ u8 mIsVisible;
     };
 };
 

--- a/include/d/d_com_inf_game.h
+++ b/include/d/d_com_inf_game.h
@@ -3163,6 +3163,10 @@ inline void dComIfGp_particle_calcMenu() {
     g_dComIfG_gameInfo.play.getParticle()->calcMenu();
 }
 
+inline int dComIfGp_particle_addModelEmitter(dPa_modelEmitter_c* emitter){
+    return g_dComIfG_gameInfo.play.getParticle()->addModelEmitter(emitter);
+}
+
 inline void dComIfGp_particle_drawModelParticle() {
     g_dComIfG_gameInfo.play.getParticle()->drawModelParticle();
 }

--- a/include/d/d_particle.h
+++ b/include/d/d_particle.h
@@ -363,6 +363,7 @@ public:
 
     static J3DModel * newModel(J3DModelData*);
     void draw();
+    int add(dPa_modelEmitter_c *emitter) { return cLs_Addition(this, emitter); }
 
     static dPa_J3Dmodel_c * mModel;
 };
@@ -469,6 +470,7 @@ public:
     u32 getParticleNum() { return mEmitterMng->getParticleNumber(); } 
     u32 getEmitterNum() { return mEmitterMng->getEmitterNumber(); } 
 
+    int addModelEmitter(dPa_modelEmitter_c *emitter) { return mModelControl->add(emitter); }
     void drawModelParticle() { mModelControl->draw(); }
     JKRHeap * getHeap() { return mHeap; }
 

--- a/src/d/actor/d_a_obj_eskban.cpp
+++ b/src/d/actor/d_a_obj_eskban.cpp
@@ -226,7 +226,7 @@ void daObjEskban::Act_c::eff_m_break(u16 particleID, u16 prm_b) {
     if (!pMdlEmtr) {
         return;
     }
-    cLs_Addition(g_dComIfG_gameInfo.play.getParticle()->mModelControl, pMdlEmtr);
+    dComIfGp_particle_addModelEmitter(pMdlEmtr);
 }
 
 /* 00000C80-00000D44       .text eff_b_break__Q211daObjEskban5Act_cFUs */

--- a/src/d/actor/d_a_obj_eskban.cpp
+++ b/src/d/actor/d_a_obj_eskban.cpp
@@ -3,94 +3,416 @@
 // Translation Unit: d_a_obj_eskban.cpp
 //
 
-#include "d/actor/d_a_obj_eskban.h"
+#include "f_op/f_op_actor_mng.h"
+
 #include "d/d_procname.h"
+#include "d/d_com_inf_game.h"
+#include "d/actor/d_a_obj_eskban.h"
+#include "d/res/res_eskban.h"
+
+/* .bss alignment */
+static u8 dummy[0x4c];
+
+namespace daObjEskban {
+/* .data alignment, seemingly unused by this unit */
+static Vec _data_align[4] = {
+    {1, 1, 1},
+    {1, 1, 1},
+    {9.40453e-38 /* possibly not actually a float? */, 0, 2.125},
+    {0, 1.75, 0},
+};
+
+Mtx Act_c::M_tmp_mtx;
+const char Act_c::M_arcname[7] = "Eskban";
+const char Act_c::M_evname[7] = "Eskban";
+
+}  // namespace daObjEskban
+
+static dCcD_SrcCyl cyl_check_src = {
+    // dCcD_SrcGObjInf
+    {
+        /* Flags             */ 0,
+        /* SrcObjAt  Type    */ 0,
+        /* SrcObjAt  Atp     */ 0,
+        /* SrcObjAt  SPrm    */ 0,
+        /* SrcObjTg  Type    */ AT_TYPE_BOMB,
+        /* SrcObjTg  SPrm    */ TG_SPRM_SET | TG_SPRM_IS_OTHER,
+        /* SrcObjCo  SPrm    */ 0,
+        /* SrcGObjAt Se      */ 0,
+        /* SrcGObjAt HitMark */ 0,
+        /* SrcGObjAt Spl     */ 0,
+        /* SrcGObjAt Mtrl    */ 0,
+        /* SrcGObjAt SPrm    */ 0,
+        /* SrcGObjTg Se      */ 0,
+        /* SrcGObjTg HitMark */ 0,
+        /* SrcGObjTg Spl     */ 0,
+        /* SrcGObjTg Mtrl    */ 0,
+        /* SrcGObjTg SPrm    */ 0,
+        /* SrcGObjCo SPrm    */ 0,
+    },
+    // cM3dGCylS
+    {{
+        /* Center */ {0.0f, 0.0f, 0.0f},
+        /* Radius */ 200.0f,
+        /* Height */ 600.0f,
+    }},
+};
+static dCcD_SrcCyl cyl_camera_src = {
+    // dCcD_SrcGObjInf
+    {
+        /* Flags             */ 0,
+        /* SrcObjAt  Type    */ 0,
+        /* SrcObjAt  Atp     */ 0,
+        /* SrcObjAt  SPrm    */ 0,
+        /* SrcObjTg  Type    */ 0,
+        /* SrcObjTg  SPrm    */ 0,
+        /* SrcObjCo  SPrm    */ CO_SPRM_SET | CO_SPRM_IS_UNK8 | CO_SPRM_VS_UNK8 | CO_SPRM_NO_CRR,
+        /* SrcGObjAt Se      */ 0,
+        /* SrcGObjAt HitMark */ 0,
+        /* SrcGObjAt Spl     */ 0,
+        /* SrcGObjAt Mtrl    */ 0,
+        /* SrcGObjAt SPrm    */ 0,
+        /* SrcGObjTg Se      */ 0,
+        /* SrcGObjTg HitMark */ 0,
+        /* SrcGObjTg Spl     */ 0,
+        /* SrcGObjTg Mtrl    */ 0,
+        /* SrcGObjTg SPrm    */ 0,
+        /* SrcGObjCo SPrm    */ 0,
+    },
+    // cM3dGCylS
+    {{
+        /* Center */ {0.0f, 0.0f, 0.0f},
+        /* Radius */ 1000.0f,
+        /* Height */ 100.0f,
+    }},
+};
+static dCcD_SrcSph sph_check_src = {
+    // dCcD_SrcGObjInf
+    {
+        /* Flags             */ 0,
+        /* SrcObjAt  Type    */ 0,
+        /* SrcObjAt  Atp     */ 0,
+        /* SrcObjAt  SPrm    */ 0,
+        /* SrcObjTg  Type    */ AT_TYPE_BOMB,
+        /* SrcObjTg  SPrm    */ TG_SPRM_SET | TG_SPRM_IS_OTHER,
+        /* SrcObjCo  SPrm    */ CO_SPRM_SET | CO_SPRM_IS_UNK8 | CO_SPRM_VS_UNK4 | CO_SPRM_VS_UNK2 |
+            CO_SPRM_NO_CRR,
+        /* SrcGObjAt Se      */ 0,
+        /* SrcGObjAt HitMark */ 0,
+        /* SrcGObjAt Spl     */ 0,
+        /* SrcGObjAt Mtrl    */ 0,
+        /* SrcGObjAt SPrm    */ 0,
+        /* SrcGObjTg Se      */ 0,
+        /* SrcGObjTg HitMark */ 0,
+        /* SrcGObjTg Spl     */ 0,
+        /* SrcGObjTg Mtrl    */ 0,
+        /* SrcGObjTg SPrm    */ 0,
+        /* SrcGObjCo SPrm    */ 0,
+    },
+    // cM3dGSphS
+    {{
+        /* Center */ {0.0f, 0.0f, 0.0f},
+        /* Radius */ 300.0f,
+    }},
+};
 
 /* 000000EC-000001FC       .text CreateHeap__Q211daObjEskban5Act_cFv */
-void daObjEskban::Act_c::CreateHeap() {
-    /* Nonmatching */
+int daObjEskban::Act_c::CreateHeap() {
+    J3DModelData* model_data =
+        static_cast<J3DModelData*>(dComIfG_getObjectRes(M_arcname, ESKBAN_BDL_ESKBAN));
+    JUT_ASSERT(261, model_data != 0);
+    mpModel = mDoExt_J3DModel__create(model_data, 0, 0x11020203U);
+    M_smoke = new dPa_smokeEcallBack();
+    JUT_ASSERT(264, M_smoke != 0);
+    return mpModel != NULL;
 }
 
 /* 000001FC-00000368       .text Create__Q211daObjEskban5Act_cFv */
-s32 daObjEskban::Act_c::Create() {
-    /* Nonmatching */
+int daObjEskban::Act_c::Create() {
+    fopAcM_SetMtx(this, mpModel->getBaseTRMtx());
+    init_mtx();
+    fopAcM_setCullSizeBox(this, -500, -1, -500, 500, 500, 500);
+    mCheckStts.Init(0xff, 0xff, this);
+    mCheckCyl.Set(cyl_check_src);
+    mCheckCyl.SetC(this->current.pos);
+    mCheckCyl.SetStts(&mCheckStts);
+
+    mCameraStts.Init(0xff, 0xff, this);
+    mCameraCyl.Set(cyl_camera_src);
+    cXyz offset(300, 450, 300);
+    mCameraCyl.SetC(this->current.pos + offset);
+    mCameraCyl.SetStts(&mCameraStts);
+
+    mCheckSphStts.Init(0xff, 0xff, this);
+    mCheckSph.Set(sph_check_src);
+    offset.set(0, 400, 0);
+    mCheckSph.SetC(this->current.pos + offset);
+    mCheckSph.SetStts(&mCheckSphStts);
+
+    mActorState = 0;
+    mRemainingSmokeAnm = 0;
+    mIsVisible = 1;
+    return TRUE;
 }
 
 /* 000003A4-000004D0       .text Mthd_Create__Q211daObjEskban5Act_cFv */
-void daObjEskban::Act_c::Mthd_Create() {
-    /* Nonmatching */
+s32 daObjEskban::Act_c::Mthd_Create() {
+    s32 phase_state;
+    fopAcM_SetupActor(this, Act_c);
+    M_smoke = NULL;
+
+    s32 swSave = param_get_swSave();
+    if (fopAcM_isSwitch(this, swSave)) {
+        return cPhs_UNK3_e;
+    }
+    phase_state = dComIfG_resLoad(&mPhs, M_arcname);
+    if (phase_state == cPhs_COMPLEATE_e) {
+        phase_state = MoveBGCreate(M_arcname, ESKBAN_DZB_ESKBAN, NULL, 0x1020);
+        JUT_ASSERT(336, (phase_state == cPhs_COMPLEATE_e) || (phase_state == cPhs_ERROR_e));
+    }
+    return phase_state;
 }
+
+daObjEskban::Act_c::Act_c() {}
 
 /* 000009C0-00000A10       .text Delete__Q211daObjEskban5Act_cFv */
 BOOL daObjEskban::Act_c::Delete() {
-    /* Nonmatching */
+    if (M_smoke) {
+        M_smoke->end();
+        M_smoke = NULL;
+    }
+    return TRUE;
 }
 
 /* 00000A10-00000A68       .text Mthd_Delete__Q211daObjEskban5Act_cFv */
-void daObjEskban::Act_c::Mthd_Delete() {
-    /* Nonmatching */
+BOOL daObjEskban::Act_c::Mthd_Delete() {
+    s32 result = MoveBGDelete();
+    if (fpcM_CreateResult(this) != cPhs_UNK3_e) {
+        dComIfG_resDelete(&mPhs, M_arcname);
+    }
+    return result;
 }
 
 /* 00000A68-00000B00       .text set_mtx__Q211daObjEskban5Act_cFv */
 void daObjEskban::Act_c::set_mtx() {
-    /* Nonmatching */
+    this->shape_angle = this->current.angle;
+    mDoMtx_stack_c::transS(this->current.pos);
+    mDoMtx_stack_c::ZXYrotM(this->shape_angle);
+    mpModel->setBaseTRMtx(mDoMtx_stack_c::get());
+    mDoMtx_copy(mDoMtx_stack_c::get(), M_tmp_mtx);
 }
 
 /* 00000B00-00000B3C       .text init_mtx__Q211daObjEskban5Act_cFv */
 void daObjEskban::Act_c::init_mtx() {
-    /* Nonmatching */
+    mpModel->setBaseScale(this->scale);
+    set_mtx();
 }
 
 /* 00000B3C-00000C80       .text eff_m_break__Q211daObjEskban5Act_cFUsUs */
-void daObjEskban::Act_c::eff_m_break(unsigned short, unsigned short) {
-    /* Nonmatching */
+void daObjEskban::Act_c::eff_m_break(u16 particleID, u16 prm_b) {
+    J3DModelData* mdlData =
+        static_cast<J3DModelData*>(dComIfG_getObjectRes("Always", ALWAYS_BDL_MPI_KOISHI));
+    J3DAnmTexPattern* txPattern =
+        static_cast<J3DAnmTexPattern*>(dComIfG_getObjectRes("Always", ALWAYS_BTP_MPI_KOISHI));
+
+    JPABaseEmitter* pBEmtr =
+        dComIfGp_particle_set(particleID, &this->current.pos, &this->shape_angle, NULL, 0xff, NULL,
+                              -1, NULL, NULL, &cXyz(3, 3, 3));
+    if (!pBEmtr) {
+        return;
+    }
+    pBEmtr->setGlobalRTMatrix(mpModel->getBaseTRMtx());
+    dPa_J3DmodelEmitter_c* pMdlEmtr = new dPa_J3DmodelEmitter_c(pBEmtr, mdlData, tevStr, txPattern, prm_b, 0);
+    if (!pMdlEmtr) {
+        return;
+    }
+    cLs_Addition(g_dComIfG_gameInfo.play.getParticle()->mModelControl, pMdlEmtr);
 }
 
 /* 00000C80-00000D44       .text eff_b_break__Q211daObjEskban5Act_cFUs */
-void daObjEskban::Act_c::eff_b_break(unsigned short) {
-    /* Nonmatching */
+void daObjEskban::Act_c::eff_b_break(u16 particleID) {
+    GXColor c0;
+    c0.r = tevStr.mColorC0.r;
+    c0.g = tevStr.mColorC0.g;
+    c0.b = tevStr.mColorC0.b;
+    c0.a = tevStr.mColorC0.a;
+
+    JPABaseEmitter* pBEmtr =
+        dComIfGp_particle_set(particleID, &this->current.pos, NULL, NULL, 0xff, NULL, -1,
+                              &tevStr.mColorK0, &c0, &cXyz(1, 1, 1));
+    if (!pBEmtr) {
+        return;
+    }
+    pBEmtr->setGlobalRTMatrix(mpModel->getBaseTRMtx());
 }
 
 /* 00000D44-00000EF0       .text daObjEskban_effect_set__Q211daObjEskban5Act_cFv */
 void daObjEskban::Act_c::daObjEskban_effect_set() {
-    /* Nonmatching */
+    eff_m_break(0x82b1, 2);
+    eff_b_break(0x82b2);
+
+    static cXyz offset_vec(0, 250, 0);
+    mDoMtx_stack_c::copy(mpModel->getBaseTRMtx());
+    mDoMtx_stack_c::multVec(&offset_vec, &mSmokePos);
+    if (!M_smoke) {
+        return;
+    }
+    JPABaseEmitter* pBEmtr = dComIfGp_particle_setToon(0x2027, &mSmokePos, NULL, NULL, 0xc8,
+                                                       M_smoke, -1, NULL, NULL, NULL);
+    if (!pBEmtr) {
+        return;
+    }
+
+    pBEmtr->setRate(30);
+    pBEmtr->setMaxFrame(1);
+    static JGeometry::TVec3<f32> d_scale(3, 3, 3);
+    static JGeometry::TVec3<f32> p_scale(7, 7, 7);
+    pBEmtr->setGlobalDynamicsScale(d_scale);
+    pBEmtr->setGlobalParticleScale(p_scale);
 }
 
 /* 00000EF0-00001400       .text Execute__Q211daObjEskban5Act_cFPPA3_A4_f */
-void daObjEskban::Act_c::Execute(float(**)[3][4]) {
-    /* Nonmatching */
+int daObjEskban::Act_c::Execute(Mtx** pMtx) {
+    dComIfG_Ccsp()->Set(&mCheckCyl);
+    dComIfG_Ccsp()->Set(&mCameraCyl);
+    dComIfG_Ccsp()->Set(&mCheckSph);
+    if (mCheckSph.ChkCoHit()) {
+        cCcD_Obj* hitObj = mCheckSph.GetCoHitObj();
+        if (hitObj) {
+            fopAc_ac_c* hitAct = hitObj->GetAc();
+            if (hitAct && fopAcM_GetName(hitAct) == PROC_NPC_MD) {
+                cXyz dist = fopAcM_GetPosition(hitAct) - fopAcM_GetPosition(this);
+                dist.y = 0;
+                if (dist.normalizeRS()) {
+                    dist *= 10;
+                } else {
+                    dist.set(10, 0, 0);
+                }
+                hitAct->current.pos += dist;
+            }
+        }
+    }
+    switch (mActorState) {
+    case ST_WAIT: /* 0x148 */
+        if (!mCameraCyl.ChkCoHit()) {
+            break;
+        }
+        cCcD_Obj* hitObj;
+        if (!(hitObj = mCameraCyl.GetCoHitObj())) {
+            break;
+        }
+        fopAc_ac_c* hitAct = hitObj->GetAc();
+        if (hitAct && fopAcM_GetName(hitAct) == PROC_Bomb2) {
+            mActorID = fopAcM_GetID(hitAct);
+            fopAcM_orderOtherEvent(this, "Eskban");
+            mActorState = ST_DESTROYED;
+        }
+        break;
+    case ST_DESTROYED: /* 0x1d8 */
+        if (eventInfo.checkCommandDemoAccrpt()) {
+            mActorState = ST_CUTSCENING;
+            break;
+        }
+        fopAcM_orderOtherEvent(this, "Eskban");
+        break;
+    case ST_CUTSCENING: /* 0x214 */
+        if (fopAcM_SearchByID(mActorID) == NULL) {
+            mActorState = ST_SMOKING;
+            mRemainingSmokeAnm = DESTROY_SMOKE_ANM_LEN;
+        }
+        if (!mCheckCyl.ChkTgHit()) {
+            break;
+        }
+        int staffID = dComIfGp_evmng_getMyStaffId("Eskban");
+        dComIfGp_evmng_cutEnd(staffID);
+        mActorState = ST_VIBRATING;
+        mRemainingVibration = DESTROY_VIBRATION_LEN;
+        mRemainingSmokeAnm = DESTROY_SMOKE_ANM_LEN;
+        mIsVisible = 0;
+        fopAcM_seStartCurrent(this, JA_SE_LK_W_WEP_CRT_HIT, 0);
+        dComIfGp_getVibration().StartQuake(7, ~0x20, cXyz(0, 1, 0));
+        mDoAud_seStart(JA_SE_READ_RIDDLE_1);
+        daObjEskban_effect_set();
+        break;
+    case ST_SMOKING: /* 0x350 */
+        if (mRemainingSmokeAnm > 0) {
+            mRemainingSmokeAnm--;
+            break;
+        } else {
+            mActorState = ST_WAIT;
+            dComIfGp_event_reset();
+            break;
+        }
+        if (dComIfGp_evmng_endCheck("Eskban") && M_smoke->isEnd()) {
+            dComIfGp_getVibration().StopQuake(-1);
+            fopAcM_delete(this);
+        }
+        dComIfGp_event_reset();
+        /* fallthrough */
+    case ST_VIBRATING: /* 0x388 */
+        if (mRemainingVibration > 0) {
+            mRemainingVibration--;
+            if (mRemainingVibration == DESTROY_VIBRATION_SHOCK_FRAME_IDX) {
+                dComIfGp_getVibration().StartShock(6, 0x4, cXyz(0, 1, 0));
+            }
+        } else if (!fopAcM_isSwitch(this, param_get_swSave())) {
+            fopAcM_onSwitch(this, param_get_swSave());
+            dComIfGp_getVibration().StopQuake(-1);
+            dComIfGp_getVibration().StartQuake(4, ~0x20, cXyz(0, 1, 0));
+        }
+        if (mRemainingSmokeAnm > 0) {
+            mRemainingSmokeAnm--;
+            break;
+        }
+        if (dComIfGp_evmng_endCheck("Eskban") && M_smoke->isEnd()) {
+            dComIfGp_getVibration().StopQuake(-1);
+            fopAcM_delete(this);
+            dComIfGp_event_reset();
+        }
+    }
+    set_mtx();
+    *pMtx = &M_tmp_mtx;
+    return TRUE;
 }
 
 /* 00001400-000014B4       .text Draw__Q211daObjEskban5Act_cFv */
 BOOL daObjEskban::Act_c::Draw() {
-    /* Nonmatching */
+    g_env_light.settingTevStruct(TEV_TYPE_BG0, &this->current.pos, &tevStr);
+    g_env_light.setLightTevColorType(mpModel, &tevStr);
+    if (!mIsVisible) {
+        return TRUE;
+    }
+    dComIfGd_setListBG();
+    mDoExt_modelUpdateDL(mpModel);
+    dComIfGd_setList();
+    return TRUE;
 }
 
 namespace daObjEskban {
 namespace {
 /* 000014B4-000014D4       .text Mthd_Create__Q211daObjEskban28@unnamed@d_a_obj_eskban_cpp@FPv */
-void Mthd_Create(void*) {
-    /* Nonmatching */
+void Mthd_Create(void* i_this) {
+    ((Act_c*)i_this)->Mthd_Create();
 }
 
 /* 000014D4-000014F4       .text Mthd_Delete__Q211daObjEskban28@unnamed@d_a_obj_eskban_cpp@FPv */
-void Mthd_Delete(void*) {
-    /* Nonmatching */
+void Mthd_Delete(void* i_this) {
+    ((Act_c*)i_this)->Mthd_Delete();
 }
 
 /* 000014F4-00001514       .text Mthd_Execute__Q211daObjEskban28@unnamed@d_a_obj_eskban_cpp@FPv */
-void Mthd_Execute(void*) {
-    /* Nonmatching */
+void Mthd_Execute(void* i_this) {
+    ((Act_c*)i_this)->MoveBGExecute();
 }
 
 /* 00001514-00001540       .text Mthd_Draw__Q211daObjEskban28@unnamed@d_a_obj_eskban_cpp@FPv */
-void Mthd_Draw(void*) {
-    /* Nonmatching */
+void Mthd_Draw(void* i_this) {
+    ((Act_c*)i_this)->MoveBGDraw();
 }
 
 /* 00001540-0000156C       .text Mthd_IsDelete__Q211daObjEskban28@unnamed@d_a_obj_eskban_cpp@FPv */
-void Mthd_IsDelete(void*) {
-    /* Nonmatching */
+void Mthd_IsDelete(void* i_this) {
+    ((Act_c*)i_this)->MoveBGIsDelete();
 }
 
 static actor_method_class Mthd_Eskban = {


### PR DESCRIPTION
weak functions are in the right order with `nosyminline on`, but the sections don't match, and there are some destructors (`cCcD_SphAttr`, `cCcD_CylAttr`, `dCcD_Stts`, `cCcD_Stts`, `dBgS_MoveBgActor`) that appear in objdiff but marked UNUSED in the .map files. 
I don't know what's up with that

Had to add some padding for the bss size to match

#389