### PR TITLE
Link J3DTransform with assembly blocks

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -972,7 +972,7 @@ config.libs = [
             Object(Matching,    "JSystem/J3DGraphBase/J3DGD.cpp"),
             Object(Matching,    "JSystem/J3DGraphBase/J3DSys.cpp"),
             Object(Matching,    "JSystem/J3DGraphBase/J3DVertex.cpp"),
-            Object(NonMatching, "JSystem/J3DGraphBase/J3DTransform.cpp"),
+            Object(Matching,    "JSystem/J3DGraphBase/J3DTransform.cpp"),
             Object(Matching,    "JSystem/J3DGraphBase/J3DPacket.cpp"),
             Object(Matching,    "JSystem/J3DGraphBase/J3DShapeMtx.cpp"),
             Object(Matching,    "JSystem/J3DGraphBase/J3DShape.cpp"),


### PR DESCRIPTION
This allows linking of `J3DTransform` using some ugly inline assembly blocks. This is how most other de-compilation projects have tackled this bit of JSystem.

I was able to get the compiler to spit out the vectorized `ps_` instructions using `__vec2x32float__ ` but that has its own set of challenges so I'll probably take a look at using that to clean up this file as a lower priority item later.