### PR TITLE
d_a_steam_tag 100%

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1717,7 +1717,7 @@ config.libs = [
     ActorRel(NonMatching, "d_a_shutter"),
     ActorRel(NonMatching, "d_a_shutter2"),
     ActorRel(NonMatching, "d_a_st"),
-    ActorRel(NonMatching, "d_a_steam_tag"),
+    ActorRel(Matching,    "d_a_steam_tag", extra_cflags=['-pragma "nosyminline on"']),
     ActorRel(Matching,    "d_a_swattack", extra_cflags=['-pragma "nosyminline on"']),
     ActorRel(Matching,    "d_a_switem", extra_cflags=['-pragma "nosyminline on"']),
     ActorRel(NonMatching, "d_a_swpropeller"),

--- a/include/d/actor/d_a_steam_tag.h
+++ b/include/d/actor/d_a_steam_tag.h
@@ -3,29 +3,47 @@
 
 #include "f_op/f_op_actor.h"
 #include "d/d_cc_d.h"
+#include "d/d_particle.h"
 #include "d/d_point_wind.h"
+#include "f_op/f_op_actor_mng.h"
 
 class JPABaseEmitter;
 
+struct daSteamTag_mData {
+    /* 0x00 */ s16 field_0x00;
+    /* 0x02 */ s16 field_0x02;
+    /* 0x04 */ s16 mCreateTimer_seed;
+    /* 0x06 */ s16 mCreateTimer_offset;
+    /* 0x08 */ s16 mEmitTimer_offset;
+    /* 0x0A */ s16 mEmitTimer_seed;
+    /* 0x0C */ u8  mSteamAlpha;
+    /* 0x0D */ u8  field_0x0D;
+    /* 0x0E */ u8  field_0x0E;
+    /* 0x0F */ u8  field_0x0F;
+};
+
 class daSteamTag_c : public fopAc_ac_c {
 public:
+    ~daSteamTag_c();
     inline s32 create();
     inline BOOL draw();
     inline BOOL execute();
 
-    void getData();
-    void CreateInit();
-    void createEmitter();
-    void endEmitter();
+    const daSteamTag_mData* getData();
+    s32 CreateInit();
+    BOOL createEmitter();
+    bool endEmitter();
 
     static void init();
+
+    static daSteamTag_mData mData;
 
 public:
     /* 0x290 */ JPABaseEmitter* mpEmitter;
     /* 0x294 */ u8 m294[0x296 - 0x294];
     /* 0x296 */ s16 mEmitTimer;
     /* 0x298 */ s16 mCreateTimer;
-    /* 0x29A */ u8 m29A[0x29B - 0x29A];
+    /* 0x29A */ u8 m29A;
     /* 0x29B */ u8 m29B;
     /* 0x29C */ dCcD_Stts mGStts;
     /* 0x2D8 */ dCcD_Cyl mCyl;
@@ -35,6 +53,10 @@ public:
 
 public:
     static u8 mEmitterNum;
+};
+
+namespace daSteamTag_prm {
+    inline u8 getSchBit(daSteamTag_c* item) { return (fopAcM_GetParam(item) >> 2) & 0xFF; }
 };
 
 #endif /* D_A_STEAM_TAG_H */

--- a/include/d/actor/d_a_steam_tag.h
+++ b/include/d/actor/d_a_steam_tag.h
@@ -12,14 +12,13 @@ class JPABaseEmitter;
 struct daSteamTag_mData {
     /* 0x00 */ s16 field_0x00;
     /* 0x02 */ s16 field_0x02;
-    /* 0x04 */ s16 mCreateTimer_seed;
-    /* 0x06 */ s16 mCreateTimer_offset;
-    /* 0x08 */ s16 mEmitTimer_offset;
-    /* 0x0A */ s16 mEmitTimer_seed;
-    /* 0x0C */ u8  mSteamAlpha;
+    /* 0x04 */ s16 create_time_range;
+    /* 0x06 */ s16 create_time_min;
+    /* 0x08 */ s16 emit_time_min;
+    /* 0x0A */ s16 emit_time_range;
+    /* 0x0C */ u8  steam_alpha;
     /* 0x0D */ u8  field_0x0D;
-    /* 0x0E */ u8  field_0x0E;
-    /* 0x0F */ u8  field_0x0F;
+    /* 0x0E */ s16  field_0x0E;
 };
 
 class daSteamTag_c : public fopAc_ac_c {

--- a/include/d/d_point_wind.h
+++ b/include/d/d_point_wind.h
@@ -10,6 +10,8 @@ public:
     WIND_INFLUENCE mWind;
 
     void set_pwind_init(cM3dGCpsS * pCps);
+    void set_pwind_power(float windStrength){ mWind.mStrength = windStrength; }
+    float get_pwind_power_p(){ return mWind.mStrength; }
     void set_pwind_move();
     void set_pwind_delete();
 };

--- a/src/d/actor/d_a_steam_tag.cpp
+++ b/src/d/actor/d_a_steam_tag.cpp
@@ -4,56 +4,209 @@
 //
 
 #include "d/actor/d_a_steam_tag.h"
+#include "JSystem/J3DGraphBase/J3DSys.h"
+#include "JSystem/JParticle/JPAEmitter.h"
+#include "d/d_cc_d.h"
+#include "d/d_com_inf_game.h"
+#include "d/d_item.h"
+#include "d/d_item_data.h"
 #include "d/d_procname.h"
+#include "dolphin/mtx/vec.h"
+
+static dCcD_SrcCps l_cps_src = {
+    // dCcD_SrcGObjInf
+    {
+        /* Flags             */ 0,
+        /* SrcObjAt  Type    */ AT_TYPE_WIND,
+        /* SrcObjAt  Atp     */ 0,
+        /* SrcObjAt  SPrm    */ cCcD_AtSPrm_Set_e | cCcD_AtSPrm_GrpAll_e,
+        /* SrcObjTg  Type    */ 0,
+        /* SrcObjTg  SPrm    */ 0,
+        /* SrcObjCo  SPrm    */ 0,
+        /* SrcGObjAt Se      */ 0,
+        /* SrcGObjAt HitMark */ 0,
+        /* SrcGObjAt Spl     */ 0,
+        /* SrcGObjAt Mtrl    */ 0,
+        /* SrcGObjAt SPrm    */ dCcG_AtSPrm_NoHitMark_e,
+        /* SrcGObjTg Se      */ 0,
+        /* SrcGObjTg HitMark */ 0,
+        /* SrcGObjTg Spl     */ 0,
+        /* SrcGObjTg Mtrl    */ 0,
+        /* SrcGObjTg SPrm    */ dCcG_TgSPrm_NoHitMark_e,
+        /* SrcGObjCo SPrm    */ 0,
+    },
+    // cM3dGCpsS
+    {
+        /* P0 */ 0.0f, 0.0f, 0.0f,
+        /* P1 */ 0.0f, 0.0f, 0.0f,
+        /* Height */ 200.0f,
+    },
+};
+
+daSteamTag_mData daSteamTag_c::mData = {15861, 49807, 300, 100, 50, 150, 0xB4, 0x00, 0x00};
 
 /* 00000078-00000084       .text getData__12daSteamTag_cFv */
-void daSteamTag_c::getData() {
-    /* Nonmatching */
+const daSteamTag_mData* daSteamTag_c::getData() {
+    return &daSteamTag_c::mData;
 }
 
 /* 00000084-0000029C       .text CreateInit__12daSteamTag_cFv */
-void daSteamTag_c::CreateInit() {
-    /* Nonmatching */
+s32 daSteamTag_c::CreateInit() {
+    m29B = daSteamTag_prm::getSchBit(this);
+    float fVar2;
+    mEmitTimer = getData()->mEmitTimer_offset + cM_rndF(getData()->mEmitTimer_seed);
+    mCreateTimer = cM_rndF(getData()->mCreateTimer_seed);;
+    mpEmitter = NULL;
+    mEmitTimer = 0;
+    mGStts.Init(0xFF,0xFF,this);
+    mCps.Set(l_cps_src);
+    mCps.SetStts(&mGStts);
+    mPntWindCpsS.mStart.x = current.pos.x;
+    mPntWindCpsS.mStart.y = current.pos.y;
+    mPntWindCpsS.mStart.z = current.pos.z;
+    mDoMtx_stack_c::transS(current.pos);
+    mDoMtx_stack_c::ZXYrotM(current.angle);
+    fVar2 = 200.0f;
+    if (current.angle.x != 0) {
+      fVar2 = 50.0f;
+    }
+    mDoMtx_stack_c::transM(0.0f, fVar2, 0.0f);
+    mDoMtx_stack_c::multVec(&cXyz::Zero, &mPntWindCpsS.mEnd);
+    mPntWindCpsS.mRadius = 50.0;
+    mCps.cM3dGCps::Set(mPntWindCpsS);
+    mCps.CalcAtVec();
+    mPointWind.set_pwind_init(&mPntWindCpsS);
+    fopAcM_offDraw(this);
+    return 1;
 }
 
 /* 0000029C-00000398       .text createEmitter__12daSteamTag_cFv */
-void daSteamTag_c::createEmitter() {
-    /* Nonmatching */
+BOOL daSteamTag_c::createEmitter() {    
+    if (mEmitterNum < 8) {
+        u16 particleID;
+        if (((s16)cM_rndF(100.0f) % 2) != 0) {
+            particleID = 0x808B;
+        } else {
+            particleID = 0x808C;
+        }
+        mpEmitter = dComIfGp_particle_setToon(particleID, &current.pos, &current.angle, &scale, getData()->mSteamAlpha);
+        if (mpEmitter) {
+            mEmitterNum++;
+            return TRUE;
+        }
+    }
+    return FALSE;
 }
 
 /* 00000398-000003B4       .text endEmitter__12daSteamTag_cFv */
-void daSteamTag_c::endEmitter() {
-    /* Nonmatching */
+bool daSteamTag_c::endEmitter() {
+    mEmitterNum--;
+    return TRUE;
 }
 
 /* 000003B4-000003BC       .text daSteamTag_Draw__FP12daSteamTag_c */
 static BOOL daSteamTag_Draw(daSteamTag_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 000003BC-000003DC       .text daSteamTag_Execute__FP12daSteamTag_c */
-static BOOL daSteamTag_Execute(daSteamTag_c*) {
-    /* Nonmatching */
+static BOOL daSteamTag_Execute(daSteamTag_c* i_this) {
+    return ((daSteamTag_c*)i_this)->execute();
 }
 
 /* 000003DC-000006FC       .text execute__12daSteamTag_cFv */
 BOOL daSteamTag_c::execute() {
-    /* Nonmatching */
+    float windStrength;
+    float fVar7;
+    
+    if ((mEmitTimer == 0) && (mCreateTimer > 0)) {
+        mCreateTimer--;
+        if (mCreateTimer == 0) {
+            if (createEmitter()) {
+                JGeometry::TVec3<s16> angle;
+                angle.x = current.angle.x;
+                angle.y = current.angle.y;
+                angle.z = current.angle.z;
+                mpEmitter->setGlobalTranslation(current.pos);
+                mpEmitter->setGlobalRotation(angle);
+                mpEmitter->setGlobalAlpha(getData()->mSteamAlpha);
+                mpEmitter->playCreateParticle();
+                mEmitTimer = getData()->mEmitTimer_offset + cM_rndF(getData()->mEmitTimer_seed);
+            }
+            else {
+                mCreateTimer = 0x1e;
+            }
+        }
+    }
+    else if ((mCreateTimer == 0) && (mEmitTimer > 0)) {
+        mEmitTimer--;
+        if (mEmitTimer == 0) {
+            if (mpEmitter != NULL) {
+                windStrength = 0.0f;
+                mpEmitter->stopCreateParticle();
+                if (mpEmitter->getParticleNumber() == 0) {
+                    mpEmitter->becomeInvalidEmitter();
+                    endEmitter();
+                    mpEmitter = NULL;
+                    mCreateTimer = getData()->mCreateTimer_offset + cM_rndF(getData()->mCreateTimer_seed);
+                }
+                else {
+                    mEmitTimer = 1;
+                    windStrength = 1.0f;
+                }
+                mPointWind.set_pwind_power(windStrength);
+            }
+        }
+        else {
+            fopAcM_seStart(this, JA_SE_OBJ_STEAM, 0);
+            if (mpEmitter != NULL) {
+              mpEmitter->setGlobalAlpha(getData()->mSteamAlpha);
+            }
+            mCps.cM3dGCps::Set(mPntWindCpsS);
+            dComIfG_Ccsp()->Set(&mCps);
+            mPointWind.set_pwind_move();
+        }
+    }
+    return TRUE;
 }
 
 /* 000006FC-00000704       .text daSteamTag_IsDelete__FP12daSteamTag_c */
 static BOOL daSteamTag_IsDelete(daSteamTag_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00000704-0000072C       .text daSteamTag_Delete__FP12daSteamTag_c */
-static BOOL daSteamTag_Delete(daSteamTag_c*) {
-    /* Nonmatching */
+static BOOL daSteamTag_Delete(daSteamTag_c* i_this) {
+    ((daSteamTag_c*)i_this)->~daSteamTag_c();
+    return TRUE;
+}
+
+daSteamTag_c::~daSteamTag_c() {
+    if (mpEmitter != NULL) {
+      mpEmitter->becomeInvalidEmitter();
+      mpEmitter = NULL;
+    }
+    mPointWind.set_pwind_delete();
+    return;
+}
+
+s32 daSteamTag_c::create() {
+    int result;
+    fopAcM_SetupActor(this, daSteamTag_c);
+    CreateInit();
+    if ((strcmp(dComIfGp_getStartStageName(),"Adanmae") == 0) &&
+        (current.roomNo == 0) &&
+        (checkItemGet(dItem_PEARL_DIN_e, TRUE))) {
+        result = cPhs_ERROR_e;
+    } else {
+        result = cPhs_COMPLEATE_e;
+    }
+    return result;
 }
 
 /* 00000930-00000AD0       .text daSteamTag_Create__FP10fopAc_ac_c */
-static s32 daSteamTag_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static s32 daSteamTag_Create(fopAc_ac_c* i_this) {
+    return ((daSteamTag_c*)i_this)->create();
 }
 
 static actor_method_class l_daSteamTag_Method = {


### PR DESCRIPTION
- Added inline functions to `d_point_wind` that were referenced in this TU
- This line `mCreateTimer = 0x1e;` in `daSteamTag_c::execute()` seems like it's referencing some constant declared in another file , not sure what it would be but it's likely related to timers somehow.
- I think the constant referenced in this line is correct (the value of it is) `checkItemGet(dItem_PEARL_DIN_e, TRUE)` in `daSteamTag_c::create()` but since I'm not sure what this actor is I don't know if Din's Pearl makes sense as the item here.