### PR TITLE
Match up data and additional functions in JASTrack

### DIFF
--- a/include/JSystem/JAudio/JASRegisterParam.h
+++ b/include/JSystem/JAudio/JASRegisterParam.h
@@ -2,10 +2,15 @@
 #define JASREGISTERPARAM_H
 
 #include "dolphin/types.h"
+#include "JSystem/JUtility/JUTAssert.h"
 
 namespace JASystem {
     class TRegisterParam {
     public:
+        static const u8 PARAM_REG_XY = 0x23;
+        static const u8 PARAM_REG_AR0 = 0x28;
+        static const u8 PARAM_REG_AR3 = 0x2B;
+
         TRegisterParam();
         void init();
         void inherit(const TRegisterParam&);
@@ -25,16 +30,25 @@ namespace JASystem {
         void setFlag(u16 flag) { field_0x0[3] = flag; }
         void setPanPower(int i, u16 power) { mPanPower[i] = power; }
 
+        inline u16 _readReg16(s32 index) {
+            return field_0x0[index];
+        }
+
+        inline u32 _readReg32(s32 index) {
+            // Name is made up but we know this function lives here because it
+            // has assertions with this file's name.
+            JUT_ASSERT(130, index >= 0);
+            JUT_ASSERT(131, index < 4);
+            return field_0x20[index];
+        }
+
         /* 0x00 */ u16 field_0x0[6];
         /* 0x0C */ u16 field_0xc;
         /* 0x0E */ u16 field_0xe;
         /* 0x10 */ u16 mPanPower[5];
         /* 0x1A */ u16 field_0x1a;
         /* 0x1C */ int field_0x1c;
-        /* 0x20 */ int field_0x20;
-        /* 0x24 */ int field_0x24;
-        /* 0x28 */ int field_0x28;
-        /* 0x2C */ int field_0x2c;
+        /* 0x20 */ u32 field_0x20[4];
     };
 }
 

--- a/include/JSystem/JAudio/JASTrack.h
+++ b/include/JSystem/JAudio/JASTrack.h
@@ -67,7 +67,7 @@ namespace JASystem {
             TIMED_IIR_Unk3    = 15,
             TIMED_Unk16       = 16,
             TIMED_Unk17       = 17,
-            TIMED_Count, // 18
+            TIMED_PARAMS, // 18
         };
 
         class TOuterParam {
@@ -138,10 +138,10 @@ namespace JASystem {
 #ifdef __MWERKS__
             union {
                 AInnerParam_ mInnerParam;
-                MoveParam_ mMoveParams[TIMED_Count];
+                MoveParam_ mMoveParams[TIMED_PARAMS];
             };
 #else
-            MoveParam_ mMoveParams[TIMED_Count];
+            MoveParam_ mMoveParams[TIMED_PARAMS];
 #endif
         };
 
@@ -218,7 +218,7 @@ namespace JASystem {
         void writeSelfPort(int, u16);
         int writePortAppDirect(u32, u16);
         int readPortAppDirect(u32, u16*);
-        void routeTrack(u32);
+        JASystem::TTrack* routeTrack(u32);
         int writePortApp(u32, u16);
         int readPortApp(u32, u16*);
         void pause(bool, bool);
@@ -226,7 +226,7 @@ namespace JASystem {
         void setTempo(u16);
         void setTimebase(u16);
         f32 panCalc(f32, f32, f32, u8);
-        static int rootCallback(void*);
+        static s32 rootCallback(void*);
         static void registerSeqCallback(u16 (*)(TTrack*, u16));
         static void newMemPool(int);
 
@@ -250,7 +250,7 @@ namespace JASystem {
         void unPauseTrackAll() { pause(false, true); }
         void setPanPower(int i, u16 power) { mRegisterParam.setPanPower(i, power); }
         void setPauseStatus(u8 status) { mPauseStatus = status; }
-        void setTranspose(s32 transpose) { field_0x37a = transpose; }
+        void setTranspose(s32 transpose) { mTranspose = transpose; }
         void setVolumeMode(u8 mode) { mVolumeMode = mode; }
 
         /* 0x000 */ union {
@@ -278,7 +278,7 @@ namespace JASystem {
         /* 0x374 */ u16 field_0x374;
         /* 0x376 */ u16 field_0x376;
         /* 0x378 */ u16 field_0x378;
-        /* 0x37A */ u8 field_0x37a;
+        /* 0x37A */ s8 mTranspose;
         /* 0x37B */ u8 field_0x37b;
         /* 0x37C */ u8 mPauseStatus;
         /* 0x37D */ u8 mVolumeMode;

--- a/src/JSystem/JAudio/JASRegisterParam.cpp
+++ b/src/JSystem/JAudio/JASRegisterParam.cpp
@@ -22,10 +22,10 @@ JASystem::TRegisterParam::TRegisterParam() {
     mPanPower[2] = 0;
     mPanPower[3] = 0;
     mPanPower[4] = 0;
-    field_0x20 = 0;
-    field_0x24 = 0;
-    field_0x28 = 0;
-    field_0x2c = 0;
+    field_0x20[0] = 0;
+    field_0x20[1] = 0;
+    field_0x20[2] = 0;
+    field_0x20[3] = 0;
 }
 
 /* 8027E310-8027E378       .text init__Q28JASystem14TRegisterParamFv */
@@ -44,10 +44,10 @@ void JASystem::TRegisterParam::init() {
     mPanPower[2] = 1;
     mPanPower[3] = 0x7fff;
     mPanPower[4] = 0x4000;
-    field_0x20 = 0;
-    field_0x24 = 0;
-    field_0x28 = 0;
-    field_0x2c = 0;
+    field_0x20[0] = 0;
+    field_0x20[1] = 0;
+    field_0x20[2] = 0;
+    field_0x20[3] = 0;
 }
 
 /* 8027E378-8027E3E0       .text inherit__Q28JASystem14TRegisterParamFRCQ28JASystem14TRegisterParam */
@@ -64,10 +64,10 @@ void JASystem::TRegisterParam::inherit(const JASystem::TRegisterParam& param_1) 
     for (int i = 0; i < 5; i++) {
         mPanPower[i] = param_1.mPanPower[i];
     }
-    field_0x20 = 0;
-    field_0x24 = 0;
-    field_0x28 = 0;
-    field_0x2c = 0;
+    field_0x20[0] = 0;
+    field_0x20[1] = 0;
+    field_0x20[2] = 0;
+    field_0x20[3] = 0;
 }
 
 /* 8027E3E0-8027E3EC       .text getBankNumber__Q28JASystem14TRegisterParamCFv */


### PR DESCRIPTION
Most matching was straightforward, I didn't do some of the longer functions `updateTrackAll` and `updateTrack` but I included the float constants inside of them that allow stuff to match.

One weird thing I'd like to get some eyes on is `TTrack::openChild` where the code seems to take an existing pointer and then re-run a constructor on it. My guess is this is a [placement new](https://en.cppreference.com/w/cpp/language/new#Placement_new) invocation but I'm not sure. The placement new operator doesn't seem to be overridden anywhere yet but I'm not sure how else you would invoke a constructor on a pointer like that.