### PR TITLE
d_a_hys 100% equivalent with weak func order

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1463,7 +1463,7 @@ config.libs = [
     ActorRel(NonMatching, "d_a_gy_ctrl"),
     ActorRel(NonMatching, "d_a_himo3"),
     ActorRel(NonMatching, "d_a_hmlif"),
-    ActorRel(Equivalent, "d_a_hys"), # weak func order
+    ActorRel(Equivalent, "d_a_hys", extra_cflags=['-pragma "nosyminline on"']), # weak func order
     ActorRel(NonMatching, "d_a_kamome"),
     ActorRel(NonMatching, "d_a_kantera"),
     ActorRel(NonMatching, "d_a_kn"),

--- a/configure.py
+++ b/configure.py
@@ -1463,7 +1463,7 @@ config.libs = [
     ActorRel(NonMatching, "d_a_gy_ctrl"),
     ActorRel(NonMatching, "d_a_himo3"),
     ActorRel(NonMatching, "d_a_hmlif"),
-    ActorRel(NonMatching, "d_a_hys"),
+    ActorRel(Equivalent, "d_a_hys"), # weak func order
     ActorRel(NonMatching, "d_a_kamome"),
     ActorRel(NonMatching, "d_a_kantera"),
     ActorRel(NonMatching, "d_a_kn"),

--- a/include/d/actor/d_a_hys.h
+++ b/include/d/actor/d_a_hys.h
@@ -2,6 +2,7 @@
 #define D_A_HYS_H
 
 #include "d/d_bg_s_movebg_actor.h"
+#include "m_Do/m_Do_ext.h"
 
 class daHys_c : public dBgS_MoveBgActor {
 public:
@@ -19,8 +20,20 @@ public:
     void mode_wait_init();
     virtual BOOL Draw();
 
+    static const char* m_arcname[];
+    static const s16 m_dzbidx[];
+    static const u32 m_heapsize[];
+
 public:
-    /* Place member variables here */
+    /* 0x2C8 */ request_of_phase_process_class mPhs;
+    /* 0x2D0 */ J3DModel* mpModel;
+    /* 0x2D4 */ mDoExt_btpAnm mBtpAnm;
+    /* 0x2E8 */ u8 field_0x2E8[0x450 - 0x2E8];
+    /* 0x450 */ u32 field_0x450;
+    /* 0x454 */ u32 field_0x454;
+    /* 0x458 */ u8 field_0x458;
+    /* 0x459 */ u8 mType;
+    /* 0x45A */ u8 field_0x45A[0x45C - 0x45A];
 };
 
 #endif /* D_A_HYS_H */

--- a/include/d/actor/d_a_hys.h
+++ b/include/d/actor/d_a_hys.h
@@ -2,6 +2,7 @@
 #define D_A_HYS_H
 
 #include "d/d_bg_s_movebg_actor.h"
+#include "d/d_cc_d.h"
 #include "m_Do/m_Do_ext.h"
 
 class daHys_c : public dBgS_MoveBgActor {
@@ -21,16 +22,20 @@ public:
     virtual BOOL Draw();
 
     static const char* m_arcname[];
+    static const s16 m_bdlidx[];
+    static const s16 m_btpidx[];
     static const s16 m_dzbidx[];
     static const u32 m_heapsize[];
+    static const f32 m_tg_r[];
 
 public:
     /* 0x2C8 */ request_of_phase_process_class mPhs;
     /* 0x2D0 */ J3DModel* mpModel;
     /* 0x2D4 */ mDoExt_btpAnm mBtpAnm;
-    /* 0x2E8 */ u8 field_0x2E8[0x450 - 0x2E8];
+    /* 0x2E8 */ dCcD_Stts mStts;
+    /* 0x324 */ dCcD_Sph mSph;
     /* 0x450 */ u32 field_0x450;
-    /* 0x454 */ u32 field_0x454;
+    /* 0x454 */ u32 mSwitchNo;
     /* 0x458 */ u8 field_0x458;
     /* 0x459 */ u8 mType;
     /* 0x45A */ u8 field_0x45A[0x45C - 0x45A];

--- a/src/d/actor/d_a_hys.cpp
+++ b/src/d/actor/d_a_hys.cpp
@@ -4,11 +4,18 @@
 //
 
 #include "d/actor/d_a_hys.h"
+#include "d/d_com_inf_game.h"
+#include "m_Do/m_Do_mtx.h"
 #include "d/d_procname.h"
+
+const char* daHys_c::m_arcname[2] = {"Hys", "Hys"};
+const s16 daHys_c::m_dzbidx[2] = {0xB, 0xB};
+const u32 daHys_c::m_heapsize[2] = {0xA00, 0xA00};
 
 /* 00000078-000000B8       .text Delete__7daHys_cFv */
 BOOL daHys_c::Delete() {
-    /* Nonmatching */
+    dComIfG_resDelete(&mPhs, m_arcname[mType]);
+    return TRUE;
 }
 
 /* 000000B8-00000250       .text CreateHeap__7daHys_cFv */
@@ -16,14 +23,37 @@ BOOL daHys_c::CreateHeap() {
     /* Nonmatching */
 }
 
+cPhs_State daHys_c::_create() {
+    /* Nonmatching */
+    fopAcM_SetupActor(this, daHys_c);
+
+    mType = fopAcM_GetParam(this) >> 8;
+    cPhs_State res = dComIfG_resLoad(&mPhs, m_arcname[mType]);
+    if (res != cPhs_COMPLEATE_e) {
+        return res;
+    }
+
+    res = MoveBGCreate(m_arcname[mType], m_dzbidx[mType], dBgS_MoveBGProc_TypicalRotY, m_heapsize[mType]);
+    if (res != cPhs_COMPLEATE_e) {
+        return res;
+    }
+
+    return cPhs_COMPLEATE_e;
+}
+
 /* 00000250-00000368       .text Create__7daHys_cFv */
 BOOL daHys_c::Create() {
     /* Nonmatching */
+    return _create();
 }
 
 /* 00000368-000003F8       .text set_mtx__7daHys_cFv */
 void daHys_c::set_mtx() {
-    /* Nonmatching */
+    mpModel->setBaseScale(scale);
+    mDoMtx_stack_c::transS(current.pos);
+    mDoMtx_stack_c::YrotM(current.angle.y);
+    mpModel->setBaseTRMtx(mDoMtx_stack_c::get());
+    mDoMtx_copy(mDoMtx_stack_c::get(), mBgMtx);
 }
 
 /* 000003F8-000004A4       .text Execute__7daHys_cFPPA3_A4_f */
@@ -53,37 +83,42 @@ void daHys_c::mode_sw_on() {
 
 /* 000006F8-00000704       .text mode_wait_init__7daHys_cFv */
 void daHys_c::mode_wait_init() {
-    /* Nonmatching */
+    field_0x450 = 0;
 }
 
 /* 00000704-00000778       .text Draw__7daHys_cFv */
 BOOL daHys_c::Draw() {
-    /* Nonmatching */
+    g_env_light.settingTevStruct(TEV_TYPE_ACTOR, &current.pos, &tevStr);
+    g_env_light.setLightTevColorType(mpModel, &tevStr);
+    mBtpAnm.entry(mpModel->getModelData(), field_0x458);
+    mDoExt_modelUpdateDL(mpModel);
+    return TRUE;
 }
 
 /* 00000778-00000904       .text daHys_Create__FPv */
-static cPhs_State daHys_Create(void*) {
+static cPhs_State daHys_Create(void* i_this) {
     /* Nonmatching */
+    return ((daHys_c*)i_this)->_create();
 }
 
 /* 00000BBC-00000BDC       .text daHys_Delete__FPv */
-static BOOL daHys_Delete(void*) {
-    /* Nonmatching */
+static BOOL daHys_Delete(void* i_this) {
+    return ((daHys_c*)i_this)->MoveBGDelete();
 }
 
 /* 00000BDC-00000C08       .text daHys_Draw__FPv */
-static BOOL daHys_Draw(void*) {
-    /* Nonmatching */
+static BOOL daHys_Draw(void* i_this) {
+    return ((daHys_c*)i_this)->Draw();
 }
 
 /* 00000C08-00000C28       .text daHys_Execute__FPv */
-static BOOL daHys_Execute(void*) {
-    /* Nonmatching */
+static BOOL daHys_Execute(void* i_this) {
+    return ((daHys_c*)i_this)->MoveBGExecute();
 }
 
 /* 00000C28-00000C30       .text daHys_IsDelete__FPv */
 static BOOL daHys_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daHysMethodTable = {

--- a/src/d/actor/d_a_hys.cpp
+++ b/src/d/actor/d_a_hys.cpp
@@ -4,6 +4,7 @@
 //
 
 #include "d/actor/d_a_hys.h"
+#include "d/res/res_hys.h"
 #include "d/d_com_inf_game.h"
 #include "m_Do/m_Do_mtx.h"
 #include "d/d_procname.h"
@@ -13,10 +14,10 @@
 const char* daHys_c::m_arcname[2] = {"Hys", "Hys"};
 
 /* Model file indexes. */
-const s16 daHys_c::m_bdlidx[2] = {5, 5};
-/* Texture file  */
-const s16 daHys_c::m_btpidx[2] = {8, 8};
-const s16 daHys_c::m_dzbidx[2] = {11, 11};
+const s16 daHys_c::m_bdlidx[2] = {HYS_BDL_HYS, HYS_BDL_HYS};
+/* Texture file indexes.  */
+const s16 daHys_c::m_btpidx[2] = {HYS_BTP_HYS, HYS_BTP_HYS};
+const s16 daHys_c::m_dzbidx[2] = {HYS_DZB_HYS, HYS_DZB_HYS};
 const u32 daHys_c::m_heapsize[2] = {0xA00, 0xA00};
 const f32 daHys_c::m_tg_r[2] = {35.0f, 70.0f};
 
@@ -94,7 +95,7 @@ cPhs_State daHys_c::_create() {
 /* 00000250-00000368       .text Create__7daHys_cFv */
 BOOL daHys_c::Create() {
     fopAcM_SetMtx(this, mpModel->getBaseTRMtx());
-    fopAcM_setCullSizeBox(this, -240.0, -240.0, -90.0, 240.0, 240.0, 90.0);
+    fopAcM_setCullSizeBox(this, -240.0f, -240.0f, -90.0f, 240.0f, 240.0f, 90.0f);
 
     mStts.Init(255, 255, this);
     mSph.Set(l_sph_src);

--- a/src/d/actor/d_a_hys.cpp
+++ b/src/d/actor/d_a_hys.cpp
@@ -8,9 +8,46 @@
 #include "m_Do/m_Do_mtx.h"
 #include "d/d_procname.h"
 
+#include "weak_data_1811.h" // IWYU pragma: keep
+
 const char* daHys_c::m_arcname[2] = {"Hys", "Hys"};
-const s16 daHys_c::m_dzbidx[2] = {0xB, 0xB};
+
+/* Model file indexes. */
+const s16 daHys_c::m_bdlidx[2] = {5, 5};
+/* Texture file  */
+const s16 daHys_c::m_btpidx[2] = {8, 8};
+const s16 daHys_c::m_dzbidx[2] = {11, 11};
 const u32 daHys_c::m_heapsize[2] = {0xA00, 0xA00};
+const f32 daHys_c::m_tg_r[2] = {35.0f, 70.0f};
+
+static dCcD_SrcSph l_sph_src = {
+    // dCcD_SrcGObjInf
+    {
+        /* Flags             */ 0,
+        /* SrcObjAt  Type    */ 0,
+        /* SrcObjAt  Atp     */ 0,
+        /* SrcObjAt  SPrm    */ 0,
+        /* SrcObjTg  Type    */ AT_TYPE_NORMAL_ARROW | AT_TYPE_FIRE_ARROW | AT_TYPE_ICE_ARROW | AT_TYPE_LIGHT_ARROW,
+        /* SrcObjTg  SPrm    */ cCcD_TgSPrm_Set_e | cCcD_TgSPrm_IsOther_e,
+        /* SrcObjCo  SPrm    */ 0,
+        /* SrcGObjAt Se      */ 0,
+        /* SrcGObjAt HitMark */ 0,
+        /* SrcGObjAt Spl     */ 0,
+        /* SrcGObjAt Mtrl    */ 0,
+        /* SrcGObjAt SPrm    */ 0,
+        /* SrcGObjTg Se      */ 0,
+        /* SrcGObjTg HitMark */ 0,
+        /* SrcGObjTg Spl     */ 0,
+        /* SrcGObjTg Mtrl    */ 0,
+        /* SrcGObjTg SPrm    */ dCcG_TgSPrm_NoHitMark_e,
+        /* SrcGObjCo SPrm    */ 0,
+    },
+    // cM3dGSphS
+    {
+        /* Center */ 0.0f, 0.0f, 0.0f,
+        /* Radius */ 30.0f,
+    },
+};
 
 /* 00000078-000000B8       .text Delete__7daHys_cFv */
 BOOL daHys_c::Delete() {
@@ -20,31 +57,66 @@ BOOL daHys_c::Delete() {
 
 /* 000000B8-00000250       .text CreateHeap__7daHys_cFv */
 BOOL daHys_c::CreateHeap() {
-    /* Nonmatching */
+    J3DModelData* modelData = (J3DModelData *)dComIfG_getObjectRes(m_arcname[mType], m_bdlidx[mType]);
+    JUT_ASSERT(0x106, modelData != NULL);
+
+    mpModel = mDoExt_J3DModel__create(modelData, 0x80000, 0x11020022);
+    if (mpModel == NULL) {
+        return FALSE;
+    }
+
+    J3DAnmTexPattern* pbtp = (J3DAnmTexPattern *)dComIfG_getObjectRes(m_arcname[mType], m_btpidx[mType]);
+    JUT_ASSERT(0x114, pbtp != NULL);
+
+    if (!mBtpAnm.init(modelData, pbtp, 0, 0, 1.0, 0, -1, FALSE, FALSE)) {
+        return FALSE;
+    }
+    field_0x458 = 0;
+    return TRUE;
 }
 
 cPhs_State daHys_c::_create() {
-    /* Nonmatching */
+    // Inlined into daHys_Create
     fopAcM_SetupActor(this, daHys_c);
 
     mType = fopAcM_GetParam(this) >> 8;
     cPhs_State res = dComIfG_resLoad(&mPhs, m_arcname[mType]);
-    if (res != cPhs_COMPLEATE_e) {
-        return res;
+    if (res == cPhs_COMPLEATE_e) {
+        res = MoveBGCreate(m_arcname[mType], m_dzbidx[mType], dBgS_MoveBGProc_TypicalRotY, m_heapsize[mType]);
+        if (res == cPhs_ERROR_e) {
+            return cPhs_ERROR_e;
+        }
     }
 
-    res = MoveBGCreate(m_arcname[mType], m_dzbidx[mType], dBgS_MoveBGProc_TypicalRotY, m_heapsize[mType]);
-    if (res != cPhs_COMPLEATE_e) {
-        return res;
-    }
-
-    return cPhs_COMPLEATE_e;
+    return res;
 }
 
 /* 00000250-00000368       .text Create__7daHys_cFv */
 BOOL daHys_c::Create() {
-    /* Nonmatching */
-    return _create();
+    fopAcM_SetMtx(this, mpModel->getBaseTRMtx());
+    fopAcM_setCullSizeBox(this, -240.0, -240.0, -90.0, 240.0, 240.0, 90.0);
+
+    mStts.Init(255, 255, this);
+    mSph.Set(l_sph_src);
+    mSph.SetStts(&mStts);
+    mSph.SetR(m_tg_r[mType]);
+
+    set_mtx();
+    mSwitchNo = fopAcM_GetParam(this) & 0xFF;
+
+    if (fopAcM_isSwitch(this, mSwitchNo)) {
+        field_0x450 = 1;
+        field_0x458 = 3;
+    } else {
+        field_0x450 = 0;
+        field_0x458 = 0;
+    }
+
+    if (mType == 1) {
+        scale.setall(2.0f);
+    }
+
+    return TRUE;
 }
 
 /* 00000368-000003F8       .text set_mtx__7daHys_cFv */
@@ -57,28 +129,67 @@ void daHys_c::set_mtx() {
 }
 
 /* 000003F8-000004A4       .text Execute__7daHys_cFPPA3_A4_f */
-BOOL daHys_c::Execute(Mtx**) {
-    /* Nonmatching */
+BOOL daHys_c::Execute(Mtx** mtx) {
+    mode_proc_call();
+
+    mpModel->setBaseScale(scale);
+    mDoMtx_stack_c::transS(current.pos);
+    mDoMtx_stack_c::YrotM(current.angle.y);
+    mpModel->setBaseTRMtx(mDoMtx_stack_c::get());
+    cMtx_copy(mDoMtx_stack_c::get(), mBgMtx);
+
+    *mtx = &mBgMtx;
+    return TRUE;
 }
 
 /* 000004A4-00000560       .text mode_proc_call__7daHys_cFv */
 void daHys_c::mode_proc_call() {
-    /* Nonmatching */
+    typedef void (daHys_c::*ModeFunc)();
+    static const ModeFunc mode_proc[2] = {
+        &daHys_c::mode_wait,
+        &daHys_c::mode_sw_on,
+    };
+
+    (this->*mode_proc[field_0x450])();
+    mSph.SetC(current.pos);
+    dComIfG_Ccsp()->Set(&mSph);
 }
 
 /* 00000560-00000600       .text mode_wait__7daHys_cFv */
 void daHys_c::mode_wait() {
-    /* Nonmatching */
+    if (mSph.ChkTgHit()) {
+        cCcD_Obj* obj = mSph.GetTgHitObj();
+        if (obj != NULL && (obj->ChkAtType(AT_TYPE_NORMAL_ARROW) ||
+                            obj->ChkAtType(AT_TYPE_FIRE_ARROW) ||
+                            obj->ChkAtType(AT_TYPE_ICE_ARROW) ||
+                            obj->ChkAtType(AT_TYPE_LIGHT_ARROW))) {
+            mSph.ClrTgHit();
+            mode_sw_on_init();
+            return;
+        }
+    }
+
+    if (field_0x458 != 0) {
+        field_0x458--;
+    }
 }
 
 /* 00000600-00000690       .text mode_sw_on_init__7daHys_cFv */
 void daHys_c::mode_sw_on_init() {
-    /* Nonmatching */
+    fopAcM_onSwitch(this, mSwitchNo);
+    field_0x450 = 1;
+    fopAcM_seStart(this, JA_SE_OBJ_ARROW_SW_ON, 0);
 }
 
 /* 00000690-000006F8       .text mode_sw_on__7daHys_cFv */
 void daHys_c::mode_sw_on() {
-    /* Nonmatching */
+    if (!fopAcM_isSwitch(this, mSwitchNo)) {
+        mode_wait_init();
+    } else {
+        if (field_0x458 < 3) {
+            field_0x458++;
+        }
+    }
 }
 
 /* 000006F8-00000704       .text mode_wait_init__7daHys_cFv */
@@ -97,7 +208,6 @@ BOOL daHys_c::Draw() {
 
 /* 00000778-00000904       .text daHys_Create__FPv */
 static cPhs_State daHys_Create(void* i_this) {
-    /* Nonmatching */
     return ((daHys_c*)i_this)->_create();
 }
 


### PR DESCRIPTION
All sections are 100% in objdiff 
![image](https://github.com/user-attachments/assets/75944122-db1f-46cc-b5c4-f0b73d02d612)

I tried both `-pragma "nosyminline on"` and `-sym off` but neither of them fully match. `nosyminline` gets close but it looks like the issue is related to the call order of the parent class? Not sure if there's anything else I should try there.

![image](https://github.com/user-attachments/assets/cb3b4bf0-3f67-4eab-b755-8794a7c46809)
