### PR TITLE
Auto-generate most trivial process_method_funcs

### DIFF
--- a/include/d/actor/d_a_bigelf.h
+++ b/include/d/actor/d_a_bigelf.h
@@ -78,9 +78,9 @@ public:
     void event0();
     void dead();
     void wait_action(void*);
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
     void CreateHeap();
 

--- a/include/d/actor/d_a_hmlif.h
+++ b/include/d/actor/d_a_hmlif.h
@@ -6,7 +6,7 @@
 class daHmlif_c : public dBgS_MoveBgActor {
 public:
     virtual BOOL Delete();
-    void daHmlifDelete();
+    BOOL daHmlifDelete();
     virtual BOOL CreateHeap();
     virtual BOOL Create();
     cPhs_State daHmlifCreate();

--- a/include/d/actor/d_a_npc_ac1.h
+++ b/include/d/actor/d_a_npc_ac1.h
@@ -56,9 +56,9 @@ public:
     void wait_action1(void*);
     void demo();
     void shadowDraw();
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
     void create_Anm();
     void create_wng_Anm();

--- a/include/d/actor/d_a_npc_aj1.h
+++ b/include/d/actor/d_a_npc_aj1.h
@@ -89,9 +89,9 @@ public:
     void wait_action2(void*);
     void demo();
     void shadowDraw();
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
     void bodyCreateHeap();
     void itemCreateHeap();

--- a/include/d/actor/d_a_npc_ba1.h
+++ b/include/d/actor/d_a_npc_ba1.h
@@ -98,9 +98,9 @@ public:
     void wait_action4(void*);
     void demo();
     void shadowDraw();
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
     void create_Anm();
     void create_itm_Mdl();

--- a/include/d/actor/d_a_npc_bj1.h
+++ b/include/d/actor/d_a_npc_bj1.h
@@ -116,9 +116,9 @@ public:
     void wait_action4(void*);
     void demo();
     void shadowDraw();
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
     void create_Anm();
     void create_prp_Anm();

--- a/include/d/actor/d_a_npc_bm1.h
+++ b/include/d/actor/d_a_npc_bm1.h
@@ -162,9 +162,9 @@ public:
     void wait_actionA(void*);
     void demo();
     void shadowDraw();
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
     void create_Anm();
     void create_hed_Anm();

--- a/include/d/actor/d_a_npc_bms1.h
+++ b/include/d/actor/d_a_npc_bms1.h
@@ -52,9 +52,9 @@ public:
     void privateCut();
     void demo_move();
     void demo_end_init();
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
     void CreateHeap();
 

--- a/include/d/actor/d_a_npc_bmsw.h
+++ b/include/d/actor/d_a_npc_bmsw.h
@@ -33,9 +33,9 @@ public:
     void setGameGetRupee(short);
     void TimerCountDown();
     void shiwake_game_action(void*);
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
     void CreateHeap();
 

--- a/include/d/actor/d_a_npc_btsw.h
+++ b/include/d/actor/d_a_npc_btsw.h
@@ -29,9 +29,9 @@ public:
     void TimerCountDown();
     void shiwake_game_action(void*);
     void getdemo_action(void*);
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
     void CreateHeap();
 

--- a/include/d/actor/d_a_npc_co1.h
+++ b/include/d/actor/d_a_npc_co1.h
@@ -67,9 +67,9 @@ public:
     void wait_action1(void*);
     void demo();
     void shadowDraw();
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
     void create_Anm();
     void create_prl_Anm();

--- a/include/d/actor/d_a_npc_de1.h
+++ b/include/d/actor/d_a_npc_de1.h
@@ -53,9 +53,9 @@ public:
     void wait_action1(void*);
     void wait_action2(void*);
     void demo();
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
     void CreateHeap();
 

--- a/include/d/actor/d_a_npc_ds1.h
+++ b/include/d/actor/d_a_npc_ds1.h
@@ -58,9 +58,9 @@ public:
     void dummy_action(void*);
     void RoomEffectSet();
     void RoomEffectDelete();
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
     void CreateHeap();
 

--- a/include/d/actor/d_a_npc_gk1.h
+++ b/include/d/actor/d_a_npc_gk1.h
@@ -55,9 +55,9 @@ public:
     void wait_action1(void*);
     void demo();
     void shadowDraw();
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
     void bodyCreateHeap();
     void itemCreateHeap();

--- a/include/d/actor/d_a_npc_gp1.h
+++ b/include/d/actor/d_a_npc_gp1.h
@@ -67,9 +67,9 @@ public:
     void wait_2();
     void wait_action1(void*);
     void demo();
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
     void create_Anm();
     void CreateHeap();

--- a/include/d/actor/d_a_npc_hi1.h
+++ b/include/d/actor/d_a_npc_hi1.h
@@ -57,9 +57,9 @@ public:
     void wait_action1(void*);
     void demo();
     void shadowDraw();
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
     void bodyCreateHeap();
     void CreateHeap();

--- a/include/d/actor/d_a_npc_ho.h
+++ b/include/d/actor/d_a_npc_ho.h
@@ -53,9 +53,9 @@ public:
     void give02();
     void preach();
     void wait_action(void*);
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
     void CreateHeap();
 

--- a/include/d/actor/d_a_npc_hr.h
+++ b/include/d/actor/d_a_npc_hr.h
@@ -138,9 +138,9 @@ public:
     void talk01();
     void ht_tact01();
     void wait_action(void*);
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
     void CreateHeap();
 

--- a/include/d/actor/d_a_npc_jb1.h
+++ b/include/d/actor/d_a_npc_jb1.h
@@ -44,9 +44,9 @@ public:
     void wait_1();
     void wait_action1(void*);
     void demo();
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
     void create_Anm();
     void create_lgt();

--- a/include/d/actor/d_a_npc_kf1.h
+++ b/include/d/actor/d_a_npc_kf1.h
@@ -87,9 +87,9 @@ public:
     void wait_action1(void*);
     void demo();
     void shadowDraw();
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
     void bodyCreateHeap();
     void itemCreateHeap();

--- a/include/d/actor/d_a_npc_kf1.h
+++ b/include/d/actor/d_a_npc_kf1.h
@@ -87,9 +87,9 @@ public:
     void wait_action1(void*);
     void demo();
     void shadowDraw();
-    BOOL _draw();
-    BOOL _execute();
-    BOOL _delete();
+    bool _draw();
+    bool _execute();
+    bool _delete();
     cPhs_State _create();
     void bodyCreateHeap();
     void itemCreateHeap();

--- a/include/d/actor/d_a_npc_kg2.h
+++ b/include/d/actor/d_a_npc_kg2.h
@@ -39,9 +39,9 @@ public:
     void wait_action(void*);
     void event_wait_action(void*);
     cPhs_State _create();
-    bool _delete();
-    bool _execute();
-    bool _draw();
+    BOOL _delete();
+    BOOL _execute();
+    BOOL _draw();
 
     static void init() {
         canon_game_result = 0;

--- a/include/d/actor/d_a_npc_kk1.h
+++ b/include/d/actor/d_a_npc_kk1.h
@@ -113,9 +113,9 @@ public:
     void wait_action1(void*);
     void demo();
     void shadowDraw();
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
     void bodyCreateHeap();
     void effcCreateHeap();

--- a/include/d/actor/d_a_npc_kk1.h
+++ b/include/d/actor/d_a_npc_kk1.h
@@ -113,9 +113,9 @@ public:
     void wait_action1(void*);
     void demo();
     void shadowDraw();
-    BOOL _draw();
-    BOOL _execute();
-    BOOL _delete();
+    bool _draw();
+    bool _execute();
+    bool _delete();
     cPhs_State _create();
     void bodyCreateHeap();
     void effcCreateHeap();

--- a/include/d/actor/d_a_npc_km1.h
+++ b/include/d/actor/d_a_npc_km1.h
@@ -53,9 +53,9 @@ public:
     void talk01();
     void wait_action1(void*);
     void demo();
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
     void CreateHeap();
 

--- a/include/d/actor/d_a_npc_km1.h
+++ b/include/d/actor/d_a_npc_km1.h
@@ -53,9 +53,9 @@ public:
     void talk01();
     void wait_action1(void*);
     void demo();
-    BOOL _draw();
-    BOOL _execute();
-    BOOL _delete();
+    bool _draw();
+    bool _execute();
+    bool _delete();
     cPhs_State _create();
     void CreateHeap();
 

--- a/include/d/actor/d_a_npc_ko1.h
+++ b/include/d/actor/d_a_npc_ko1.h
@@ -127,9 +127,9 @@ public:
     void wait_action4(void*);
     void demo();
     void shadowDraw();
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
     void create_Anm();
     void create_hed_Anm();

--- a/include/d/actor/d_a_npc_kp1.h
+++ b/include/d/actor/d_a_npc_kp1.h
@@ -56,9 +56,9 @@ public:
     void wait_action1(void*);
     void demo();
     void shadowDraw();
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
     void CreateHeap();
 

--- a/include/d/actor/d_a_npc_ls1.h
+++ b/include/d/actor/d_a_npc_ls1.h
@@ -104,9 +104,9 @@ public:
     void demo_action1(void*);
     void demo();
     void shadowDraw();
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
     void bodyCreateHeap();
     void handCreateHeap();

--- a/include/d/actor/d_a_npc_mk.h
+++ b/include/d/actor/d_a_npc_mk.h
@@ -76,9 +76,9 @@ public:
     void seek_action(void*);
     void hind_action(void*);
     void visit_action(void*);
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
     void CreateHeap();
 

--- a/include/d/actor/d_a_npc_ob1.h
+++ b/include/d/actor/d_a_npc_ob1.h
@@ -73,9 +73,9 @@ public:
     void wait_action2(void*);
     void demo();
     void shadowDraw();
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
     void create_Anm();
     void create_hed_Mdl();

--- a/include/d/actor/d_a_npc_p1.h
+++ b/include/d/actor/d_a_npc_p1.h
@@ -29,11 +29,11 @@ public:
     void setAttentionPos(cXyz*);
     cPhs_State _create();
     void CreateHeap();
-    bool _delete();
+    BOOL _delete();
     void getKajiID();
     void kaji_anm();
-    bool _execute();
-    bool _draw();
+    BOOL _execute();
+    BOOL _draw();
     void lookBack();
 
 public:

--- a/include/d/actor/d_a_npc_pf1.h
+++ b/include/d/actor/d_a_npc_pf1.h
@@ -67,9 +67,9 @@ public:
     void wait_action1(void*);
     void demo();
     void shadowDraw();
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
     void bodyCreateHeap();
     void CreateHeap();

--- a/include/d/actor/d_a_npc_pm1.h
+++ b/include/d/actor/d_a_npc_pm1.h
@@ -53,9 +53,9 @@ public:
     void talk01();
     void wait_action1(void*);
     void demo();
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
     void CreateHeap();
 

--- a/include/d/actor/d_a_npc_rsh1.h
+++ b/include/d/actor/d_a_npc_rsh1.h
@@ -58,9 +58,9 @@ public:
     void privateCut();
     void event_action(void*);
     void dummy_action(void*);
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
     void CreateHeap();
     void set_mtx();

--- a/include/d/actor/d_a_npc_sarace.h
+++ b/include/d/actor/d_a_npc_sarace.h
@@ -30,9 +30,9 @@ public:
     void wait_action(void*);
     void event_endCheck_action(void*);
     void set_mtx();
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
     void CreateHeap();
     

--- a/include/d/actor/d_a_npc_tc.h
+++ b/include/d/actor/d_a_npc_tc.h
@@ -58,10 +58,10 @@ public:
     void wait_action(void*);
     void calc_sitpos();
     void set_mtx();
-    bool _draw();
+    BOOL _draw();
     void setTower();
-    bool _execute();
-    bool _delete();
+    BOOL _execute();
+    BOOL _delete();
     void isCreate();
     cPhs_State _create();
     void _createHeap();

--- a/include/d/actor/d_a_npc_tt.h
+++ b/include/d/actor/d_a_npc_tt.h
@@ -63,9 +63,9 @@ public:
     void wait_action(void*);
     void set_ke_root(int, int, int);
     void ke_execute();
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
     void CreateHeap();
 

--- a/include/d/actor/d_a_npc_uk.h
+++ b/include/d/actor/d_a_npc_uk.h
@@ -80,9 +80,9 @@ public:
     void seek_action(void*);
     void hind_action(void*);
     void visit_action(void*);
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
     void CreateHeap();
 

--- a/include/d/actor/d_a_npc_ym1.h
+++ b/include/d/actor/d_a_npc_ym1.h
@@ -79,9 +79,9 @@ public:
     void demo_action1(void*);
     void demo();
     void shadowDraw();
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
     void bodyCreateHeap();
     void headCreateHeap();

--- a/include/d/actor/d_a_npc_yw1.h
+++ b/include/d/actor/d_a_npc_yw1.h
@@ -74,9 +74,9 @@ public:
     void wait_action2(void*);
     void demo();
     void shadowDraw();
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
     void bodyCreateHeap();
     void headCreateHeap();

--- a/include/d/actor/d_a_npc_zk1.h
+++ b/include/d/actor/d_a_npc_zk1.h
@@ -53,9 +53,9 @@ public:
     void wait_action1(void*);
     void demo();
     void shadowDraw();
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
     void bodyCreateHeap();
     void CreateHeap();

--- a/include/d/actor/d_a_npc_zl1.h
+++ b/include/d/actor/d_a_npc_zl1.h
@@ -140,9 +140,9 @@ public:
     void optn_action1(void*);
     void demo();
     void shadowDraw();
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
     void bodyCreateHeap();
     void itemCreateHeap();

--- a/include/d/actor/d_a_obj_kanoke.h
+++ b/include/d/actor/d_a_obj_kanoke.h
@@ -13,9 +13,9 @@ public:
     cPhs_State _create();
     void createHeap();
     void createInit();
-    bool _delete();
-    bool _draw();
-    bool _execute();
+    BOOL _delete();
+    BOOL _draw();
+    BOOL _execute();
     void executeNormal();
     void executeYureYoko();
     void executeOpenYoko();

--- a/include/d/actor/d_a_tag_ba1.h
+++ b/include/d/actor/d_a_tag_ba1.h
@@ -8,9 +8,9 @@ public:
     void XyCheck_cB(int);
     void XyEvent_cB(int);
     void createInit();
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
 
 public:

--- a/include/d/actor/d_a_tag_kf1.h
+++ b/include/d/actor/d_a_tag_kf1.h
@@ -26,9 +26,9 @@ public:
     void wait01();
     void wait02();
     void wait_action1(void*);
-    bool _draw();
-    bool _execute();
-    bool _delete();
+    BOOL _draw();
+    BOOL _execute();
+    BOOL _delete();
     cPhs_State _create();
 
 public:

--- a/include/d/actor/d_a_tag_kf1.h
+++ b/include/d/actor/d_a_tag_kf1.h
@@ -26,9 +26,9 @@ public:
     void wait01();
     void wait02();
     void wait_action1(void*);
-    BOOL _draw();
-    BOOL _execute();
-    BOOL _delete();
+    bool _draw();
+    bool _execute();
+    bool _delete();
     cPhs_State _create();
 
 public:

--- a/include/d/actor/d_a_tag_photo.h
+++ b/include/d/actor/d_a_tag_photo.h
@@ -12,10 +12,10 @@ public:
     cPhs_State _create();
     void createHeap();
     void createInit();
-    bool _delete();
-    bool _draw();
+    BOOL _delete();
+    BOOL _draw();
     void setMode(unsigned char);
-    bool _execute();
+    BOOL _execute();
     void executeWait();
     void executeTalk();
     void checkOrder();

--- a/src/d/actor/d_a_acorn_leaf.cpp
+++ b/src/d/actor/d_a_acorn_leaf.cpp
@@ -85,8 +85,8 @@ bool daAleaf_c::_draw() {
 }
 
 /* 00000CD4-00000CF4       .text daAleaf_Create__FPv */
-static cPhs_State daAleaf_Create(void*) {
-    /* Nonmatching */
+static cPhs_State daAleaf_Create(void* i_this) {
+    return ((daAleaf_c*)i_this)->_create();
 }
 
 /* 00000CF4-00000D24       .text daAleaf_Delete__FPv */
@@ -95,18 +95,18 @@ static BOOL daAleaf_Delete(void*) {
 }
 
 /* 00000D24-00000D48       .text daAleaf_Draw__FPv */
-static BOOL daAleaf_Draw(void*) {
-    /* Nonmatching */
+static BOOL daAleaf_Draw(void* i_this) {
+    return ((daAleaf_c*)i_this)->_draw();
 }
 
 /* 00000D48-00000D6C       .text daAleaf_Execute__FPv */
-static BOOL daAleaf_Execute(void*) {
-    /* Nonmatching */
+static BOOL daAleaf_Execute(void* i_this) {
+    return ((daAleaf_c*)i_this)->_execute();
 }
 
 /* 00000D6C-00000D74       .text daAleaf_IsDelete__FPv */
 static BOOL daAleaf_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daAleafMethodTable = {

--- a/src/d/actor/d_a_amiprop.cpp
+++ b/src/d/actor/d_a_amiprop.cpp
@@ -85,28 +85,28 @@ bool daAmiProp_c::_draw() {
 }
 
 /* 00000924-00000944       .text daAmiProp_Create__FPv */
-static cPhs_State daAmiProp_Create(void*) {
-    /* Nonmatching */
+static cPhs_State daAmiProp_Create(void* i_this) {
+    return ((daAmiProp_c*)i_this)->_create();
 }
 
 /* 00000944-00000968       .text daAmiProp_Delete__FPv */
-static BOOL daAmiProp_Delete(void*) {
-    /* Nonmatching */
+static BOOL daAmiProp_Delete(void* i_this) {
+    return ((daAmiProp_c*)i_this)->_delete();
 }
 
 /* 00000968-0000098C       .text daAmiProp_Draw__FPv */
-static BOOL daAmiProp_Draw(void*) {
-    /* Nonmatching */
+static BOOL daAmiProp_Draw(void* i_this) {
+    return ((daAmiProp_c*)i_this)->_draw();
 }
 
 /* 0000098C-000009B0       .text daAmiProp_Execute__FPv */
-static BOOL daAmiProp_Execute(void*) {
-    /* Nonmatching */
+static BOOL daAmiProp_Execute(void* i_this) {
+    return ((daAmiProp_c*)i_this)->_execute();
 }
 
 /* 000009B0-000009B8       .text daAmiProp_IsDelete__FPv */
 static BOOL daAmiProp_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daAmiPropMethodTable = {

--- a/src/d/actor/d_a_atdoor.cpp
+++ b/src/d/actor/d_a_atdoor.cpp
@@ -74,7 +74,7 @@ static BOOL daAtdoor_Execute(daAtdoor_c*) {
 
 /* 00000694-0000069C       .text daAtdoor_IsDelete__FP10daAtdoor_c */
 static BOOL daAtdoor_IsDelete(daAtdoor_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 0000069C-0000070C       .text daAtdoor_Delete__FP10daAtdoor_c */
@@ -83,8 +83,8 @@ static BOOL daAtdoor_Delete(daAtdoor_c*) {
 }
 
 /* 0000070C-0000072C       .text daAtdoor_Create__FP10fopAc_ac_c */
-static cPhs_State daAtdoor_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daAtdoor_Create(fopAc_ac_c* i_this) {
+    return ((daAtdoor_c*)i_this)->create();
 }
 
 static actor_method_class l_daAtdoor_Method = {

--- a/src/d/actor/d_a_bb.cpp
+++ b/src/d/actor/d_a_bb.cpp
@@ -151,7 +151,7 @@ static BOOL daBb_Execute(bb_class*) {
 
 /* 00007778-00007780       .text daBb_IsDelete__FP8bb_class */
 static BOOL daBb_IsDelete(bb_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00007780-000077EC       .text daBb_Delete__FP8bb_class */

--- a/src/d/actor/d_a_bdk.cpp
+++ b/src/d/actor/d_a_bdk.cpp
@@ -296,7 +296,7 @@ static BOOL daBdk_Execute(bdk_class*) {
 
 /* 0000BD74-0000BD7C       .text daBdk_IsDelete__FP9bdk_class */
 static BOOL daBdk_IsDelete(bdk_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 0000BD7C-0000BF08       .text daBdk_Delete__FP9bdk_class */

--- a/src/d/actor/d_a_bdkobj.cpp
+++ b/src/d/actor/d_a_bdkobj.cpp
@@ -51,7 +51,7 @@ static BOOL daBdkobj_Execute(bdkobj_class*) {
 
 /* 00002274-0000227C       .text daBdkobj_IsDelete__FP12bdkobj_class */
 static BOOL daBdkobj_IsDelete(bdkobj_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 0000227C-000022E8       .text daBdkobj_Delete__FP12bdkobj_class */

--- a/src/d/actor/d_a_beam.cpp
+++ b/src/d/actor/d_a_beam.cpp
@@ -141,8 +141,8 @@ void daBeam_c::wait_proc() {
 }
 
 /* 00001C84-00001CA4       .text daBeamCreate__FPv */
-static s32 daBeamCreate(void*) {
-    /* Nonmatching */
+static s32 daBeamCreate(void* i_this) {
+    return ((daBeam_c*)i_this)->_create();
 }
 
 /* 00001CA4-00001D34       .text _create__8daBeam_cFv */
@@ -156,8 +156,8 @@ static BOOL daBeamDelete(void*) {
 }
 
 /* 0000298C-000029B0       .text daBeamExecute__FPv */
-static BOOL daBeamExecute(void*) {
-    /* Nonmatching */
+static BOOL daBeamExecute(void* i_this) {
+    return ((daBeam_c*)i_this)->_execute();
 }
 
 /* 000029B0-00002AA0       .text daBeamDraw__FPv */
@@ -167,7 +167,7 @@ static BOOL daBeamDraw(void*) {
 
 /* 00002AA0-00002AA8       .text daBeamIsDelete__FPv */
 static BOOL daBeamIsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daBeamMethodTable = {

--- a/src/d/actor/d_a_bgn.cpp
+++ b/src/d/actor/d_a_bgn.cpp
@@ -253,7 +253,7 @@ static BOOL daBgn_Execute(bgn_class*) {
 
 /* 0000B134-0000B13C       .text daBgn_IsDelete__FP9bgn_class */
 static BOOL daBgn_IsDelete(bgn_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 0000B13C-0000B238       .text daBgn_Delete__FP9bgn_class */

--- a/src/d/actor/d_a_bgn2.cpp
+++ b/src/d/actor/d_a_bgn2.cpp
@@ -30,7 +30,7 @@ void bgn3_s_sub(void*, void*) {
 
 /* 00000354-0000035C       .text daBgn2_Draw__FP10bgn2_class */
 static BOOL daBgn2_Draw(bgn2_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 0000035C-000006EC       .text gr_check__FP10bgn2_classP4cXyz */
@@ -130,7 +130,7 @@ static BOOL daBgn2_Execute(bgn2_class*) {
 
 /* 000037B0-000037B8       .text daBgn2_IsDelete__FP10bgn2_class */
 static BOOL daBgn2_IsDelete(bgn2_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 000037B8-00003828       .text daBgn2_Delete__FP10bgn2_class */

--- a/src/d/actor/d_a_bgn3.cpp
+++ b/src/d/actor/d_a_bgn3.cpp
@@ -130,7 +130,7 @@ static BOOL daBgn3_Execute(bgn3_class*) {
 
 /* 00004358-00004360       .text daBgn3_IsDelete__FP10bgn3_class */
 static BOOL daBgn3_IsDelete(bgn3_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00004360-000043EC       .text daBgn3_Delete__FP10bgn3_class */

--- a/src/d/actor/d_a_bigelf.cpp
+++ b/src/d/actor/d_a_bigelf.cpp
@@ -303,17 +303,17 @@ void daBigelf_c::wait_action(void*) {
 }
 
 /* 00002C8C-00002DB4       .text _draw__10daBigelf_cFv */
-bool daBigelf_c::_draw() {
+BOOL daBigelf_c::_draw() {
     /* Nonmatching */
 }
 
 /* 00002DB4-00002F5C       .text _execute__10daBigelf_cFv */
-bool daBigelf_c::_execute() {
+BOOL daBigelf_c::_execute() {
     /* Nonmatching */
 }
 
 /* 00002F5C-00002FAC       .text _delete__10daBigelf_cFv */
-bool daBigelf_c::_delete() {
+BOOL daBigelf_c::_delete() {
     /* Nonmatching */
 }
 
@@ -333,28 +333,28 @@ void daBigelf_c::CreateHeap() {
 }
 
 /* 00003808-00003828       .text daBigelf_Create__FP10fopAc_ac_c */
-static cPhs_State daBigelf_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daBigelf_Create(fopAc_ac_c* i_this) {
+    return ((daBigelf_c*)i_this)->_create();
 }
 
 /* 00003828-00003848       .text daBigelf_Delete__FP10daBigelf_c */
-static BOOL daBigelf_Delete(daBigelf_c*) {
-    /* Nonmatching */
+static BOOL daBigelf_Delete(daBigelf_c* i_this) {
+    return ((daBigelf_c*)i_this)->_delete();
 }
 
 /* 00003848-00003868       .text daBigelf_Execute__FP10daBigelf_c */
-static BOOL daBigelf_Execute(daBigelf_c*) {
-    /* Nonmatching */
+static BOOL daBigelf_Execute(daBigelf_c* i_this) {
+    return ((daBigelf_c*)i_this)->_execute();
 }
 
 /* 00003868-00003888       .text daBigelf_Draw__FP10daBigelf_c */
-static BOOL daBigelf_Draw(daBigelf_c*) {
-    /* Nonmatching */
+static BOOL daBigelf_Draw(daBigelf_c* i_this) {
+    return ((daBigelf_c*)i_this)->_draw();
 }
 
 /* 00003888-00003890       .text daBigelf_IsDelete__FP10daBigelf_c */
 static BOOL daBigelf_IsDelete(daBigelf_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daBigelf_Method = {

--- a/src/d/actor/d_a_bl.cpp
+++ b/src/d/actor/d_a_bl.cpp
@@ -140,7 +140,7 @@ static BOOL daBL_Execute(bl_class*) {
 
 /* 00005504-0000550C       .text daBL_IsDelete__FP8bl_class */
 static BOOL daBL_IsDelete(bl_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 0000550C-0000558C       .text daBL_Delete__FP8bl_class */

--- a/src/d/actor/d_a_bmd.cpp
+++ b/src/d/actor/d_a_bmd.cpp
@@ -130,7 +130,7 @@ static BOOL daBmd_Execute(bmd_class*) {
 
 /* 00005BF4-00005BFC       .text daBmd_IsDelete__FP9bmd_class */
 static BOOL daBmd_IsDelete(bmd_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00005BFC-00005CF4       .text daBmd_Delete__FP9bmd_class */

--- a/src/d/actor/d_a_bmdfoot.cpp
+++ b/src/d/actor/d_a_bmdfoot.cpp
@@ -86,7 +86,7 @@ static BOOL daBmdfoot_Execute(bmdfoot_class*) {
 
 /* 00002594-0000259C       .text daBmdfoot_IsDelete__FP13bmdfoot_class */
 static BOOL daBmdfoot_IsDelete(bmdfoot_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 0000259C-000026B0       .text daBmdfoot_Delete__FP13bmdfoot_class */

--- a/src/d/actor/d_a_bmdhand.cpp
+++ b/src/d/actor/d_a_bmdhand.cpp
@@ -100,7 +100,7 @@ static BOOL daBmdhand_Execute(bmdhand_class*) {
 
 /* 00003028-00003030       .text daBmdhand_IsDelete__FP13bmdhand_class */
 static BOOL daBmdhand_IsDelete(bmdhand_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00003030-000030C4       .text daBmdhand_Delete__FP13bmdhand_class */

--- a/src/d/actor/d_a_bo.cpp
+++ b/src/d/actor/d_a_bo.cpp
@@ -120,7 +120,7 @@ static BOOL daBO_Execute(bo_class*) {
 
 /* 000048B0-000048B8       .text daBO_IsDelete__FP8bo_class */
 static BOOL daBO_IsDelete(bo_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 000048B8-00004998       .text daBO_Delete__FP8bo_class */

--- a/src/d/actor/d_a_boomerang.cpp
+++ b/src/d/actor/d_a_boomerang.cpp
@@ -78,8 +78,8 @@ BOOL daBoomerang_c::draw() {
 }
 
 /* 800E1998-800E19B8       .text daBoomerang_Draw__FP13daBoomerang_c */
-static BOOL daBoomerang_Draw(daBoomerang_c*) {
-    /* Nonmatching */
+static BOOL daBoomerang_Draw(daBoomerang_c* i_this) {
+    return ((daBoomerang_c*)i_this)->draw();
 }
 
 /* 800E19B8-800E1A14       .text getFlyMax__13daBoomerang_cFv */
@@ -148,18 +148,18 @@ BOOL daBoomerang_c::execute() {
 }
 
 /* 800E2BD0-800E2BF0       .text daBoomerang_Execute__FP13daBoomerang_c */
-static BOOL daBoomerang_Execute(daBoomerang_c*) {
-    /* Nonmatching */
+static BOOL daBoomerang_Execute(daBoomerang_c* i_this) {
+    return ((daBoomerang_c*)i_this)->execute();
 }
 
 /* 800E2BF0-800E2BF8       .text daBoomerang_IsDelete__FP13daBoomerang_c */
 static BOOL daBoomerang_IsDelete(daBoomerang_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 800E2BF8-800E2C00       .text daBoomerang_Delete__FP13daBoomerang_c */
 static BOOL daBoomerang_Delete(daBoomerang_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 800E2C00-800E2CC8       .text createHeap__13daBoomerang_cFv */
@@ -178,8 +178,8 @@ cPhs_State daBoomerang_c::create() {
 }
 
 /* 800E33F0-800E3410       .text daBoomerang_Create__FP10fopAc_ac_c */
-static cPhs_State daBoomerang_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daBoomerang_Create(fopAc_ac_c* i_this) {
+    return ((daBoomerang_c*)i_this)->create();
 }
 
 static actor_method_class l_daBoomerang_Method = {

--- a/src/d/actor/d_a_bpw.cpp
+++ b/src/d/actor/d_a_bpw.cpp
@@ -235,7 +235,7 @@ static BOOL daBPW_Execute(bpw_class*) {
 
 /* 0000C5C0-0000C5C8       .text daBPW_IsDelete__FP9bpw_class */
 static BOOL daBPW_IsDelete(bpw_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 0000C5C8-0000C770       .text daBPW_Delete__FP9bpw_class */

--- a/src/d/actor/d_a_btd.cpp
+++ b/src/d/actor/d_a_btd.cpp
@@ -206,7 +206,7 @@ static BOOL daBtd_Execute(btd_class*) {
 
 /* 000081B8-000081C0       .text daBtd_IsDelete__FP9btd_class */
 static BOOL daBtd_IsDelete(btd_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 000081C0-00008304       .text daBtd_Delete__FP9btd_class */

--- a/src/d/actor/d_a_bwd.cpp
+++ b/src/d/actor/d_a_bwd.cpp
@@ -140,7 +140,7 @@ static BOOL daBwd_Execute(bwd_class*) {
 
 /* 00008C24-00008C2C       .text daBwd_IsDelete__FP9bwd_class */
 static BOOL daBwd_IsDelete(bwd_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00008C2C-00008E0C       .text daBwd_Delete__FP9bwd_class */

--- a/src/d/actor/d_a_bwds.cpp
+++ b/src/d/actor/d_a_bwds.cpp
@@ -80,7 +80,7 @@ static BOOL daBwds_Execute(bwds_class*) {
 
 /* 000031B4-000031BC       .text daBwds_IsDelete__FP10bwds_class */
 static BOOL daBwds_IsDelete(bwds_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 000031BC-00003278       .text daBwds_Delete__FP10bwds_class */

--- a/src/d/actor/d_a_canon.cpp
+++ b/src/d/actor/d_a_canon.cpp
@@ -207,8 +207,8 @@ void daCanon_c::GameInfo2DDraw() {
 }
 
 /* 00002074-00002094       .text daCanonCreate__FPv */
-static s32 daCanonCreate(void*) {
-    /* Nonmatching */
+static s32 daCanonCreate(void* i_this) {
+    return ((daCanon_c*)i_this)->_create();
 }
 
 /* 00002094-000023C0       .text _create__9daCanon_cFv */
@@ -233,7 +233,7 @@ static BOOL daCanonDraw(void*) {
 
 /* 0000283C-00002844       .text daCanonIsDelete__FPv */
 static BOOL daCanonIsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daCanonMethodTable = {

--- a/src/d/actor/d_a_cc.cpp
+++ b/src/d/actor/d_a_cc.cpp
@@ -150,7 +150,7 @@ static BOOL daCC_Execute(cc_class*) {
 
 /* 00006214-0000621C       .text daCC_IsDelete__FP8cc_class */
 static BOOL daCC_IsDelete(cc_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 0000621C-00006290       .text daCC_Delete__FP8cc_class */

--- a/src/d/actor/d_a_coming2.cpp
+++ b/src/d/actor/d_a_coming2.cpp
@@ -185,28 +185,28 @@ bool daComing2::Act_c::_draw() {
 namespace daComing2 {
 namespace {
 /* 000023B8-000023D8       .text Mthd_Create__Q29daComing225@unnamed@d_a_coming2_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daComing2::Act_c*)i_this)->_create();
 }
 
 /* 000023D8-000023FC       .text Mthd_Delete__Q29daComing225@unnamed@d_a_coming2_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daComing2::Act_c*)i_this)->_delete();
 }
 
 /* 000023FC-00002420       .text Mthd_Execute__Q29daComing225@unnamed@d_a_coming2_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daComing2::Act_c*)i_this)->_execute();
 }
 
 /* 00002420-00002444       .text Mthd_Draw__Q29daComing225@unnamed@d_a_coming2_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daComing2::Act_c*)i_this)->_draw();
 }
 
 /* 00002444-0000244C       .text Mthd_IsDelete__Q29daComing225@unnamed@d_a_coming2_cpp@FPv */
 BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class Mthd_Table = {

--- a/src/d/actor/d_a_coming3.cpp
+++ b/src/d/actor/d_a_coming3.cpp
@@ -125,28 +125,28 @@ bool daComing3::Act_c::_draw() {
 namespace daComing3 {
 namespace {
 /* 00001D14-00001D34       .text Mthd_Create__Q29daComing325@unnamed@d_a_coming3_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daComing3::Act_c*)i_this)->_create();
 }
 
 /* 00001D34-00001D58       .text Mthd_Delete__Q29daComing325@unnamed@d_a_coming3_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daComing3::Act_c*)i_this)->_delete();
 }
 
 /* 00001D58-00001D7C       .text Mthd_Execute__Q29daComing325@unnamed@d_a_coming3_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daComing3::Act_c*)i_this)->_execute();
 }
 
 /* 00001D7C-00001DA0       .text Mthd_Draw__Q29daComing325@unnamed@d_a_coming3_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daComing3::Act_c*)i_this)->_draw();
 }
 
 /* 00001DA0-00001DA8       .text Mthd_IsDelete__Q29daComing325@unnamed@d_a_coming3_cpp@FPv */
 BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class Mthd_Table = {

--- a/src/d/actor/d_a_dai.cpp
+++ b/src/d/actor/d_a_dai.cpp
@@ -125,28 +125,28 @@ void daDai_c::next_msgStatus(unsigned long*) {
 }
 
 /* 0000109C-000010BC       .text daDai_Create__FPv */
-static cPhs_State daDai_Create(void*) {
-    /* Nonmatching */
+static cPhs_State daDai_Create(void* i_this) {
+    return ((daDai_c*)i_this)->_create();
 }
 
 /* 000010BC-000010E0       .text daDai_Delete__FPv */
-static BOOL daDai_Delete(void*) {
-    /* Nonmatching */
+static BOOL daDai_Delete(void* i_this) {
+    return ((daDai_c*)i_this)->_delete();
 }
 
 /* 000010E0-00001104       .text daDai_Draw__FPv */
-static BOOL daDai_Draw(void*) {
-    /* Nonmatching */
+static BOOL daDai_Draw(void* i_this) {
+    return ((daDai_c*)i_this)->_draw();
 }
 
 /* 00001104-00001128       .text daDai_Execute__FPv */
-static BOOL daDai_Execute(void*) {
-    /* Nonmatching */
+static BOOL daDai_Execute(void* i_this) {
+    return ((daDai_c*)i_this)->_execute();
 }
 
 /* 00001128-00001130       .text daDai_IsDelete__FPv */
 static BOOL daDai_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daDaiMethodTable = {

--- a/src/d/actor/d_a_daiocta.cpp
+++ b/src/d/actor/d_a_daiocta.cpp
@@ -325,28 +325,28 @@ bool daDaiocta_c::_delete() {
 }
 
 /* 0000513C-0000515C       .text daDaioctaCreate__FPv */
-static s32 daDaioctaCreate(void*) {
-    /* Nonmatching */
+static s32 daDaioctaCreate(void* i_this) {
+    return ((daDaiocta_c*)i_this)->_create();
 }
 
 /* 0000515C-00005180       .text daDaioctaDelete__FPv */
-static BOOL daDaioctaDelete(void*) {
-    /* Nonmatching */
+static BOOL daDaioctaDelete(void* i_this) {
+    return ((daDaiocta_c*)i_this)->_delete();
 }
 
 /* 00005180-000051A4       .text daDaioctaExecute__FPv */
-static BOOL daDaioctaExecute(void*) {
-    /* Nonmatching */
+static BOOL daDaioctaExecute(void* i_this) {
+    return ((daDaiocta_c*)i_this)->_execute();
 }
 
 /* 000051A4-000051C8       .text daDaioctaDraw__FPv */
-static BOOL daDaioctaDraw(void*) {
-    /* Nonmatching */
+static BOOL daDaioctaDraw(void* i_this) {
+    return ((daDaiocta_c*)i_this)->_draw();
 }
 
 /* 000051C8-000051D0       .text daDaioctaIsDelete__FPv */
 static BOOL daDaioctaIsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daDaioctaMethodTable = {

--- a/src/d/actor/d_a_daiocta_eye.cpp
+++ b/src/d/actor/d_a_daiocta_eye.cpp
@@ -144,28 +144,28 @@ bool daDaiocta_Eye_c::_delete() {
 }
 
 /* 000017B4-000017D4       .text daDaiocta_EyeCreate__FPv */
-static s32 daDaiocta_EyeCreate(void*) {
-    /* Nonmatching */
+static s32 daDaiocta_EyeCreate(void* i_this) {
+    return ((daDaiocta_Eye_c*)i_this)->_create();
 }
 
 /* 000017D4-000017F8       .text daDaiocta_EyeDelete__FPv */
-static BOOL daDaiocta_EyeDelete(void*) {
-    /* Nonmatching */
+static BOOL daDaiocta_EyeDelete(void* i_this) {
+    return ((daDaiocta_Eye_c*)i_this)->_delete();
 }
 
 /* 000017F8-0000181C       .text daDaiocta_EyeExecute__FPv */
-static BOOL daDaiocta_EyeExecute(void*) {
-    /* Nonmatching */
+static BOOL daDaiocta_EyeExecute(void* i_this) {
+    return ((daDaiocta_Eye_c*)i_this)->_execute();
 }
 
 /* 0000181C-00001840       .text daDaiocta_EyeDraw__FPv */
-static BOOL daDaiocta_EyeDraw(void*) {
-    /* Nonmatching */
+static BOOL daDaiocta_EyeDraw(void* i_this) {
+    return ((daDaiocta_Eye_c*)i_this)->_draw();
 }
 
 /* 00001840-00001848       .text daDaiocta_EyeIsDelete__FPv */
 static BOOL daDaiocta_EyeIsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daDaiocta_EyeMethodTable = {

--- a/src/d/actor/d_a_demo_dk.cpp
+++ b/src/d/actor/d_a_demo_dk.cpp
@@ -34,7 +34,7 @@ static BOOL daDEMO_DK_Execute(demo_dk_class*) {
 
 /* 000004C0-000004C8       .text daDEMO_DK_IsDelete__FP13demo_dk_class */
 static BOOL daDEMO_DK_IsDelete(demo_dk_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 000004C8-000004F8       .text daDEMO_DK_Delete__FP13demo_dk_class */

--- a/src/d/actor/d_a_demo_kmm.cpp
+++ b/src/d/actor/d_a_demo_kmm.cpp
@@ -54,7 +54,7 @@ static BOOL daDemo_Kmm_Execute(daDemo_Kmm_c*) {
 
 /* 000004A8-000004B0       .text daDemo_Kmm_IsDelete__FP12daDemo_Kmm_c */
 static BOOL daDemo_Kmm_IsDelete(daDemo_Kmm_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 000004B0-00000500       .text daDemo_Kmm_Delete__FP12daDemo_Kmm_c */
@@ -63,8 +63,8 @@ static BOOL daDemo_Kmm_Delete(daDemo_Kmm_c*) {
 }
 
 /* 00000500-00000520       .text daDemo_Kmm_Create__FP10fopAc_ac_c */
-static cPhs_State daDemo_Kmm_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daDemo_Kmm_Create(fopAc_ac_c* i_this) {
+    return ((daDemo_Kmm_c*)i_this)->create();
 }
 
 static actor_method_class l_daDemo_Kmm_Method = {

--- a/src/d/actor/d_a_dk.cpp
+++ b/src/d/actor/d_a_dk.cpp
@@ -60,7 +60,7 @@ static BOOL daDk_Execute(dk_class*) {
 
 /* 00000D08-00000D10       .text daDk_IsDelete__FP8dk_class */
 static BOOL daDk_IsDelete(dk_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00000D10-00000D7C       .text daDk_Delete__FP8dk_class */

--- a/src/d/actor/d_a_door10.cpp
+++ b/src/d/actor/d_a_door10.cpp
@@ -163,8 +163,8 @@ BOOL daDoor10_c::draw() {
 }
 
 /* 00001BAC-00001BCC       .text daDoor10_Draw__FP10daDoor10_c */
-static BOOL daDoor10_Draw(daDoor10_c*) {
-    /* Nonmatching */
+static BOOL daDoor10_Draw(daDoor10_c* i_this) {
+    return ((daDoor10_c*)i_this)->draw();
 }
 
 /* 00001BCC-00001CCC       .text daDoor10_Execute__FP10daDoor10_c */
@@ -174,7 +174,7 @@ static BOOL daDoor10_Execute(daDoor10_c*) {
 
 /* 00001CCC-00001CD4       .text daDoor10_IsDelete__FP10daDoor10_c */
 static BOOL daDoor10_IsDelete(daDoor10_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00001CD4-00001E18       .text daDoor10_Delete__FP10daDoor10_c */

--- a/src/d/actor/d_a_door12.cpp
+++ b/src/d/actor/d_a_door12.cpp
@@ -173,8 +173,8 @@ BOOL daDoor12_c::draw() {
 }
 
 /* 00001AD0-00001AF0       .text daDoor12_Draw__FP10daDoor12_c */
-static BOOL daDoor12_Draw(daDoor12_c*) {
-    /* Nonmatching */
+static BOOL daDoor12_Draw(daDoor12_c* i_this) {
+    return ((daDoor12_c*)i_this)->draw();
 }
 
 /* 00001AF0-00001BC8       .text daDoor12_Execute__FP10daDoor12_c */
@@ -184,7 +184,7 @@ static BOOL daDoor12_Execute(daDoor12_c*) {
 
 /* 00001BC8-00001BD0       .text daDoor12_IsDelete__FP10daDoor12_c */
 static BOOL daDoor12_IsDelete(daDoor12_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00001BD0-00001CC4       .text daDoor12_Delete__FP10daDoor12_c */

--- a/src/d/actor/d_a_dr2.cpp
+++ b/src/d/actor/d_a_dr2.cpp
@@ -80,7 +80,7 @@ static BOOL daDr2_Execute(dr2_class*) {
 
 /* 00001B90-00001B98       .text daDr2_IsDelete__FP9dr2_class */
 static BOOL daDr2_IsDelete(dr2_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00001B98-00001C58       .text daDr2_Delete__FP9dr2_class */

--- a/src/d/actor/d_a_ep.cpp
+++ b/src/d/actor/d_a_ep.cpp
@@ -60,7 +60,7 @@ static BOOL daEp_Execute(ep_class*) {
 
 /* 00002270-00002278       .text daEp_IsDelete__FP8ep_class */
 static BOOL daEp_IsDelete(ep_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00002278-000022D4       .text daEp_Delete__FP8ep_class */

--- a/src/d/actor/d_a_fallrock.cpp
+++ b/src/d/actor/d_a_fallrock.cpp
@@ -60,8 +60,8 @@ static BOOL daFallRock_Draw(daFallRock_c*) {
 }
 
 /* 000002B0-000002D0       .text daFallRock_Execute__FP12daFallRock_c */
-static BOOL daFallRock_Execute(daFallRock_c*) {
-    /* Nonmatching */
+static BOOL daFallRock_Execute(daFallRock_c* i_this) {
+    return ((daFallRock_c*)i_this)->execute();
 }
 
 /* 000002D0-00000810       .text execute__12daFallRock_cFv */
@@ -71,7 +71,7 @@ BOOL daFallRock_c::execute() {
 
 /* 00000E38-00000E40       .text daFallRock_IsDelete__FP12daFallRock_c */
 static BOOL daFallRock_IsDelete(daFallRock_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00000E40-00000E68       .text daFallRock_Delete__FP12daFallRock_c */
@@ -80,8 +80,8 @@ static BOOL daFallRock_Delete(daFallRock_c*) {
 }
 
 /* 00001030-00001050       .text daFallRock_Create__FP10fopAc_ac_c */
-static cPhs_State daFallRock_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daFallRock_Create(fopAc_ac_c* i_this) {
+    return ((daFallRock_c*)i_this)->create();
 }
 
 /* 00001050-0000127C       .text create__12daFallRock_cFv */

--- a/src/d/actor/d_a_fallrock_tag.cpp
+++ b/src/d/actor/d_a_fallrock_tag.cpp
@@ -9,7 +9,7 @@
 
 /* 00000078-00000080       .text daFallRockTag_Draw__FP15daFallRockTag_c */
 static BOOL daFallRockTag_Draw(daFallRockTag_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00000080-000002A0       .text daFallRockTag_Execute__FP15daFallRockTag_c */
@@ -19,7 +19,7 @@ static BOOL daFallRockTag_Execute(daFallRockTag_c*) {
 
 /* 000002A0-000002A8       .text daFallRockTag_IsDelete__FP15daFallRockTag_c */
 static BOOL daFallRockTag_IsDelete(daFallRockTag_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 000002A8-000002EC       .text daFallRockTag_Delete__FP15daFallRockTag_c */

--- a/src/d/actor/d_a_fgmahou.cpp
+++ b/src/d/actor/d_a_fgmahou.cpp
@@ -30,7 +30,7 @@ static BOOL daFgmahou_Execute(fgmahou_class*) {
 
 /* 00000DD8-00000DE0       .text daFgmahou_IsDelete__FP13fgmahou_class */
 static BOOL daFgmahou_IsDelete(fgmahou_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00000DE0-00000E3C       .text daFgmahou_Delete__FP13fgmahou_class */

--- a/src/d/actor/d_a_fm.cpp
+++ b/src/d/actor/d_a_fm.cpp
@@ -605,28 +605,28 @@ bool daFm_c::_delete() {
 }
 
 /* 0000A0FC-0000A11C       .text daFmCreate__FPv */
-static s32 daFmCreate(void*) {
-    /* Nonmatching */
+static s32 daFmCreate(void* i_this) {
+    return ((daFm_c*)i_this)->_create();
 }
 
 /* 0000A11C-0000A140       .text daFmDelete__FPv */
-static BOOL daFmDelete(void*) {
-    /* Nonmatching */
+static BOOL daFmDelete(void* i_this) {
+    return ((daFm_c*)i_this)->_delete();
 }
 
 /* 0000A140-0000A164       .text daFmExecute__FPv */
-static BOOL daFmExecute(void*) {
-    /* Nonmatching */
+static BOOL daFmExecute(void* i_this) {
+    return ((daFm_c*)i_this)->_execute();
 }
 
 /* 0000A164-0000A188       .text daFmDraw__FPv */
-static BOOL daFmDraw(void*) {
-    /* Nonmatching */
+static BOOL daFmDraw(void* i_this) {
+    return ((daFm_c*)i_this)->_draw();
 }
 
 /* 0000A188-0000A190       .text daFmIsDelete__FPv */
 static BOOL daFmIsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daFmMethodTable = {

--- a/src/d/actor/d_a_gm.cpp
+++ b/src/d/actor/d_a_gm.cpp
@@ -116,7 +116,7 @@ static BOOL daGM_Execute(gm_class*) {
 
 /* 00007770-00007778       .text daGM_IsDelete__FP8gm_class */
 static BOOL daGM_IsDelete(gm_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00007778-000078C4       .text daGM_Delete__FP8gm_class */

--- a/src/d/actor/d_a_gnd.cpp
+++ b/src/d/actor/d_a_gnd.cpp
@@ -180,7 +180,7 @@ static BOOL daGnd_Execute(gnd_class*) {
 
 /* 000076B8-000076C0       .text daGnd_IsDelete__FP9gnd_class */
 static BOOL daGnd_IsDelete(gnd_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 000076C0-00007738       .text daGnd_Delete__FP9gnd_class */

--- a/src/d/actor/d_a_goal_flag.cpp
+++ b/src/d/actor/d_a_goal_flag.cpp
@@ -98,8 +98,8 @@ void daGoal_Flag_c::RaceEnd() {
 }
 
 /* 000023E0-00002400       .text daGoal_FlagCreate__FPv */
-static s32 daGoal_FlagCreate(void*) {
-    /* Nonmatching */
+static s32 daGoal_FlagCreate(void* i_this) {
+    return ((daGoal_Flag_c*)i_this)->_create();
 }
 
 /* 00002400-00002968       .text _create__13daGoal_Flag_cFv */
@@ -124,7 +124,7 @@ static BOOL daGoal_FlagDraw(void*) {
 
 /* 00002CA4-00002CAC       .text daGoal_FlagIsDelete__FPv */
 static BOOL daGoal_FlagIsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daGoal_FlagMethodTable = {

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -36,8 +36,8 @@ void daHo_packet_c::draw() {
 }
 
 /* 800E9BE8-800E9C0C       .text daGrid_Draw__FP8daGrid_c */
-static BOOL daGrid_Draw(daGrid_c*) {
-    /* Nonmatching */
+static BOOL daGrid_Draw(daGrid_c* i_this) {
+    return ((daGrid_c*)i_this)->_draw();
 }
 
 /* 800E9C0C-800EA928       .text ho_move__FP8daGrid_c */
@@ -46,23 +46,23 @@ void ho_move(daGrid_c*) {
 }
 
 /* 800EA928-800EA94C       .text daGrid_Execute__FP8daGrid_c */
-static BOOL daGrid_Execute(daGrid_c*) {
-    /* Nonmatching */
+static BOOL daGrid_Execute(daGrid_c* i_this) {
+    return ((daGrid_c*)i_this)->_execute();
 }
 
 /* 800EA94C-800EA954       .text daGrid_IsDelete__FP8daGrid_c */
 static BOOL daGrid_IsDelete(daGrid_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 800EA954-800EA978       .text daGrid_Delete__FP8daGrid_c */
-static BOOL daGrid_Delete(daGrid_c*) {
-    /* Nonmatching */
+static BOOL daGrid_Delete(daGrid_c* i_this) {
+    return ((daGrid_c*)i_this)->_delete();
 }
 
 /* 800EA978-800EA998       .text daGrid_Create__FP10fopAc_ac_c */
-static cPhs_State daGrid_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daGrid_Create(fopAc_ac_c* i_this) {
+    return ((daGrid_c*)i_this)->_create();
 }
 
 /* 800EA998-800EAEAC       .text _create__8daGrid_cFv */

--- a/src/d/actor/d_a_gy.cpp
+++ b/src/d/actor/d_a_gy.cpp
@@ -310,28 +310,28 @@ bool daGy_c::_delete() {
 }
 
 /* 00005AD4-00005AF4       .text daGyCreate__FPv */
-static s32 daGyCreate(void*) {
-    /* Nonmatching */
+static s32 daGyCreate(void* i_this) {
+    return ((daGy_c*)i_this)->_create();
 }
 
 /* 00005AF4-00005B18       .text daGyDelete__FPv */
-static BOOL daGyDelete(void*) {
-    /* Nonmatching */
+static BOOL daGyDelete(void* i_this) {
+    return ((daGy_c*)i_this)->_delete();
 }
 
 /* 00005B18-00005B3C       .text daGyExecute__FPv */
-static BOOL daGyExecute(void*) {
-    /* Nonmatching */
+static BOOL daGyExecute(void* i_this) {
+    return ((daGy_c*)i_this)->_execute();
 }
 
 /* 00005B3C-00005B60       .text daGyDraw__FPv */
-static BOOL daGyDraw(void*) {
-    /* Nonmatching */
+static BOOL daGyDraw(void* i_this) {
+    return ((daGy_c*)i_this)->_draw();
 }
 
 /* 00005B60-00005B68       .text daGyIsDelete__FPv */
 static BOOL daGyIsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daGyMethodTable = {

--- a/src/d/actor/d_a_gy_ctrl.cpp
+++ b/src/d/actor/d_a_gy_ctrl.cpp
@@ -148,28 +148,28 @@ bool daGy_Ctrl_c::_delete() {
 }
 
 /* 00001C44-00001C64       .text daGy_CtrlCreate__FPv */
-static s32 daGy_CtrlCreate(void*) {
-    /* Nonmatching */
+static s32 daGy_CtrlCreate(void* i_this) {
+    return ((daGy_Ctrl_c*)i_this)->_create();
 }
 
 /* 00001C64-00001C88       .text daGy_CtrlDelete__FPv */
-static BOOL daGy_CtrlDelete(void*) {
-    /* Nonmatching */
+static BOOL daGy_CtrlDelete(void* i_this) {
+    return ((daGy_Ctrl_c*)i_this)->_delete();
 }
 
 /* 00001C88-00001CAC       .text daGy_CtrlExecute__FPv */
-static BOOL daGy_CtrlExecute(void*) {
-    /* Nonmatching */
+static BOOL daGy_CtrlExecute(void* i_this) {
+    return ((daGy_Ctrl_c*)i_this)->_execute();
 }
 
 /* 00001CAC-00001CD0       .text daGy_CtrlDraw__FPv */
-static BOOL daGy_CtrlDraw(void*) {
-    /* Nonmatching */
+static BOOL daGy_CtrlDraw(void* i_this) {
+    return ((daGy_Ctrl_c*)i_this)->_draw();
 }
 
 /* 00001CD0-00001CD8       .text daGy_CtrlIsDelete__FPv */
 static BOOL daGy_CtrlIsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daGy_CtrlMethodTable = {

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -90,7 +90,7 @@ static BOOL daHimo2_Execute(himo2_class*) {
 
 /* 800F062C-800F0634       .text daHimo2_IsDelete__FP11himo2_class */
 static BOOL daHimo2_IsDelete(himo2_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 800F0634-800F0670       .text daHimo2_Delete__FP11himo2_class */

--- a/src/d/actor/d_a_himo3.cpp
+++ b/src/d/actor/d_a_himo3.cpp
@@ -45,7 +45,7 @@ static BOOL daHimo3_Execute(himo3_class*) {
 
 /* 00001A3C-00001A44       .text daHimo3_IsDelete__FP11himo3_class */
 static BOOL daHimo3_IsDelete(himo3_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00001A44-00001AE0       .text daHimo3_Delete__FP11himo3_class */

--- a/src/d/actor/d_a_hmlif.cpp
+++ b/src/d/actor/d_a_hmlif.cpp
@@ -44,7 +44,7 @@ BOOL daHmlif_c::Delete() {
 }
 
 /* 00000080-000000D8       .text daHmlifDelete__9daHmlif_cFv */
-void daHmlif_c::daHmlifDelete() {
+BOOL daHmlif_c::daHmlifDelete() {
     /* Nonmatching */
 }
 
@@ -124,13 +124,13 @@ BOOL daHmlif_c::Draw() {
 }
 
 /* 00001610-00001630       .text daHmlif_Create__FPv */
-static cPhs_State daHmlif_Create(void*) {
-    /* Nonmatching */
+static cPhs_State daHmlif_Create(void* i_this) {
+    return ((daHmlif_c*)i_this)->daHmlifCreate();
 }
 
 /* 00001630-00001650       .text daHmlif_Delete__FPv */
-static BOOL daHmlif_Delete(void*) {
-    /* Nonmatching */
+static BOOL daHmlif_Delete(void* i_this) {
+    return ((daHmlif_c*)i_this)->daHmlifDelete();
 }
 
 /* 00001650-0000167C       .text daHmlif_Draw__FPv */
@@ -145,7 +145,7 @@ static BOOL daHmlif_Execute(void*) {
 
 /* 0000169C-000016A4       .text daHmlif_IsDelete__FPv */
 static BOOL daHmlif_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daHmlifMethodTable = {

--- a/src/d/actor/d_a_icelift.cpp
+++ b/src/d/actor/d_a_icelift.cpp
@@ -74,28 +74,28 @@ bool daIlift_c::_draw() {
 }
 
 /* 00000FF8-00001018       .text daIlift_Create__FPv */
-static cPhs_State daIlift_Create(void*) {
-    /* Nonmatching */
+static cPhs_State daIlift_Create(void* i_this) {
+    return ((daIlift_c*)i_this)->_create();
 }
 
 /* 00001018-0000103C       .text daIlift_Delete__FPv */
-static BOOL daIlift_Delete(void*) {
-    /* Nonmatching */
+static BOOL daIlift_Delete(void* i_this) {
+    return ((daIlift_c*)i_this)->_delete();
 }
 
 /* 0000103C-00001060       .text daIlift_Draw__FPv */
-static BOOL daIlift_Draw(void*) {
-    /* Nonmatching */
+static BOOL daIlift_Draw(void* i_this) {
+    return ((daIlift_c*)i_this)->_draw();
 }
 
 /* 00001060-00001084       .text daIlift_Execute__FPv */
-static BOOL daIlift_Execute(void*) {
-    /* Nonmatching */
+static BOOL daIlift_Execute(void* i_this) {
+    return ((daIlift_c*)i_this)->_execute();
 }
 
 /* 00001084-0000108C       .text daIlift_IsDelete__FPv */
 static BOOL daIlift_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daIliftMethodTable = {

--- a/src/d/actor/d_a_kamome.cpp
+++ b/src/d/actor/d_a_kamome.cpp
@@ -121,7 +121,7 @@ static BOOL daKamome_Execute(kamome_class*) {
 
 /* 000049F8-00004A00       .text daKamome_IsDelete__FP12kamome_class */
 static BOOL daKamome_IsDelete(kamome_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00004A00-00004A70       .text daKamome_Delete__FP12kamome_class */

--- a/src/d/actor/d_a_kanban.cpp
+++ b/src/d/actor/d_a_kanban.cpp
@@ -86,7 +86,7 @@ static BOOL daKanban_Execute(kanban_class*) {
 
 /* 000022A8-000022B0       .text daKanban_IsDelete__FP12kanban_class */
 static BOOL daKanban_IsDelete(kanban_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 000022B0-00002300       .text daKanban_Delete__FP12kanban_class */

--- a/src/d/actor/d_a_kantera.cpp
+++ b/src/d/actor/d_a_kantera.cpp
@@ -45,7 +45,7 @@ static BOOL daKantera_Execute(kantera_class*) {
 
 /* 00001ABC-00001AC4       .text daKantera_IsDelete__FP13kantera_class */
 static BOOL daKantera_IsDelete(kantera_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00001AC4-00001B30       .text daKantera_Delete__FP13kantera_class */

--- a/src/d/actor/d_a_kb.cpp
+++ b/src/d/actor/d_a_kb.cpp
@@ -166,7 +166,7 @@ static BOOL daKb_Execute(kb_class*) {
 
 /* 00006E38-00006E40       .text daKb_IsDelete__FP8kb_class */
 static BOOL daKb_IsDelete(kb_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00006E40-00006F28       .text daKb_Delete__FP8kb_class */

--- a/src/d/actor/d_a_kddoor.cpp
+++ b/src/d/actor/d_a_kddoor.cpp
@@ -293,8 +293,8 @@ BOOL daKddoor_c::draw() {
 }
 
 /* 000029E0-00002A00       .text daKddoor_Draw__FP10daKddoor_c */
-static BOOL daKddoor_Draw(daKddoor_c*) {
-    /* Nonmatching */
+static BOOL daKddoor_Draw(daKddoor_c* i_this) {
+    return ((daKddoor_c*)i_this)->draw();
 }
 
 /* 00002A00-00002AF4       .text daKddoor_Execute__FP10daKddoor_c */
@@ -304,7 +304,7 @@ static BOOL daKddoor_Execute(daKddoor_c*) {
 
 /* 00002AF4-00002AFC       .text daKddoor_IsDelete__FP10daKddoor_c */
 static BOOL daKddoor_IsDelete(daKddoor_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00002AFC-00002C44       .text daKddoor_Delete__FP10daKddoor_c */
@@ -313,8 +313,8 @@ static BOOL daKddoor_Delete(daKddoor_c*) {
 }
 
 /* 00002C44-00002C64       .text daKddoor_Create__FP10fopAc_ac_c */
-static cPhs_State daKddoor_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daKddoor_Create(fopAc_ac_c* i_this) {
+    return ((daKddoor_c*)i_this)->create();
 }
 
 static actor_method_class l_daKddoor_Method = {

--- a/src/d/actor/d_a_ki.cpp
+++ b/src/d/actor/d_a_ki.cpp
@@ -101,7 +101,7 @@ static BOOL daKi_Execute(ki_class*) {
 
 /* 00003E04-00003E0C       .text daKi_IsDelete__FP8ki_class */
 static BOOL daKi_IsDelete(ki_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00003E0C-00003EB8       .text daKi_Delete__FP8ki_class */

--- a/src/d/actor/d_a_klft.cpp
+++ b/src/d/actor/d_a_klft.cpp
@@ -51,7 +51,7 @@ static BOOL daKlft_Execute(klft_class*) {
 
 /* 00001444-0000144C       .text daKlft_IsDelete__FP10klft_class */
 static BOOL daKlft_IsDelete(klft_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 0000144C-00001520       .text daKlft_Delete__FP10klft_class */

--- a/src/d/actor/d_a_kmon.cpp
+++ b/src/d/actor/d_a_kmon.cpp
@@ -54,7 +54,7 @@ static BOOL daKmonDraw(void*) {
 
 /* 00000A9C-00000AA4       .text daKmonIsDelete__FPv */
 static BOOL daKmonIsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daKmonMethodTable = {

--- a/src/d/actor/d_a_kn.cpp
+++ b/src/d/actor/d_a_kn.cpp
@@ -44,7 +44,7 @@ static BOOL daKN_Execute(kn_class*) {
 
 /* 00000F80-00000F88       .text daKN_IsDelete__FP8kn_class */
 static BOOL daKN_IsDelete(kn_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00000F88-00000FD8       .text daKN_Delete__FP8kn_class */

--- a/src/d/actor/d_a_knob00.cpp
+++ b/src/d/actor/d_a_knob00.cpp
@@ -163,8 +163,8 @@ BOOL daKnob00_c::draw() {
 }
 
 /* 00001CA0-00001CC0       .text daKnob00_Draw__FP10daKnob00_c */
-static BOOL daKnob00_Draw(daKnob00_c*) {
-    /* Nonmatching */
+static BOOL daKnob00_Draw(daKnob00_c* i_this) {
+    return ((daKnob00_c*)i_this)->draw();
 }
 
 /* 00001CC0-00001E78       .text daKnob00_Execute__FP10daKnob00_c */
@@ -174,7 +174,7 @@ static BOOL daKnob00_Execute(daKnob00_c*) {
 
 /* 00001E78-00001E80       .text daKnob00_IsDelete__FP10daKnob00_c */
 static BOOL daKnob00_IsDelete(daKnob00_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00001E80-00001F50       .text daKnob00_Delete__FP10daKnob00_c */
@@ -183,8 +183,8 @@ static BOOL daKnob00_Delete(daKnob00_c*) {
 }
 
 /* 00001F50-00001F70       .text daKnob00_Create__FP10fopAc_ac_c */
-static cPhs_State daKnob00_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daKnob00_Create(fopAc_ac_c* i_this) {
+    return ((daKnob00_c*)i_this)->create();
 }
 
 static actor_method_class l_daKnob00_Method = {

--- a/src/d/actor/d_a_kokiie.cpp
+++ b/src/d/actor/d_a_kokiie.cpp
@@ -34,7 +34,7 @@ static BOOL daKokiie_Execute(kokiie_class*) {
 
 /* 0000107C-00001084       .text daKokiie_IsDelete__FP12kokiie_class */
 static BOOL daKokiie_IsDelete(kokiie_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00001084-000010E4       .text daKokiie_Delete__FP12kokiie_class */

--- a/src/d/actor/d_a_lstair.cpp
+++ b/src/d/actor/d_a_lstair.cpp
@@ -83,13 +83,13 @@ void daLStair_c::set_off_se() {
 }
 
 /* 00001144-00001164       .text daLStair_Create__FPv */
-static cPhs_State daLStair_Create(void*) {
-    /* Nonmatching */
+static cPhs_State daLStair_Create(void* i_this) {
+    return ((daLStair_c*)i_this)->_create();
 }
 
 /* 00001164-00001188       .text daLStair_Delete__FPv */
-static BOOL daLStair_Delete(void*) {
-    /* Nonmatching */
+static BOOL daLStair_Delete(void* i_this) {
+    return ((daLStair_c*)i_this)->_delete();
 }
 
 /* 00001188-0000128C       .text daLStair_Draw__FPv */
@@ -98,13 +98,13 @@ static BOOL daLStair_Draw(void*) {
 }
 
 /* 0000128C-000012B0       .text daLStair_Execute__FPv */
-static BOOL daLStair_Execute(void*) {
-    /* Nonmatching */
+static BOOL daLStair_Execute(void* i_this) {
+    return ((daLStair_c*)i_this)->_execute();
 }
 
 /* 000012B0-000012B8       .text daLStair_IsDelete__FPv */
 static BOOL daLStair_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daLStairMethodTable = {

--- a/src/d/actor/d_a_majuu_flag.cpp
+++ b/src/d/actor/d_a_majuu_flag.cpp
@@ -59,7 +59,7 @@ static BOOL daMajuu_Flag_Execute(daMajuu_Flag_c*) {
 
 /* 000013B0-000013B8       .text daMajuu_Flag_IsDelete__FP14daMajuu_Flag_c */
 static BOOL daMajuu_Flag_IsDelete(daMajuu_Flag_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 000013B8-00001454       .text daMajuu_Flag_Delete__FP14daMajuu_Flag_c */

--- a/src/d/actor/d_a_mant.cpp
+++ b/src/d/actor/d_a_mant.cpp
@@ -45,12 +45,12 @@ static BOOL daMant_Execute(mant_class*) {
 
 /* 00001A3C-00001A44       .text daMant_IsDelete__FP10mant_class */
 static BOOL daMant_IsDelete(mant_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00001A44-00001A4C       .text daMant_Delete__FP10mant_class */
 static BOOL daMant_Delete(mant_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00001A4C-00001D18       .text daMant_Create__FP10fopAc_ac_c */

--- a/src/d/actor/d_a_mdoor.cpp
+++ b/src/d/actor/d_a_mdoor.cpp
@@ -124,7 +124,7 @@ static BOOL daMdoor_Execute(daMdoor_c*) {
 
 /* 00000F84-00000F8C       .text daMdoor_IsDelete__FP9daMdoor_c */
 static BOOL daMdoor_IsDelete(daMdoor_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00000F8C-00001054       .text daMdoor_Delete__FP9daMdoor_c */
@@ -133,8 +133,8 @@ static BOOL daMdoor_Delete(daMdoor_c*) {
 }
 
 /* 00001054-00001074       .text daMdoor_Create__FP10fopAc_ac_c */
-static cPhs_State daMdoor_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daMdoor_Create(fopAc_ac_c* i_this) {
+    return ((daMdoor_c*)i_this)->create();
 }
 
 static actor_method_class l_daMdoor_Method = {

--- a/src/d/actor/d_a_mflft.cpp
+++ b/src/d/actor/d_a_mflft.cpp
@@ -61,7 +61,7 @@ static BOOL daMflft_Execute(mflft_class*) {
 
 /* 00002284-0000228C       .text daMflft_IsDelete__FP11mflft_class */
 static BOOL daMflft_IsDelete(mflft_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 0000228C-00002310       .text daMflft_Delete__FP11mflft_class */

--- a/src/d/actor/d_a_mgameboard.cpp
+++ b/src/d/actor/d_a_mgameboard.cpp
@@ -73,8 +73,8 @@ static BOOL daMgBoard_Delete(void*) {
 }
 
 /* 00001518-0000153C       .text daMgBoard_Draw__FPv */
-static BOOL daMgBoard_Draw(void*) {
-    /* Nonmatching */
+static BOOL daMgBoard_Draw(void* i_this) {
+    return ((daMgBoard_c*)i_this)->_draw();
 }
 
 /* 0000153C-00001850       .text _draw__11daMgBoard_cFv */
@@ -83,13 +83,13 @@ bool daMgBoard_c::_draw() {
 }
 
 /* 00001850-00001874       .text daMgBoard_Execute__FPv */
-static BOOL daMgBoard_Execute(void*) {
-    /* Nonmatching */
+static BOOL daMgBoard_Execute(void* i_this) {
+    return ((daMgBoard_c*)i_this)->_execute();
 }
 
 /* 00001874-0000187C       .text daMgBoard_IsDelete__FPv */
 static BOOL daMgBoard_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daMgBoardMethodTable = {

--- a/src/d/actor/d_a_mo2.cpp
+++ b/src/d/actor/d_a_mo2.cpp
@@ -320,7 +320,7 @@ static BOOL daMo2_Execute(mo2_class*) {
 
 /* 0000B618-0000B620       .text daMo2_IsDelete__FP9mo2_class */
 static BOOL daMo2_IsDelete(mo2_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 0000B620-0000B720       .text daMo2_Delete__FP9mo2_class */

--- a/src/d/actor/d_a_mt.cpp
+++ b/src/d/actor/d_a_mt.cpp
@@ -146,7 +146,7 @@ static BOOL daMt_Execute(mt_class*) {
 
 /* 00007CC4-00007CCC       .text daMt_IsDelete__FP8mt_class */
 static BOOL daMt_IsDelete(mt_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00007CCC-00007E18       .text daMt_Delete__FP8mt_class */

--- a/src/d/actor/d_a_npc_ac1.cpp
+++ b/src/d/actor/d_a_npc_ac1.cpp
@@ -258,17 +258,17 @@ void daNpc_Ac1_c::shadowDraw() {
 }
 
 /* 00001C70-00001DC4       .text _draw__11daNpc_Ac1_cFv */
-bool daNpc_Ac1_c::_draw() {
+BOOL daNpc_Ac1_c::_draw() {
     /* Nonmatching */
 }
 
 /* 00001DC4-00001F80       .text _execute__11daNpc_Ac1_cFv */
-bool daNpc_Ac1_c::_execute() {
+BOOL daNpc_Ac1_c::_execute() {
     /* Nonmatching */
 }
 
 /* 00001F80-00001FFC       .text _delete__11daNpc_Ac1_cFv */
-bool daNpc_Ac1_c::_delete() {
+BOOL daNpc_Ac1_c::_delete() {
     /* Nonmatching */
 }
 
@@ -308,28 +308,28 @@ void daNpc_Ac1_c::CreateHeap() {
 }
 
 /* 00003044-00003064       .text daNpc_Ac1_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Ac1_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_Ac1_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_Ac1_c*)i_this)->_create();
 }
 
 /* 00003064-00003084       .text daNpc_Ac1_Delete__FP11daNpc_Ac1_c */
-static BOOL daNpc_Ac1_Delete(daNpc_Ac1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Ac1_Delete(daNpc_Ac1_c* i_this) {
+    return ((daNpc_Ac1_c*)i_this)->_delete();
 }
 
 /* 00003084-000030A4       .text daNpc_Ac1_Execute__FP11daNpc_Ac1_c */
-static BOOL daNpc_Ac1_Execute(daNpc_Ac1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Ac1_Execute(daNpc_Ac1_c* i_this) {
+    return ((daNpc_Ac1_c*)i_this)->_execute();
 }
 
 /* 000030A4-000030C4       .text daNpc_Ac1_Draw__FP11daNpc_Ac1_c */
-static BOOL daNpc_Ac1_Draw(daNpc_Ac1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Ac1_Draw(daNpc_Ac1_c* i_this) {
+    return ((daNpc_Ac1_c*)i_this)->_draw();
 }
 
 /* 000030C4-000030CC       .text daNpc_Ac1_IsDelete__FP11daNpc_Ac1_c */
 static BOOL daNpc_Ac1_IsDelete(daNpc_Ac1_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daNpc_Ac1_Method = {

--- a/src/d/actor/d_a_npc_ah.cpp
+++ b/src/d/actor/d_a_npc_ah.cpp
@@ -219,28 +219,28 @@ void daNpcAh_c::chkEndEvent() {
 }
 
 /* 00002338-00002358       .text daNpc_AhCreate__FPv */
-static s32 daNpc_AhCreate(void*) {
-    /* Nonmatching */
+static s32 daNpc_AhCreate(void* i_this) {
+    return ((daNpcAh_c*)i_this)->_create();
 }
 
 /* 00002358-0000237C       .text daNpc_AhDelete__FPv */
-static BOOL daNpc_AhDelete(void*) {
-    /* Nonmatching */
+static BOOL daNpc_AhDelete(void* i_this) {
+    return ((daNpcAh_c*)i_this)->_delete();
 }
 
 /* 0000237C-000023A0       .text daNpc_AhExecute__FPv */
-static BOOL daNpc_AhExecute(void*) {
-    /* Nonmatching */
+static BOOL daNpc_AhExecute(void* i_this) {
+    return ((daNpcAh_c*)i_this)->_execute();
 }
 
 /* 000023A0-000023C4       .text daNpc_AhDraw__FPv */
-static BOOL daNpc_AhDraw(void*) {
-    /* Nonmatching */
+static BOOL daNpc_AhDraw(void* i_this) {
+    return ((daNpcAh_c*)i_this)->_draw();
 }
 
 /* 000023C4-000023CC       .text daNpc_AhIsDelete__FPv */
 static BOOL daNpc_AhIsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daNpc_AhMethodTable = {

--- a/src/d/actor/d_a_npc_aj1.cpp
+++ b/src/d/actor/d_a_npc_aj1.cpp
@@ -418,17 +418,17 @@ void daNpc_Aj1_c::shadowDraw() {
 }
 
 /* 00003254-00003380       .text _draw__11daNpc_Aj1_cFv */
-bool daNpc_Aj1_c::_draw() {
+BOOL daNpc_Aj1_c::_draw() {
     /* Nonmatching */
 }
 
 /* 00003380-000035A8       .text _execute__11daNpc_Aj1_cFv */
-bool daNpc_Aj1_c::_execute() {
+BOOL daNpc_Aj1_c::_execute() {
     /* Nonmatching */
 }
 
 /* 000035A8-0000363C       .text _delete__11daNpc_Aj1_cFv */
-bool daNpc_Aj1_c::_delete() {
+BOOL daNpc_Aj1_c::_delete() {
     /* Nonmatching */
 }
 
@@ -453,28 +453,28 @@ void daNpc_Aj1_c::CreateHeap() {
 }
 
 /* 00003FFC-0000401C       .text daNpc_Aj1_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Aj1_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_Aj1_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_Aj1_c*)i_this)->_create();
 }
 
 /* 0000401C-0000403C       .text daNpc_Aj1_Delete__FP11daNpc_Aj1_c */
-static BOOL daNpc_Aj1_Delete(daNpc_Aj1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Aj1_Delete(daNpc_Aj1_c* i_this) {
+    return ((daNpc_Aj1_c*)i_this)->_delete();
 }
 
 /* 0000403C-0000405C       .text daNpc_Aj1_Execute__FP11daNpc_Aj1_c */
-static BOOL daNpc_Aj1_Execute(daNpc_Aj1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Aj1_Execute(daNpc_Aj1_c* i_this) {
+    return ((daNpc_Aj1_c*)i_this)->_execute();
 }
 
 /* 0000405C-0000407C       .text daNpc_Aj1_Draw__FP11daNpc_Aj1_c */
-static BOOL daNpc_Aj1_Draw(daNpc_Aj1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Aj1_Draw(daNpc_Aj1_c* i_this) {
+    return ((daNpc_Aj1_c*)i_this)->_draw();
 }
 
 /* 0000407C-00004084       .text daNpc_Aj1_IsDelete__FP11daNpc_Aj1_c */
 static BOOL daNpc_Aj1_IsDelete(daNpc_Aj1_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daNpc_Aj1_Method = {

--- a/src/d/actor/d_a_npc_auction.cpp
+++ b/src/d/actor/d_a_npc_auction.cpp
@@ -215,7 +215,7 @@ static BOOL daNpc_AuctionDraw(void*) {
 
 /* 00002EB8-00002EC0       .text daNpc_AuctionIsDelete__FPv */
 static BOOL daNpc_AuctionIsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daNpc_AuctionMethodTable = {

--- a/src/d/actor/d_a_npc_ba1.cpp
+++ b/src/d/actor/d_a_npc_ba1.cpp
@@ -458,17 +458,17 @@ void daNpc_Ba1_c::shadowDraw() {
 }
 
 /* 00003AA8-00003C0C       .text _draw__11daNpc_Ba1_cFv */
-bool daNpc_Ba1_c::_draw() {
+BOOL daNpc_Ba1_c::_draw() {
     /* Nonmatching */
 }
 
 /* 00003C0C-00003E1C       .text _execute__11daNpc_Ba1_cFv */
-bool daNpc_Ba1_c::_execute() {
+BOOL daNpc_Ba1_c::_execute() {
     /* Nonmatching */
 }
 
 /* 00003E1C-00003E78       .text _delete__11daNpc_Ba1_cFv */
-bool daNpc_Ba1_c::_delete() {
+BOOL daNpc_Ba1_c::_delete() {
     /* Nonmatching */
 }
 
@@ -498,28 +498,28 @@ void daNpc_Ba1_c::CreateHeap() {
 }
 
 /* 0000485C-0000487C       .text daNpc_Ba1_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Ba1_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_Ba1_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_Ba1_c*)i_this)->_create();
 }
 
 /* 0000487C-0000489C       .text daNpc_Ba1_Delete__FP11daNpc_Ba1_c */
-static BOOL daNpc_Ba1_Delete(daNpc_Ba1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Ba1_Delete(daNpc_Ba1_c* i_this) {
+    return ((daNpc_Ba1_c*)i_this)->_delete();
 }
 
 /* 0000489C-000048BC       .text daNpc_Ba1_Execute__FP11daNpc_Ba1_c */
-static BOOL daNpc_Ba1_Execute(daNpc_Ba1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Ba1_Execute(daNpc_Ba1_c* i_this) {
+    return ((daNpc_Ba1_c*)i_this)->_execute();
 }
 
 /* 000048BC-000048DC       .text daNpc_Ba1_Draw__FP11daNpc_Ba1_c */
-static BOOL daNpc_Ba1_Draw(daNpc_Ba1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Ba1_Draw(daNpc_Ba1_c* i_this) {
+    return ((daNpc_Ba1_c*)i_this)->_draw();
 }
 
 /* 000048DC-000048E4       .text daNpc_Ba1_IsDelete__FP11daNpc_Ba1_c */
 static BOOL daNpc_Ba1_IsDelete(daNpc_Ba1_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daNpc_Ba1_Method = {

--- a/src/d/actor/d_a_npc_bj1.cpp
+++ b/src/d/actor/d_a_npc_bj1.cpp
@@ -558,17 +558,17 @@ void daNpc_Bj1_c::shadowDraw() {
 }
 
 /* 00005AC4-00005E38       .text _draw__11daNpc_Bj1_cFv */
-bool daNpc_Bj1_c::_draw() {
+BOOL daNpc_Bj1_c::_draw() {
     /* Nonmatching */
 }
 
 /* 00005E38-00006128       .text _execute__11daNpc_Bj1_cFv */
-bool daNpc_Bj1_c::_execute() {
+BOOL daNpc_Bj1_c::_execute() {
     /* Nonmatching */
 }
 
 /* 00006128-000061A4       .text _delete__11daNpc_Bj1_cFv */
-bool daNpc_Bj1_c::_delete() {
+BOOL daNpc_Bj1_c::_delete() {
     /* Nonmatching */
 }
 
@@ -603,28 +603,28 @@ void daNpc_Bj1_c::CreateHeap() {
 }
 
 /* 00007114-00007134       .text daNpc_Bj1_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Bj1_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_Bj1_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_Bj1_c*)i_this)->_create();
 }
 
 /* 00007134-00007154       .text daNpc_Bj1_Delete__FP11daNpc_Bj1_c */
-static BOOL daNpc_Bj1_Delete(daNpc_Bj1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Bj1_Delete(daNpc_Bj1_c* i_this) {
+    return ((daNpc_Bj1_c*)i_this)->_delete();
 }
 
 /* 00007154-00007174       .text daNpc_Bj1_Execute__FP11daNpc_Bj1_c */
-static BOOL daNpc_Bj1_Execute(daNpc_Bj1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Bj1_Execute(daNpc_Bj1_c* i_this) {
+    return ((daNpc_Bj1_c*)i_this)->_execute();
 }
 
 /* 00007174-00007194       .text daNpc_Bj1_Draw__FP11daNpc_Bj1_c */
-static BOOL daNpc_Bj1_Draw(daNpc_Bj1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Bj1_Draw(daNpc_Bj1_c* i_this) {
+    return ((daNpc_Bj1_c*)i_this)->_draw();
 }
 
 /* 00007194-0000719C       .text daNpc_Bj1_IsDelete__FP11daNpc_Bj1_c */
 static BOOL daNpc_Bj1_IsDelete(daNpc_Bj1_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daNpc_Bj1_Method = {

--- a/src/d/actor/d_a_npc_bm1.cpp
+++ b/src/d/actor/d_a_npc_bm1.cpp
@@ -758,17 +758,17 @@ void daNpc_Bm1_c::shadowDraw() {
 }
 
 /* 0000768C-00007AB4       .text _draw__11daNpc_Bm1_cFv */
-bool daNpc_Bm1_c::_draw() {
+BOOL daNpc_Bm1_c::_draw() {
     /* Nonmatching */
 }
 
 /* 00007AB4-00007CAC       .text _execute__11daNpc_Bm1_cFv */
-bool daNpc_Bm1_c::_execute() {
+BOOL daNpc_Bm1_c::_execute() {
     /* Nonmatching */
 }
 
 /* 00007CAC-00007D50       .text _delete__11daNpc_Bm1_cFv */
-bool daNpc_Bm1_c::_delete() {
+BOOL daNpc_Bm1_c::_delete() {
     /* Nonmatching */
 }
 
@@ -813,28 +813,28 @@ void daNpc_Bm1_c::CreateHeap() {
 }
 
 /* 0000946C-0000948C       .text daNpc_Bm1_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Bm1_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_Bm1_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_Bm1_c*)i_this)->_create();
 }
 
 /* 0000948C-000094AC       .text daNpc_Bm1_Delete__FP11daNpc_Bm1_c */
-static BOOL daNpc_Bm1_Delete(daNpc_Bm1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Bm1_Delete(daNpc_Bm1_c* i_this) {
+    return ((daNpc_Bm1_c*)i_this)->_delete();
 }
 
 /* 000094AC-000094CC       .text daNpc_Bm1_Execute__FP11daNpc_Bm1_c */
-static BOOL daNpc_Bm1_Execute(daNpc_Bm1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Bm1_Execute(daNpc_Bm1_c* i_this) {
+    return ((daNpc_Bm1_c*)i_this)->_execute();
 }
 
 /* 000094CC-000094EC       .text daNpc_Bm1_Draw__FP11daNpc_Bm1_c */
-static BOOL daNpc_Bm1_Draw(daNpc_Bm1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Bm1_Draw(daNpc_Bm1_c* i_this) {
+    return ((daNpc_Bm1_c*)i_this)->_draw();
 }
 
 /* 000094EC-000094F4       .text daNpc_Bm1_IsDelete__FP11daNpc_Bm1_c */
 static BOOL daNpc_Bm1_IsDelete(daNpc_Bm1_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daNpc_Bm1_Method = {

--- a/src/d/actor/d_a_npc_bmcon1.cpp
+++ b/src/d/actor/d_a_npc_bmcon1.cpp
@@ -278,28 +278,28 @@ void daNpcBmcon_c::isClear() {
 }
 
 /* 00003DFC-00003E1C       .text daNpc_BmconCreate__FPv */
-static s32 daNpc_BmconCreate(void*) {
-    /* Nonmatching */
+static s32 daNpc_BmconCreate(void* i_this) {
+    return ((daNpcBmcon_c*)i_this)->_create();
 }
 
 /* 00003E1C-00003E40       .text daNpc_BmconDelete__FPv */
-static BOOL daNpc_BmconDelete(void*) {
-    /* Nonmatching */
+static BOOL daNpc_BmconDelete(void* i_this) {
+    return ((daNpcBmcon_c*)i_this)->_delete();
 }
 
 /* 00003E40-00003E64       .text daNpc_BmconExecute__FPv */
-static BOOL daNpc_BmconExecute(void*) {
-    /* Nonmatching */
+static BOOL daNpc_BmconExecute(void* i_this) {
+    return ((daNpcBmcon_c*)i_this)->_execute();
 }
 
 /* 00003E64-00003E88       .text daNpc_BmconDraw__FPv */
-static BOOL daNpc_BmconDraw(void*) {
-    /* Nonmatching */
+static BOOL daNpc_BmconDraw(void* i_this) {
+    return ((daNpcBmcon_c*)i_this)->_draw();
 }
 
 /* 00003E88-00003E90       .text daNpc_BmconIsDelete__FPv */
 static BOOL daNpc_BmconIsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daNpc_BmconMethodTable = {

--- a/src/d/actor/d_a_npc_bms1.cpp
+++ b/src/d/actor/d_a_npc_bms1.cpp
@@ -235,17 +235,17 @@ void daNpc_Bms1_c::demo_end_init() {
 }
 
 /* 000030B0-00003314       .text _draw__12daNpc_Bms1_cFv */
-bool daNpc_Bms1_c::_draw() {
+BOOL daNpc_Bms1_c::_draw() {
     /* Nonmatching */
 }
 
 /* 00003314-00003474       .text _execute__12daNpc_Bms1_cFv */
-bool daNpc_Bms1_c::_execute() {
+BOOL daNpc_Bms1_c::_execute() {
     /* Nonmatching */
 }
 
 /* 00003474-00003514       .text _delete__12daNpc_Bms1_cFv */
-bool daNpc_Bms1_c::_delete() {
+BOOL daNpc_Bms1_c::_delete() {
     /* Nonmatching */
 }
 
@@ -265,28 +265,28 @@ void daNpc_Bms1_c::CreateHeap() {
 }
 
 /* 000043B8-000043D8       .text daNpc_Bms1_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Bms1_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_Bms1_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_Bms1_c*)i_this)->_create();
 }
 
 /* 000043D8-000043F8       .text daNpc_Bms1_Delete__FP12daNpc_Bms1_c */
-static BOOL daNpc_Bms1_Delete(daNpc_Bms1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Bms1_Delete(daNpc_Bms1_c* i_this) {
+    return ((daNpc_Bms1_c*)i_this)->_delete();
 }
 
 /* 000043F8-00004418       .text daNpc_Bms1_Execute__FP12daNpc_Bms1_c */
-static BOOL daNpc_Bms1_Execute(daNpc_Bms1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Bms1_Execute(daNpc_Bms1_c* i_this) {
+    return ((daNpc_Bms1_c*)i_this)->_execute();
 }
 
 /* 00004418-00004438       .text daNpc_Bms1_Draw__FP12daNpc_Bms1_c */
-static BOOL daNpc_Bms1_Draw(daNpc_Bms1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Bms1_Draw(daNpc_Bms1_c* i_this) {
+    return ((daNpc_Bms1_c*)i_this)->_draw();
 }
 
 /* 00004438-00004440       .text daNpc_Bms1_IsDelete__FP12daNpc_Bms1_c */
 static BOOL daNpc_Bms1_IsDelete(daNpc_Bms1_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 // /* 000047AC-000047C8       .text setEyePos__12daNpc_Bms1_cF4cXyz */

--- a/src/d/actor/d_a_npc_bmsw.cpp
+++ b/src/d/actor/d_a_npc_bmsw.cpp
@@ -160,17 +160,17 @@ void daNpc_Bmsw_c::shiwake_game_action(void*) {
 }
 
 /* 00002950-00002B24       .text _draw__12daNpc_Bmsw_cFv */
-bool daNpc_Bmsw_c::_draw() {
+BOOL daNpc_Bmsw_c::_draw() {
     /* Nonmatching */
 }
 
 /* 00002B24-00002CA4       .text _execute__12daNpc_Bmsw_cFv */
-bool daNpc_Bmsw_c::_execute() {
+BOOL daNpc_Bmsw_c::_execute() {
     /* Nonmatching */
 }
 
 /* 00002CA4-00002D40       .text _delete__12daNpc_Bmsw_cFv */
-bool daNpc_Bmsw_c::_delete() {
+BOOL daNpc_Bmsw_c::_delete() {
     /* Nonmatching */
 }
 
@@ -285,28 +285,28 @@ void SwCam_c::Move() {
 }
 
 /* 00004D0C-00004D2C       .text daNpc_Bmsw_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Bmsw_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_Bmsw_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_Bmsw_c*)i_this)->_create();
 }
 
 /* 00004D2C-00004D4C       .text daNpc_Bmsw_Delete__FP12daNpc_Bmsw_c */
-static BOOL daNpc_Bmsw_Delete(daNpc_Bmsw_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Bmsw_Delete(daNpc_Bmsw_c* i_this) {
+    return ((daNpc_Bmsw_c*)i_this)->_delete();
 }
 
 /* 00004D4C-00004D6C       .text daNpc_Bmsw_Execute__FP12daNpc_Bmsw_c */
-static BOOL daNpc_Bmsw_Execute(daNpc_Bmsw_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Bmsw_Execute(daNpc_Bmsw_c* i_this) {
+    return ((daNpc_Bmsw_c*)i_this)->_execute();
 }
 
 /* 00004D6C-00004D8C       .text daNpc_Bmsw_Draw__FP12daNpc_Bmsw_c */
-static BOOL daNpc_Bmsw_Draw(daNpc_Bmsw_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Bmsw_Draw(daNpc_Bmsw_c* i_this) {
+    return ((daNpc_Bmsw_c*)i_this)->_draw();
 }
 
 /* 00004D8C-00004D94       .text daNpc_Bmsw_IsDelete__FP12daNpc_Bmsw_c */
 static BOOL daNpc_Bmsw_IsDelete(daNpc_Bmsw_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daNpc_Bmsw_Method = {

--- a/src/d/actor/d_a_npc_btsw.cpp
+++ b/src/d/actor/d_a_npc_btsw.cpp
@@ -166,17 +166,17 @@ void daNpc_Btsw_c::getdemo_action(void*) {
 }
 
 /* 00002844-000029A0       .text _draw__12daNpc_Btsw_cFv */
-bool daNpc_Btsw_c::_draw() {
+BOOL daNpc_Btsw_c::_draw() {
     /* Nonmatching */
 }
 
 /* 000029A0-00002AF4       .text _execute__12daNpc_Btsw_cFv */
-bool daNpc_Btsw_c::_execute() {
+BOOL daNpc_Btsw_c::_execute() {
     /* Nonmatching */
 }
 
 /* 00002AF4-00002B90       .text _delete__12daNpc_Btsw_cFv */
-bool daNpc_Btsw_c::_delete() {
+BOOL daNpc_Btsw_c::_delete() {
     /* Nonmatching */
 }
 
@@ -291,28 +291,28 @@ void SwCam2_c::Move() {
 }
 
 /* 00004788-000047A8       .text daNpc_Btsw_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Btsw_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_Btsw_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_Btsw_c*)i_this)->_create();
 }
 
 /* 000047A8-000047C8       .text daNpc_Btsw_Delete__FP12daNpc_Btsw_c */
-static BOOL daNpc_Btsw_Delete(daNpc_Btsw_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Btsw_Delete(daNpc_Btsw_c* i_this) {
+    return ((daNpc_Btsw_c*)i_this)->_delete();
 }
 
 /* 000047C8-000047E8       .text daNpc_Btsw_Execute__FP12daNpc_Btsw_c */
-static BOOL daNpc_Btsw_Execute(daNpc_Btsw_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Btsw_Execute(daNpc_Btsw_c* i_this) {
+    return ((daNpc_Btsw_c*)i_this)->_execute();
 }
 
 /* 000047E8-00004808       .text daNpc_Btsw_Draw__FP12daNpc_Btsw_c */
-static BOOL daNpc_Btsw_Draw(daNpc_Btsw_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Btsw_Draw(daNpc_Btsw_c* i_this) {
+    return ((daNpc_Btsw_c*)i_this)->_draw();
 }
 
 /* 00004808-00004810       .text daNpc_Btsw_IsDelete__FP12daNpc_Btsw_c */
 static BOOL daNpc_Btsw_IsDelete(daNpc_Btsw_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daNpc_Btsw_Method = {

--- a/src/d/actor/d_a_npc_cb1.cpp
+++ b/src/d/actor/d_a_npc_cb1.cpp
@@ -601,28 +601,29 @@ daNpc_Cb1_c::~daNpc_Cb1_c() {
 }
 
 /* 000093A8-000093C8       .text daNpc_Cb1_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Cb1_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_Cb1_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_Cb1_c*)i_this)->create();
 }
 
 /* 000093C8-000093F0       .text daNpc_Cb1_Delete__FP11daNpc_Cb1_c */
-static BOOL daNpc_Cb1_Delete(daNpc_Cb1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Cb1_Delete(daNpc_Cb1_c* i_this) {
+    ((daNpc_Cb1_c*)i_this)->~daNpc_Cb1_c();
+    return TRUE;
 }
 
 /* 000093F0-00009410       .text daNpc_Cb1_Execute__FP11daNpc_Cb1_c */
-static BOOL daNpc_Cb1_Execute(daNpc_Cb1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Cb1_Execute(daNpc_Cb1_c* i_this) {
+    return ((daNpc_Cb1_c*)i_this)->execute();
 }
 
 /* 00009410-00009430       .text daNpc_Cb1_Draw__FP11daNpc_Cb1_c */
-static BOOL daNpc_Cb1_Draw(daNpc_Cb1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Cb1_Draw(daNpc_Cb1_c* i_this) {
+    return ((daNpc_Cb1_c*)i_this)->draw();
 }
 
 /* 00009430-00009438       .text daNpc_Cb1_IsDelete__FP11daNpc_Cb1_c */
 static BOOL daNpc_Cb1_IsDelete(daNpc_Cb1_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daNpc_Cb1_Method = {

--- a/src/d/actor/d_a_npc_co1.cpp
+++ b/src/d/actor/d_a_npc_co1.cpp
@@ -298,17 +298,17 @@ void daNpc_Co1_c::shadowDraw() {
 }
 
 /* 000027AC-0000295C       .text _draw__11daNpc_Co1_cFv */
-bool daNpc_Co1_c::_draw() {
+BOOL daNpc_Co1_c::_draw() {
     /* Nonmatching */
 }
 
 /* 0000295C-00002B08       .text _execute__11daNpc_Co1_cFv */
-bool daNpc_Co1_c::_execute() {
+BOOL daNpc_Co1_c::_execute() {
     /* Nonmatching */
 }
 
 /* 00002B08-00002B6C       .text _delete__11daNpc_Co1_cFv */
-bool daNpc_Co1_c::_delete() {
+BOOL daNpc_Co1_c::_delete() {
     /* Nonmatching */
 }
 
@@ -343,28 +343,28 @@ void daNpc_Co1_c::CreateHeap() {
 }
 
 /* 000037C8-000037E8       .text daNpc_Co1_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Co1_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_Co1_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_Co1_c*)i_this)->_create();
 }
 
 /* 000037E8-00003808       .text daNpc_Co1_Delete__FP11daNpc_Co1_c */
-static BOOL daNpc_Co1_Delete(daNpc_Co1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Co1_Delete(daNpc_Co1_c* i_this) {
+    return ((daNpc_Co1_c*)i_this)->_delete();
 }
 
 /* 00003808-00003828       .text daNpc_Co1_Execute__FP11daNpc_Co1_c */
-static BOOL daNpc_Co1_Execute(daNpc_Co1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Co1_Execute(daNpc_Co1_c* i_this) {
+    return ((daNpc_Co1_c*)i_this)->_execute();
 }
 
 /* 00003828-00003848       .text daNpc_Co1_Draw__FP11daNpc_Co1_c */
-static BOOL daNpc_Co1_Draw(daNpc_Co1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Co1_Draw(daNpc_Co1_c* i_this) {
+    return ((daNpc_Co1_c*)i_this)->_draw();
 }
 
 /* 00003848-00003850       .text daNpc_Co1_IsDelete__FP11daNpc_Co1_c */
 static BOOL daNpc_Co1_IsDelete(daNpc_Co1_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daNpc_Co1_Method = {

--- a/src/d/actor/d_a_npc_de1.cpp
+++ b/src/d/actor/d_a_npc_de1.cpp
@@ -238,17 +238,17 @@ void daNpc_De1_c::demo() {
 }
 
 /* 00002248-00002358       .text _draw__11daNpc_De1_cFv */
-bool daNpc_De1_c::_draw() {
+BOOL daNpc_De1_c::_draw() {
     /* Nonmatching */
 }
 
 /* 00002358-00002454       .text _execute__11daNpc_De1_cFv */
-bool daNpc_De1_c::_execute() {
+BOOL daNpc_De1_c::_execute() {
     /* Nonmatching */
 }
 
 /* 00002454-00002500       .text _delete__11daNpc_De1_cFv */
-bool daNpc_De1_c::_delete() {
+BOOL daNpc_De1_c::_delete() {
     /* Nonmatching */
 }
 
@@ -268,28 +268,28 @@ void daNpc_De1_c::CreateHeap() {
 }
 
 /* 00002E04-00002E24       .text daNpc_De1_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_De1_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_De1_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_De1_c*)i_this)->_create();
 }
 
 /* 00002E24-00002E44       .text daNpc_De1_Delete__FP11daNpc_De1_c */
-static BOOL daNpc_De1_Delete(daNpc_De1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_De1_Delete(daNpc_De1_c* i_this) {
+    return ((daNpc_De1_c*)i_this)->_delete();
 }
 
 /* 00002E44-00002E64       .text daNpc_De1_Execute__FP11daNpc_De1_c */
-static BOOL daNpc_De1_Execute(daNpc_De1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_De1_Execute(daNpc_De1_c* i_this) {
+    return ((daNpc_De1_c*)i_this)->_execute();
 }
 
 /* 00002E64-00002E84       .text daNpc_De1_Draw__FP11daNpc_De1_c */
-static BOOL daNpc_De1_Draw(daNpc_De1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_De1_Draw(daNpc_De1_c* i_this) {
+    return ((daNpc_De1_c*)i_this)->_draw();
 }
 
 /* 00002E84-00002E8C       .text daNpc_De1_IsDelete__FP11daNpc_De1_c */
 static BOOL daNpc_De1_IsDelete(daNpc_De1_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daNpc_De1_Method = {

--- a/src/d/actor/d_a_npc_ds1.cpp
+++ b/src/d/actor/d_a_npc_ds1.cpp
@@ -275,17 +275,17 @@ void daNpc_Ds1_c::RoomEffectDelete() {
 }
 
 /* 00003F20-000041D0       .text _draw__11daNpc_Ds1_cFv */
-bool daNpc_Ds1_c::_draw() {
+BOOL daNpc_Ds1_c::_draw() {
     /* Nonmatching */
 }
 
 /* 000041D0-00004554       .text _execute__11daNpc_Ds1_cFv */
-bool daNpc_Ds1_c::_execute() {
+BOOL daNpc_Ds1_c::_execute() {
     /* Nonmatching */
 }
 
 /* 00004554-0000465C       .text _delete__11daNpc_Ds1_cFv */
-bool daNpc_Ds1_c::_delete() {
+BOOL daNpc_Ds1_c::_delete() {
     /* Nonmatching */
 }
 
@@ -305,28 +305,28 @@ void daNpc_Ds1_c::CreateHeap() {
 }
 
 /* 000052D4-000052F4       .text daNpc_Ds1_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Ds1_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_Ds1_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_Ds1_c*)i_this)->_create();
 }
 
 /* 000052F4-00005314       .text daNpc_Ds1_Delete__FP11daNpc_Ds1_c */
-static BOOL daNpc_Ds1_Delete(daNpc_Ds1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Ds1_Delete(daNpc_Ds1_c* i_this) {
+    return ((daNpc_Ds1_c*)i_this)->_delete();
 }
 
 /* 00005314-00005334       .text daNpc_Ds1_Execute__FP11daNpc_Ds1_c */
-static BOOL daNpc_Ds1_Execute(daNpc_Ds1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Ds1_Execute(daNpc_Ds1_c* i_this) {
+    return ((daNpc_Ds1_c*)i_this)->_execute();
 }
 
 /* 00005334-00005354       .text daNpc_Ds1_Draw__FP11daNpc_Ds1_c */
-static BOOL daNpc_Ds1_Draw(daNpc_Ds1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Ds1_Draw(daNpc_Ds1_c* i_this) {
+    return ((daNpc_Ds1_c*)i_this)->_draw();
 }
 
 /* 00005354-0000535C       .text daNpc_Ds1_IsDelete__FP11daNpc_Ds1_c */
 static BOOL daNpc_Ds1_IsDelete(daNpc_Ds1_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daNpc_Ds1_Method = {

--- a/src/d/actor/d_a_npc_gk1.cpp
+++ b/src/d/actor/d_a_npc_gk1.cpp
@@ -253,17 +253,17 @@ void daNpc_Gk1_c::shadowDraw() {
 }
 
 /* 00001F48-00002064       .text _draw__11daNpc_Gk1_cFv */
-bool daNpc_Gk1_c::_draw() {
+BOOL daNpc_Gk1_c::_draw() {
     /* Nonmatching */
 }
 
 /* 00002064-00002280       .text _execute__11daNpc_Gk1_cFv */
-bool daNpc_Gk1_c::_execute() {
+BOOL daNpc_Gk1_c::_execute() {
     /* Nonmatching */
 }
 
 /* 00002280-000022D4       .text _delete__11daNpc_Gk1_cFv */
-bool daNpc_Gk1_c::_delete() {
+BOOL daNpc_Gk1_c::_delete() {
     /* Nonmatching */
 }
 
@@ -293,28 +293,28 @@ void daNpc_Gk1_c::CreateHeap() {
 }
 
 /* 00002D2C-00002D4C       .text daNpc_Gk1_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Gk1_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_Gk1_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_Gk1_c*)i_this)->_create();
 }
 
 /* 00002D4C-00002D6C       .text daNpc_Gk1_Delete__FP11daNpc_Gk1_c */
-static BOOL daNpc_Gk1_Delete(daNpc_Gk1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Gk1_Delete(daNpc_Gk1_c* i_this) {
+    return ((daNpc_Gk1_c*)i_this)->_delete();
 }
 
 /* 00002D6C-00002D8C       .text daNpc_Gk1_Execute__FP11daNpc_Gk1_c */
-static BOOL daNpc_Gk1_Execute(daNpc_Gk1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Gk1_Execute(daNpc_Gk1_c* i_this) {
+    return ((daNpc_Gk1_c*)i_this)->_execute();
 }
 
 /* 00002D8C-00002DAC       .text daNpc_Gk1_Draw__FP11daNpc_Gk1_c */
-static BOOL daNpc_Gk1_Draw(daNpc_Gk1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Gk1_Draw(daNpc_Gk1_c* i_this) {
+    return ((daNpc_Gk1_c*)i_this)->_draw();
 }
 
 /* 00002DAC-00002DB4       .text daNpc_Gk1_IsDelete__FP11daNpc_Gk1_c */
 static BOOL daNpc_Gk1_IsDelete(daNpc_Gk1_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daNpc_Gk1_Method = {

--- a/src/d/actor/d_a_npc_gp1.cpp
+++ b/src/d/actor/d_a_npc_gp1.cpp
@@ -303,17 +303,17 @@ void daNpc_Gp1_c::demo() {
 }
 
 /* 00002C6C-00002E24       .text _draw__11daNpc_Gp1_cFv */
-bool daNpc_Gp1_c::_draw() {
+BOOL daNpc_Gp1_c::_draw() {
     /* Nonmatching */
 }
 
 /* 00002E24-00003008       .text _execute__11daNpc_Gp1_cFv */
-bool daNpc_Gp1_c::_execute() {
+BOOL daNpc_Gp1_c::_execute() {
     /* Nonmatching */
 }
 
 /* 00003008-00003064       .text _delete__11daNpc_Gp1_cFv */
-bool daNpc_Gp1_c::_delete() {
+BOOL daNpc_Gp1_c::_delete() {
     /* Nonmatching */
 }
 
@@ -338,28 +338,28 @@ void daNpc_Gp1_c::CreateHeap() {
 }
 
 /* 000039A0-000039C0       .text daNpc_Gp1_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Gp1_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_Gp1_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_Gp1_c*)i_this)->_create();
 }
 
 /* 000039C0-000039E0       .text daNpc_Gp1_Delete__FP11daNpc_Gp1_c */
-static BOOL daNpc_Gp1_Delete(daNpc_Gp1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Gp1_Delete(daNpc_Gp1_c* i_this) {
+    return ((daNpc_Gp1_c*)i_this)->_delete();
 }
 
 /* 000039E0-00003A00       .text daNpc_Gp1_Execute__FP11daNpc_Gp1_c */
-static BOOL daNpc_Gp1_Execute(daNpc_Gp1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Gp1_Execute(daNpc_Gp1_c* i_this) {
+    return ((daNpc_Gp1_c*)i_this)->_execute();
 }
 
 /* 00003A00-00003A20       .text daNpc_Gp1_Draw__FP11daNpc_Gp1_c */
-static BOOL daNpc_Gp1_Draw(daNpc_Gp1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Gp1_Draw(daNpc_Gp1_c* i_this) {
+    return ((daNpc_Gp1_c*)i_this)->_draw();
 }
 
 /* 00003A20-00003A28       .text daNpc_Gp1_IsDelete__FP11daNpc_Gp1_c */
 static BOOL daNpc_Gp1_IsDelete(daNpc_Gp1_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daNpc_Gp1_Method = {

--- a/src/d/actor/d_a_npc_hi1.cpp
+++ b/src/d/actor/d_a_npc_hi1.cpp
@@ -258,17 +258,17 @@ void daNpc_Hi1_c::shadowDraw() {
 }
 
 /* 00001BC4-00001CB4       .text _draw__11daNpc_Hi1_cFv */
-bool daNpc_Hi1_c::_draw() {
+BOOL daNpc_Hi1_c::_draw() {
     /* Nonmatching */
 }
 
 /* 00001CB4-00001EDC       .text _execute__11daNpc_Hi1_cFv */
-bool daNpc_Hi1_c::_execute() {
+BOOL daNpc_Hi1_c::_execute() {
     /* Nonmatching */
 }
 
 /* 00001EDC-00001F30       .text _delete__11daNpc_Hi1_cFv */
-bool daNpc_Hi1_c::_delete() {
+BOOL daNpc_Hi1_c::_delete() {
     /* Nonmatching */
 }
 
@@ -288,28 +288,28 @@ void daNpc_Hi1_c::CreateHeap() {
 }
 
 /* 000027EC-0000280C       .text daNpc_Hi1_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Hi1_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_Hi1_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_Hi1_c*)i_this)->_create();
 }
 
 /* 0000280C-0000282C       .text daNpc_Hi1_Delete__FP11daNpc_Hi1_c */
-static BOOL daNpc_Hi1_Delete(daNpc_Hi1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Hi1_Delete(daNpc_Hi1_c* i_this) {
+    return ((daNpc_Hi1_c*)i_this)->_delete();
 }
 
 /* 0000282C-0000284C       .text daNpc_Hi1_Execute__FP11daNpc_Hi1_c */
-static BOOL daNpc_Hi1_Execute(daNpc_Hi1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Hi1_Execute(daNpc_Hi1_c* i_this) {
+    return ((daNpc_Hi1_c*)i_this)->_execute();
 }
 
 /* 0000284C-0000286C       .text daNpc_Hi1_Draw__FP11daNpc_Hi1_c */
-static BOOL daNpc_Hi1_Draw(daNpc_Hi1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Hi1_Draw(daNpc_Hi1_c* i_this) {
+    return ((daNpc_Hi1_c*)i_this)->_draw();
 }
 
 /* 0000286C-00002874       .text daNpc_Hi1_IsDelete__FP11daNpc_Hi1_c */
 static BOOL daNpc_Hi1_IsDelete(daNpc_Hi1_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daNpc_Hi1_Method = {

--- a/src/d/actor/d_a_npc_ho.cpp
+++ b/src/d/actor/d_a_npc_ho.cpp
@@ -163,17 +163,17 @@ void daNpc_Ho_c::wait_action(void*) {
 }
 
 /* 00001B2C-00001C94       .text _draw__10daNpc_Ho_cFv */
-bool daNpc_Ho_c::_draw() {
+BOOL daNpc_Ho_c::_draw() {
     /* Nonmatching */
 }
 
 /* 00001C94-00001EB0       .text _execute__10daNpc_Ho_cFv */
-bool daNpc_Ho_c::_execute() {
+BOOL daNpc_Ho_c::_execute() {
     /* Nonmatching */
 }
 
 /* 00001EB0-00001EFC       .text _delete__10daNpc_Ho_cFv */
-bool daNpc_Ho_c::_delete() {
+BOOL daNpc_Ho_c::_delete() {
     /* Nonmatching */
 }
 
@@ -193,28 +193,28 @@ void daNpc_Ho_c::CreateHeap() {
 }
 
 /* 00002784-000027A4       .text daNpc_Ho_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Ho_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_Ho_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_Ho_c*)i_this)->_create();
 }
 
 /* 000027A4-000027C4       .text daNpc_Ho_Delete__FP10daNpc_Ho_c */
-static BOOL daNpc_Ho_Delete(daNpc_Ho_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Ho_Delete(daNpc_Ho_c* i_this) {
+    return ((daNpc_Ho_c*)i_this)->_delete();
 }
 
 /* 000027C4-000027E4       .text daNpc_Ho_Execute__FP10daNpc_Ho_c */
-static BOOL daNpc_Ho_Execute(daNpc_Ho_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Ho_Execute(daNpc_Ho_c* i_this) {
+    return ((daNpc_Ho_c*)i_this)->_execute();
 }
 
 /* 000027E4-00002804       .text daNpc_Ho_Draw__FP10daNpc_Ho_c */
-static BOOL daNpc_Ho_Draw(daNpc_Ho_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Ho_Draw(daNpc_Ho_c* i_this) {
+    return ((daNpc_Ho_c*)i_this)->_draw();
 }
 
 /* 00002804-0000280C       .text daNpc_Ho_IsDelete__FP10daNpc_Ho_c */
 static BOOL daNpc_Ho_IsDelete(daNpc_Ho_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daNpc_Ho_Method = {

--- a/src/d/actor/d_a_npc_hr.cpp
+++ b/src/d/actor/d_a_npc_hr.cpp
@@ -433,17 +433,17 @@ void daNpc_Hr_c::wait_action(void*) {
 }
 
 /* 00004CB4-00004E6C       .text _draw__10daNpc_Hr_cFv */
-bool daNpc_Hr_c::_draw() {
+BOOL daNpc_Hr_c::_draw() {
     /* Nonmatching */
 }
 
 /* 00004E6C-000050FC       .text _execute__10daNpc_Hr_cFv */
-bool daNpc_Hr_c::_execute() {
+BOOL daNpc_Hr_c::_execute() {
     /* Nonmatching */
 }
 
 /* 000050FC-00005188       .text _delete__10daNpc_Hr_cFv */
-bool daNpc_Hr_c::_delete() {
+BOOL daNpc_Hr_c::_delete() {
     /* Nonmatching */
 }
 
@@ -463,28 +463,28 @@ void daNpc_Hr_c::CreateHeap() {
 }
 
 /* 00005CE8-00005D08       .text daNpc_Hr_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Hr_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_Hr_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_Hr_c*)i_this)->_create();
 }
 
 /* 00005D08-00005D28       .text daNpc_Hr_Delete__FP10daNpc_Hr_c */
-static BOOL daNpc_Hr_Delete(daNpc_Hr_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Hr_Delete(daNpc_Hr_c* i_this) {
+    return ((daNpc_Hr_c*)i_this)->_delete();
 }
 
 /* 00005D28-00005D48       .text daNpc_Hr_Execute__FP10daNpc_Hr_c */
-static BOOL daNpc_Hr_Execute(daNpc_Hr_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Hr_Execute(daNpc_Hr_c* i_this) {
+    return ((daNpc_Hr_c*)i_this)->_execute();
 }
 
 /* 00005D48-00005D68       .text daNpc_Hr_Draw__FP10daNpc_Hr_c */
-static BOOL daNpc_Hr_Draw(daNpc_Hr_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Hr_Draw(daNpc_Hr_c* i_this) {
+    return ((daNpc_Hr_c*)i_this)->_draw();
 }
 
 /* 00005D68-00005D70       .text daNpc_Hr_IsDelete__FP10daNpc_Hr_c */
 static BOOL daNpc_Hr_IsDelete(daNpc_Hr_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daNpc_Hr_Method = {

--- a/src/d/actor/d_a_npc_jb1.cpp
+++ b/src/d/actor/d_a_npc_jb1.cpp
@@ -168,17 +168,17 @@ void daNpc_Jb1_c::demo() {
 }
 
 /* 00000D58-00000E74       .text _draw__11daNpc_Jb1_cFv */
-bool daNpc_Jb1_c::_draw() {
+BOOL daNpc_Jb1_c::_draw() {
     /* Nonmatching */
 }
 
 /* 00000E74-00000FBC       .text _execute__11daNpc_Jb1_cFv */
-bool daNpc_Jb1_c::_execute() {
+BOOL daNpc_Jb1_c::_execute() {
     /* Nonmatching */
 }
 
 /* 00000FBC-00001054       .text _delete__11daNpc_Jb1_cFv */
-bool daNpc_Jb1_c::_delete() {
+BOOL daNpc_Jb1_c::_delete() {
     /* Nonmatching */
 }
 
@@ -208,28 +208,28 @@ void daNpc_Jb1_c::CreateHeap() {
 }
 
 /* 00001C20-00001C40       .text daNpc_Jb1_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Jb1_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_Jb1_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_Jb1_c*)i_this)->_create();
 }
 
 /* 00001C40-00001C60       .text daNpc_Jb1_Delete__FP11daNpc_Jb1_c */
-static BOOL daNpc_Jb1_Delete(daNpc_Jb1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Jb1_Delete(daNpc_Jb1_c* i_this) {
+    return ((daNpc_Jb1_c*)i_this)->_delete();
 }
 
 /* 00001C60-00001C80       .text daNpc_Jb1_Execute__FP11daNpc_Jb1_c */
-static BOOL daNpc_Jb1_Execute(daNpc_Jb1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Jb1_Execute(daNpc_Jb1_c* i_this) {
+    return ((daNpc_Jb1_c*)i_this)->_execute();
 }
 
 /* 00001C80-00001CA0       .text daNpc_Jb1_Draw__FP11daNpc_Jb1_c */
-static BOOL daNpc_Jb1_Draw(daNpc_Jb1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Jb1_Draw(daNpc_Jb1_c* i_this) {
+    return ((daNpc_Jb1_c*)i_this)->_draw();
 }
 
 /* 00001CA0-00001CA8       .text daNpc_Jb1_IsDelete__FP11daNpc_Jb1_c */
 static BOOL daNpc_Jb1_IsDelete(daNpc_Jb1_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daNpc_Jb1_Method = {

--- a/src/d/actor/d_a_npc_kf1.cpp
+++ b/src/d/actor/d_a_npc_kf1.cpp
@@ -423,17 +423,17 @@ void daNpc_Kf1_c::shadowDraw() {
 }
 
 /* 00003884-0000397C       .text _draw__11daNpc_Kf1_cFv */
-bool daNpc_Kf1_c::_draw() {
+BOOL daNpc_Kf1_c::_draw() {
     /* Nonmatching */
 }
 
 /* 0000397C-00003BC4       .text _execute__11daNpc_Kf1_cFv */
-bool daNpc_Kf1_c::_execute() {
+BOOL daNpc_Kf1_c::_execute() {
     /* Nonmatching */
 }
 
 /* 00003BC4-00003C18       .text _delete__11daNpc_Kf1_cFv */
-bool daNpc_Kf1_c::_delete() {
+BOOL daNpc_Kf1_c::_delete() {
     /* Nonmatching */
 }
 
@@ -458,28 +458,28 @@ void daNpc_Kf1_c::CreateHeap() {
 }
 
 /* 00004590-000045B0       .text daNpc_Kf1_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Kf1_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_Kf1_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_Kf1_c*)i_this)->_create();
 }
 
 /* 000045B0-000045D0       .text daNpc_Kf1_Delete__FP11daNpc_Kf1_c */
-static BOOL daNpc_Kf1_Delete(daNpc_Kf1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Kf1_Delete(daNpc_Kf1_c* i_this) {
+    return ((daNpc_Kf1_c*)i_this)->_delete();
 }
 
 /* 000045D0-000045F0       .text daNpc_Kf1_Execute__FP11daNpc_Kf1_c */
-static BOOL daNpc_Kf1_Execute(daNpc_Kf1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Kf1_Execute(daNpc_Kf1_c* i_this) {
+    return ((daNpc_Kf1_c*)i_this)->_execute();
 }
 
 /* 000045F0-00004610       .text daNpc_Kf1_Draw__FP11daNpc_Kf1_c */
-static BOOL daNpc_Kf1_Draw(daNpc_Kf1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Kf1_Draw(daNpc_Kf1_c* i_this) {
+    return ((daNpc_Kf1_c*)i_this)->_draw();
 }
 
 /* 00004610-00004618       .text daNpc_Kf1_IsDelete__FP11daNpc_Kf1_c */
 static BOOL daNpc_Kf1_IsDelete(daNpc_Kf1_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daNpc_Kf1_Method = {

--- a/src/d/actor/d_a_npc_kf1.cpp
+++ b/src/d/actor/d_a_npc_kf1.cpp
@@ -423,17 +423,17 @@ void daNpc_Kf1_c::shadowDraw() {
 }
 
 /* 00003884-0000397C       .text _draw__11daNpc_Kf1_cFv */
-BOOL daNpc_Kf1_c::_draw() {
+bool daNpc_Kf1_c::_draw() {
     /* Nonmatching */
 }
 
 /* 0000397C-00003BC4       .text _execute__11daNpc_Kf1_cFv */
-BOOL daNpc_Kf1_c::_execute() {
+bool daNpc_Kf1_c::_execute() {
     /* Nonmatching */
 }
 
 /* 00003BC4-00003C18       .text _delete__11daNpc_Kf1_cFv */
-BOOL daNpc_Kf1_c::_delete() {
+bool daNpc_Kf1_c::_delete() {
     /* Nonmatching */
 }
 
@@ -458,28 +458,28 @@ void daNpc_Kf1_c::CreateHeap() {
 }
 
 /* 00004590-000045B0       .text daNpc_Kf1_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Kf1_Create(fopAc_ac_c* i_this) {
-    return ((daNpc_Kf1_c*)i_this)->_create();
+static cPhs_State daNpc_Kf1_Create(fopAc_ac_c*) {
+    /* Nonmatching */
 }
 
 /* 000045B0-000045D0       .text daNpc_Kf1_Delete__FP11daNpc_Kf1_c */
-static BOOL daNpc_Kf1_Delete(daNpc_Kf1_c* i_this) {
-    return ((daNpc_Kf1_c*)i_this)->_delete();
+static BOOL daNpc_Kf1_Delete(daNpc_Kf1_c*) {
+    /* Nonmatching */
 }
 
 /* 000045D0-000045F0       .text daNpc_Kf1_Execute__FP11daNpc_Kf1_c */
-static BOOL daNpc_Kf1_Execute(daNpc_Kf1_c* i_this) {
-    return ((daNpc_Kf1_c*)i_this)->_execute();
+static BOOL daNpc_Kf1_Execute(daNpc_Kf1_c*) {
+    /* Nonmatching */
 }
 
 /* 000045F0-00004610       .text daNpc_Kf1_Draw__FP11daNpc_Kf1_c */
-static BOOL daNpc_Kf1_Draw(daNpc_Kf1_c* i_this) {
-    return ((daNpc_Kf1_c*)i_this)->_draw();
+static BOOL daNpc_Kf1_Draw(daNpc_Kf1_c*) {
+    /* Nonmatching */
 }
 
 /* 00004610-00004618       .text daNpc_Kf1_IsDelete__FP11daNpc_Kf1_c */
 static BOOL daNpc_Kf1_IsDelete(daNpc_Kf1_c*) {
-    return TRUE;
+    /* Nonmatching */
 }
 
 static actor_method_class l_daNpc_Kf1_Method = {

--- a/src/d/actor/d_a_npc_kg1.cpp
+++ b/src/d/actor/d_a_npc_kg1.cpp
@@ -146,8 +146,8 @@ void daNpc_Kg1_c::setAnm() {
 }
 
 /* 00001F8C-00001FAC       .text daNpc_Kg1Create__FPv */
-static s32 daNpc_Kg1Create(void*) {
-    /* Nonmatching */
+static s32 daNpc_Kg1Create(void* i_this) {
+    return ((daNpc_Kg1_c*)i_this)->_create();
 }
 
 /* 00001FAC-0000203C       .text _create__11daNpc_Kg1_cFv */
@@ -172,7 +172,7 @@ static BOOL daNpc_Kg1Draw(void*) {
 
 /* 000027CC-000027D4       .text daNpc_Kg1IsDelete__FPv */
 static BOOL daNpc_Kg1IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daNpc_Kg1MethodTable = {

--- a/src/d/actor/d_a_npc_kg2.cpp
+++ b/src/d/actor/d_a_npc_kg2.cpp
@@ -196,43 +196,43 @@ cPhs_State daNpc_Kg2_c::_create() {
 }
 
 /* 00002B6C-00002BFC       .text _delete__11daNpc_Kg2_cFv */
-bool daNpc_Kg2_c::_delete() {
+BOOL daNpc_Kg2_c::_delete() {
     /* Nonmatching */
 }
 
 /* 00002BFC-00002D14       .text _execute__11daNpc_Kg2_cFv */
-bool daNpc_Kg2_c::_execute() {
+BOOL daNpc_Kg2_c::_execute() {
     /* Nonmatching */
 }
 
 /* 00002D14-00002E74       .text _draw__11daNpc_Kg2_cFv */
-bool daNpc_Kg2_c::_draw() {
+BOOL daNpc_Kg2_c::_draw() {
     /* Nonmatching */
 }
 
 /* 00002E74-00002E94       .text daNpc_Kg2_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Kg2_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_Kg2_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_Kg2_c*)i_this)->_create();
 }
 
 /* 00002E94-00002EB4       .text daNpc_Kg2_Delete__FP11daNpc_Kg2_c */
-static BOOL daNpc_Kg2_Delete(daNpc_Kg2_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Kg2_Delete(daNpc_Kg2_c* i_this) {
+    return ((daNpc_Kg2_c*)i_this)->_delete();
 }
 
 /* 00002EB4-00002ED4       .text daNpc_Kg2_Execute__FP11daNpc_Kg2_c */
-static BOOL daNpc_Kg2_Execute(daNpc_Kg2_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Kg2_Execute(daNpc_Kg2_c* i_this) {
+    return ((daNpc_Kg2_c*)i_this)->_execute();
 }
 
 /* 00002ED4-00002EF4       .text daNpc_Kg2_Draw__FP11daNpc_Kg2_c */
-static BOOL daNpc_Kg2_Draw(daNpc_Kg2_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Kg2_Draw(daNpc_Kg2_c* i_this) {
+    return ((daNpc_Kg2_c*)i_this)->_draw();
 }
 
 /* 00002EF4-00002EFC       .text daNpc_Kg2_IsDelete__FP11daNpc_Kg2_c */
 static BOOL daNpc_Kg2_IsDelete(daNpc_Kg2_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daNpc_Kg2_Method = {

--- a/src/d/actor/d_a_npc_kk1.cpp
+++ b/src/d/actor/d_a_npc_kk1.cpp
@@ -533,17 +533,17 @@ void daNpc_Kk1_c::shadowDraw() {
 }
 
 /* 000055C4-00005798       .text _draw__11daNpc_Kk1_cFv */
-bool daNpc_Kk1_c::_draw() {
+BOOL daNpc_Kk1_c::_draw() {
     /* Nonmatching */
 }
 
 /* 00005798-000059EC       .text _execute__11daNpc_Kk1_cFv */
-bool daNpc_Kk1_c::_execute() {
+BOOL daNpc_Kk1_c::_execute() {
     /* Nonmatching */
 }
 
 /* 000059EC-00005A58       .text _delete__11daNpc_Kk1_cFv */
-bool daNpc_Kk1_c::_delete() {
+BOOL daNpc_Kk1_c::_delete() {
     /* Nonmatching */
 }
 
@@ -568,28 +568,28 @@ void daNpc_Kk1_c::CreateHeap() {
 }
 
 /* 00006684-000066A4       .text daNpc_Kk1_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Kk1_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_Kk1_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_Kk1_c*)i_this)->_create();
 }
 
 /* 000066A4-000066C4       .text daNpc_Kk1_Delete__FP11daNpc_Kk1_c */
-static BOOL daNpc_Kk1_Delete(daNpc_Kk1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Kk1_Delete(daNpc_Kk1_c* i_this) {
+    return ((daNpc_Kk1_c*)i_this)->_delete();
 }
 
 /* 000066C4-000066E4       .text daNpc_Kk1_Execute__FP11daNpc_Kk1_c */
-static BOOL daNpc_Kk1_Execute(daNpc_Kk1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Kk1_Execute(daNpc_Kk1_c* i_this) {
+    return ((daNpc_Kk1_c*)i_this)->_execute();
 }
 
 /* 000066E4-00006704       .text daNpc_Kk1_Draw__FP11daNpc_Kk1_c */
-static BOOL daNpc_Kk1_Draw(daNpc_Kk1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Kk1_Draw(daNpc_Kk1_c* i_this) {
+    return ((daNpc_Kk1_c*)i_this)->_draw();
 }
 
 /* 00006704-0000670C       .text daNpc_Kk1_IsDelete__FP11daNpc_Kk1_c */
 static BOOL daNpc_Kk1_IsDelete(daNpc_Kk1_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daNpc_Kk1_Method = {

--- a/src/d/actor/d_a_npc_kk1.cpp
+++ b/src/d/actor/d_a_npc_kk1.cpp
@@ -533,17 +533,17 @@ void daNpc_Kk1_c::shadowDraw() {
 }
 
 /* 000055C4-00005798       .text _draw__11daNpc_Kk1_cFv */
-BOOL daNpc_Kk1_c::_draw() {
+bool daNpc_Kk1_c::_draw() {
     /* Nonmatching */
 }
 
 /* 00005798-000059EC       .text _execute__11daNpc_Kk1_cFv */
-BOOL daNpc_Kk1_c::_execute() {
+bool daNpc_Kk1_c::_execute() {
     /* Nonmatching */
 }
 
 /* 000059EC-00005A58       .text _delete__11daNpc_Kk1_cFv */
-BOOL daNpc_Kk1_c::_delete() {
+bool daNpc_Kk1_c::_delete() {
     /* Nonmatching */
 }
 
@@ -568,28 +568,28 @@ void daNpc_Kk1_c::CreateHeap() {
 }
 
 /* 00006684-000066A4       .text daNpc_Kk1_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Kk1_Create(fopAc_ac_c* i_this) {
-    return ((daNpc_Kk1_c*)i_this)->_create();
+static cPhs_State daNpc_Kk1_Create(fopAc_ac_c*) {
+    /* Nonmatching */
 }
 
 /* 000066A4-000066C4       .text daNpc_Kk1_Delete__FP11daNpc_Kk1_c */
-static BOOL daNpc_Kk1_Delete(daNpc_Kk1_c* i_this) {
-    return ((daNpc_Kk1_c*)i_this)->_delete();
+static BOOL daNpc_Kk1_Delete(daNpc_Kk1_c*) {
+    /* Nonmatching */
 }
 
 /* 000066C4-000066E4       .text daNpc_Kk1_Execute__FP11daNpc_Kk1_c */
-static BOOL daNpc_Kk1_Execute(daNpc_Kk1_c* i_this) {
-    return ((daNpc_Kk1_c*)i_this)->_execute();
+static BOOL daNpc_Kk1_Execute(daNpc_Kk1_c*) {
+    /* Nonmatching */
 }
 
 /* 000066E4-00006704       .text daNpc_Kk1_Draw__FP11daNpc_Kk1_c */
-static BOOL daNpc_Kk1_Draw(daNpc_Kk1_c* i_this) {
-    return ((daNpc_Kk1_c*)i_this)->_draw();
+static BOOL daNpc_Kk1_Draw(daNpc_Kk1_c*) {
+    /* Nonmatching */
 }
 
 /* 00006704-0000670C       .text daNpc_Kk1_IsDelete__FP11daNpc_Kk1_c */
 static BOOL daNpc_Kk1_IsDelete(daNpc_Kk1_c*) {
-    return TRUE;
+    /* Nonmatching */
 }
 
 static actor_method_class l_daNpc_Kk1_Method = {

--- a/src/d/actor/d_a_npc_km1.cpp
+++ b/src/d/actor/d_a_npc_km1.cpp
@@ -194,17 +194,17 @@ void daNpc_Km1_c::demo() {
 }
 
 /* 00001548-000016AC       .text _draw__11daNpc_Km1_cFv */
-BOOL daNpc_Km1_c::_draw() {
+bool daNpc_Km1_c::_draw() {
     /* Nonmatching */
 }
 
 /* 000016AC-00001808       .text _execute__11daNpc_Km1_cFv */
-BOOL daNpc_Km1_c::_execute() {
+bool daNpc_Km1_c::_execute() {
     /* Nonmatching */
 }
 
 /* 00001808-0000188C       .text _delete__11daNpc_Km1_cFv */
-BOOL daNpc_Km1_c::_delete() {
+bool daNpc_Km1_c::_delete() {
     /* Nonmatching */
 }
 
@@ -224,28 +224,28 @@ void daNpc_Km1_c::CreateHeap() {
 }
 
 /* 00002158-00002178       .text daNpc_Km1_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Km1_Create(fopAc_ac_c* i_this) {
-    return ((daNpc_Km1_c*)i_this)->_create();
+static cPhs_State daNpc_Km1_Create(fopAc_ac_c*) {
+    /* Nonmatching */
 }
 
 /* 00002178-00002198       .text daNpc_Km1_Delete__FP11daNpc_Km1_c */
-static BOOL daNpc_Km1_Delete(daNpc_Km1_c* i_this) {
-    return ((daNpc_Km1_c*)i_this)->_delete();
+static BOOL daNpc_Km1_Delete(daNpc_Km1_c*) {
+    /* Nonmatching */
 }
 
 /* 00002198-000021B8       .text daNpc_Km1_Execute__FP11daNpc_Km1_c */
-static BOOL daNpc_Km1_Execute(daNpc_Km1_c* i_this) {
-    return ((daNpc_Km1_c*)i_this)->_execute();
+static BOOL daNpc_Km1_Execute(daNpc_Km1_c*) {
+    /* Nonmatching */
 }
 
 /* 000021B8-000021D8       .text daNpc_Km1_Draw__FP11daNpc_Km1_c */
-static BOOL daNpc_Km1_Draw(daNpc_Km1_c* i_this) {
-    return ((daNpc_Km1_c*)i_this)->_draw();
+static BOOL daNpc_Km1_Draw(daNpc_Km1_c*) {
+    /* Nonmatching */
 }
 
 /* 000021D8-000021E0       .text daNpc_Km1_IsDelete__FP11daNpc_Km1_c */
 static BOOL daNpc_Km1_IsDelete(daNpc_Km1_c*) {
-    return TRUE;
+    /* Nonmatching */
 }
 
 static actor_method_class l_daNpc_Km1_Method = {

--- a/src/d/actor/d_a_npc_km1.cpp
+++ b/src/d/actor/d_a_npc_km1.cpp
@@ -194,17 +194,17 @@ void daNpc_Km1_c::demo() {
 }
 
 /* 00001548-000016AC       .text _draw__11daNpc_Km1_cFv */
-bool daNpc_Km1_c::_draw() {
+BOOL daNpc_Km1_c::_draw() {
     /* Nonmatching */
 }
 
 /* 000016AC-00001808       .text _execute__11daNpc_Km1_cFv */
-bool daNpc_Km1_c::_execute() {
+BOOL daNpc_Km1_c::_execute() {
     /* Nonmatching */
 }
 
 /* 00001808-0000188C       .text _delete__11daNpc_Km1_cFv */
-bool daNpc_Km1_c::_delete() {
+BOOL daNpc_Km1_c::_delete() {
     /* Nonmatching */
 }
 
@@ -224,28 +224,28 @@ void daNpc_Km1_c::CreateHeap() {
 }
 
 /* 00002158-00002178       .text daNpc_Km1_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Km1_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_Km1_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_Km1_c*)i_this)->_create();
 }
 
 /* 00002178-00002198       .text daNpc_Km1_Delete__FP11daNpc_Km1_c */
-static BOOL daNpc_Km1_Delete(daNpc_Km1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Km1_Delete(daNpc_Km1_c* i_this) {
+    return ((daNpc_Km1_c*)i_this)->_delete();
 }
 
 /* 00002198-000021B8       .text daNpc_Km1_Execute__FP11daNpc_Km1_c */
-static BOOL daNpc_Km1_Execute(daNpc_Km1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Km1_Execute(daNpc_Km1_c* i_this) {
+    return ((daNpc_Km1_c*)i_this)->_execute();
 }
 
 /* 000021B8-000021D8       .text daNpc_Km1_Draw__FP11daNpc_Km1_c */
-static BOOL daNpc_Km1_Draw(daNpc_Km1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Km1_Draw(daNpc_Km1_c* i_this) {
+    return ((daNpc_Km1_c*)i_this)->_draw();
 }
 
 /* 000021D8-000021E0       .text daNpc_Km1_IsDelete__FP11daNpc_Km1_c */
 static BOOL daNpc_Km1_IsDelete(daNpc_Km1_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daNpc_Km1_Method = {

--- a/src/d/actor/d_a_npc_ko1.cpp
+++ b/src/d/actor/d_a_npc_ko1.cpp
@@ -628,17 +628,17 @@ void daNpc_Ko1_c::shadowDraw() {
 }
 
 /* 00007008-0000728C       .text _draw__11daNpc_Ko1_cFv */
-bool daNpc_Ko1_c::_draw() {
+BOOL daNpc_Ko1_c::_draw() {
     /* Nonmatching */
 }
 
 /* 0000728C-0000756C       .text _execute__11daNpc_Ko1_cFv */
-bool daNpc_Ko1_c::_execute() {
+BOOL daNpc_Ko1_c::_execute() {
     /* Nonmatching */
 }
 
 /* 0000756C-000075F0       .text _delete__11daNpc_Ko1_cFv */
-bool daNpc_Ko1_c::_delete() {
+BOOL daNpc_Ko1_c::_delete() {
     /* Nonmatching */
 }
 
@@ -678,28 +678,28 @@ void daNpc_Ko1_c::CreateHeap() {
 }
 
 /* 00008604-00008624       .text daNpc_Ko1_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Ko1_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_Ko1_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_Ko1_c*)i_this)->_create();
 }
 
 /* 00008624-00008644       .text daNpc_Ko1_Delete__FP11daNpc_Ko1_c */
-static BOOL daNpc_Ko1_Delete(daNpc_Ko1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Ko1_Delete(daNpc_Ko1_c* i_this) {
+    return ((daNpc_Ko1_c*)i_this)->_delete();
 }
 
 /* 00008644-00008664       .text daNpc_Ko1_Execute__FP11daNpc_Ko1_c */
-static BOOL daNpc_Ko1_Execute(daNpc_Ko1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Ko1_Execute(daNpc_Ko1_c* i_this) {
+    return ((daNpc_Ko1_c*)i_this)->_execute();
 }
 
 /* 00008664-00008684       .text daNpc_Ko1_Draw__FP11daNpc_Ko1_c */
-static BOOL daNpc_Ko1_Draw(daNpc_Ko1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Ko1_Draw(daNpc_Ko1_c* i_this) {
+    return ((daNpc_Ko1_c*)i_this)->_draw();
 }
 
 /* 00008684-0000868C       .text daNpc_Ko1_IsDelete__FP11daNpc_Ko1_c */
 static BOOL daNpc_Ko1_IsDelete(daNpc_Ko1_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daNpc_Ko1_Method = {

--- a/src/d/actor/d_a_npc_kp1.cpp
+++ b/src/d/actor/d_a_npc_kp1.cpp
@@ -209,17 +209,17 @@ void daNpc_Kp1_c::shadowDraw() {
 }
 
 /* 00001E9C-00001FA4       .text _draw__11daNpc_Kp1_cFv */
-bool daNpc_Kp1_c::_draw() {
+BOOL daNpc_Kp1_c::_draw() {
     /* Nonmatching */
 }
 
 /* 00001FA4-00002100       .text _execute__11daNpc_Kp1_cFv */
-bool daNpc_Kp1_c::_execute() {
+BOOL daNpc_Kp1_c::_execute() {
     /* Nonmatching */
 }
 
 /* 00002100-0000215C       .text _delete__11daNpc_Kp1_cFv */
-bool daNpc_Kp1_c::_delete() {
+BOOL daNpc_Kp1_c::_delete() {
     /* Nonmatching */
 }
 
@@ -239,28 +239,28 @@ void daNpc_Kp1_c::CreateHeap() {
 }
 
 /* 00002B14-00002B34       .text daNpc_Kp1_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Kp1_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_Kp1_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_Kp1_c*)i_this)->_create();
 }
 
 /* 00002B34-00002B54       .text daNpc_Kp1_Delete__FP11daNpc_Kp1_c */
-static BOOL daNpc_Kp1_Delete(daNpc_Kp1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Kp1_Delete(daNpc_Kp1_c* i_this) {
+    return ((daNpc_Kp1_c*)i_this)->_delete();
 }
 
 /* 00002B54-00002B74       .text daNpc_Kp1_Execute__FP11daNpc_Kp1_c */
-static BOOL daNpc_Kp1_Execute(daNpc_Kp1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Kp1_Execute(daNpc_Kp1_c* i_this) {
+    return ((daNpc_Kp1_c*)i_this)->_execute();
 }
 
 /* 00002B74-00002B94       .text daNpc_Kp1_Draw__FP11daNpc_Kp1_c */
-static BOOL daNpc_Kp1_Draw(daNpc_Kp1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Kp1_Draw(daNpc_Kp1_c* i_this) {
+    return ((daNpc_Kp1_c*)i_this)->_draw();
 }
 
 /* 00002B94-00002B9C       .text daNpc_Kp1_IsDelete__FP11daNpc_Kp1_c */
 static BOOL daNpc_Kp1_IsDelete(daNpc_Kp1_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daNpc_Kp1_Method = {

--- a/src/d/actor/d_a_npc_ls1.cpp
+++ b/src/d/actor/d_a_npc_ls1.cpp
@@ -463,17 +463,17 @@ void daNpc_Ls1_c::shadowDraw() {
 }
 
 /* 00004288-00004418       .text _draw__11daNpc_Ls1_cFv */
-bool daNpc_Ls1_c::_draw() {
+BOOL daNpc_Ls1_c::_draw() {
     /* Nonmatching */
 }
 
 /* 00004418-00004654       .text _execute__11daNpc_Ls1_cFv */
-bool daNpc_Ls1_c::_execute() {
+BOOL daNpc_Ls1_c::_execute() {
     /* Nonmatching */
 }
 
 /* 00004654-000046A8       .text _delete__11daNpc_Ls1_cFv */
-bool daNpc_Ls1_c::_delete() {
+BOOL daNpc_Ls1_c::_delete() {
     /* Nonmatching */
 }
 
@@ -503,28 +503,28 @@ void daNpc_Ls1_c::CreateHeap() {
 }
 
 /* 000055BC-000055DC       .text daNpc_Ls1_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Ls1_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_Ls1_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_Ls1_c*)i_this)->_create();
 }
 
 /* 000055DC-000055FC       .text daNpc_Ls1_Delete__FP11daNpc_Ls1_c */
-static BOOL daNpc_Ls1_Delete(daNpc_Ls1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Ls1_Delete(daNpc_Ls1_c* i_this) {
+    return ((daNpc_Ls1_c*)i_this)->_delete();
 }
 
 /* 000055FC-0000561C       .text daNpc_Ls1_Execute__FP11daNpc_Ls1_c */
-static BOOL daNpc_Ls1_Execute(daNpc_Ls1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Ls1_Execute(daNpc_Ls1_c* i_this) {
+    return ((daNpc_Ls1_c*)i_this)->_execute();
 }
 
 /* 0000561C-0000563C       .text daNpc_Ls1_Draw__FP11daNpc_Ls1_c */
-static BOOL daNpc_Ls1_Draw(daNpc_Ls1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Ls1_Draw(daNpc_Ls1_c* i_this) {
+    return ((daNpc_Ls1_c*)i_this)->_draw();
 }
 
 /* 0000563C-00005644       .text daNpc_Ls1_IsDelete__FP11daNpc_Ls1_c */
 static BOOL daNpc_Ls1_IsDelete(daNpc_Ls1_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daNpc_Ls1_Method = {

--- a/src/d/actor/d_a_npc_mk.cpp
+++ b/src/d/actor/d_a_npc_mk.cpp
@@ -274,17 +274,17 @@ void daNpc_Mk_c::visit_action(void*) {
 }
 
 /* 00003C7C-00003DA0       .text _draw__10daNpc_Mk_cFv */
-bool daNpc_Mk_c::_draw() {
+BOOL daNpc_Mk_c::_draw() {
     /* Nonmatching */
 }
 
 /* 00003DA0-00004010       .text _execute__10daNpc_Mk_cFv */
-bool daNpc_Mk_c::_execute() {
+BOOL daNpc_Mk_c::_execute() {
     /* Nonmatching */
 }
 
 /* 00004010-0000405C       .text _delete__10daNpc_Mk_cFv */
-bool daNpc_Mk_c::_delete() {
+BOOL daNpc_Mk_c::_delete() {
     /* Nonmatching */
 }
 
@@ -304,28 +304,28 @@ void daNpc_Mk_c::CreateHeap() {
 }
 
 /* 00004954-00004974       .text daNpc_Mk_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Mk_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_Mk_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_Mk_c*)i_this)->_create();
 }
 
 /* 00004974-00004994       .text daNpc_Mk_Delete__FP10daNpc_Mk_c */
-static BOOL daNpc_Mk_Delete(daNpc_Mk_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Mk_Delete(daNpc_Mk_c* i_this) {
+    return ((daNpc_Mk_c*)i_this)->_delete();
 }
 
 /* 00004994-000049B4       .text daNpc_Mk_Execute__FP10daNpc_Mk_c */
-static BOOL daNpc_Mk_Execute(daNpc_Mk_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Mk_Execute(daNpc_Mk_c* i_this) {
+    return ((daNpc_Mk_c*)i_this)->_execute();
 }
 
 /* 000049B4-000049D4       .text daNpc_Mk_Draw__FP10daNpc_Mk_c */
-static BOOL daNpc_Mk_Draw(daNpc_Mk_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Mk_Draw(daNpc_Mk_c* i_this) {
+    return ((daNpc_Mk_c*)i_this)->_draw();
 }
 
 /* 000049D4-000049DC       .text daNpc_Mk_IsDelete__FP10daNpc_Mk_c */
 static BOOL daNpc_Mk_IsDelete(daNpc_Mk_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daNpc_Mk_Method = {

--- a/src/d/actor/d_a_npc_mn.cpp
+++ b/src/d/actor/d_a_npc_mn.cpp
@@ -379,28 +379,28 @@ void daNpcMn_c::isChangePos(unsigned char) {
 }
 
 /* 00003CE8-00003D08       .text daNpc_MnCreate__FPv */
-static s32 daNpc_MnCreate(void*) {
-    /* Nonmatching */
+static s32 daNpc_MnCreate(void* i_this) {
+    return ((daNpcMn_c*)i_this)->_create();
 }
 
 /* 00003D08-00003D2C       .text daNpc_MnDelete__FPv */
-static BOOL daNpc_MnDelete(void*) {
-    /* Nonmatching */
+static BOOL daNpc_MnDelete(void* i_this) {
+    return ((daNpcMn_c*)i_this)->_delete();
 }
 
 /* 00003D2C-00003D50       .text daNpc_MnExecute__FPv */
-static BOOL daNpc_MnExecute(void*) {
-    /* Nonmatching */
+static BOOL daNpc_MnExecute(void* i_this) {
+    return ((daNpcMn_c*)i_this)->_execute();
 }
 
 /* 00003D50-00003D74       .text daNpc_MnDraw__FPv */
-static BOOL daNpc_MnDraw(void*) {
-    /* Nonmatching */
+static BOOL daNpc_MnDraw(void* i_this) {
+    return ((daNpcMn_c*)i_this)->_draw();
 }
 
 /* 00003D74-00003D7C       .text daNpc_MnIsDelete__FPv */
 static BOOL daNpc_MnIsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daNpc_MnMethodTable = {

--- a/src/d/actor/d_a_npc_mt.cpp
+++ b/src/d/actor/d_a_npc_mt.cpp
@@ -294,28 +294,28 @@ void daNpcMt_c::changePhotoNo(u8) {
 }
 
 /* 00002D4C-00002D6C       .text daNpc_MtCreate__FPv */
-static s32 daNpc_MtCreate(void*) {
-    /* Nonmatching */
+static s32 daNpc_MtCreate(void* i_this) {
+    return ((daNpcMt_c*)i_this)->_create();
 }
 
 /* 00002D6C-00002D90       .text daNpc_MtDelete__FPv */
-static BOOL daNpc_MtDelete(void*) {
-    /* Nonmatching */
+static BOOL daNpc_MtDelete(void* i_this) {
+    return ((daNpcMt_c*)i_this)->_delete();
 }
 
 /* 00002D90-00002DB4       .text daNpc_MtExecute__FPv */
-static BOOL daNpc_MtExecute(void*) {
-    /* Nonmatching */
+static BOOL daNpc_MtExecute(void* i_this) {
+    return ((daNpcMt_c*)i_this)->_execute();
 }
 
 /* 00002DB4-00002DD8       .text daNpc_MtDraw__FPv */
-static BOOL daNpc_MtDraw(void*) {
-    /* Nonmatching */
+static BOOL daNpc_MtDraw(void* i_this) {
+    return ((daNpcMt_c*)i_this)->_draw();
 }
 
 /* 00002DD8-00002DE0       .text daNpc_MtIsDelete__FPv */
 static BOOL daNpc_MtIsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daNpc_MtMethodTable = {

--- a/src/d/actor/d_a_npc_ob1.cpp
+++ b/src/d/actor/d_a_npc_ob1.cpp
@@ -333,17 +333,17 @@ void daNpc_Ob1_c::shadowDraw() {
 }
 
 /* 00002F18-0000300C       .text _draw__11daNpc_Ob1_cFv */
-bool daNpc_Ob1_c::_draw() {
+BOOL daNpc_Ob1_c::_draw() {
     /* Nonmatching */
 }
 
 /* 0000300C-000031F0       .text _execute__11daNpc_Ob1_cFv */
-bool daNpc_Ob1_c::_execute() {
+BOOL daNpc_Ob1_c::_execute() {
     /* Nonmatching */
 }
 
 /* 000031F0-0000324C       .text _delete__11daNpc_Ob1_cFv */
-bool daNpc_Ob1_c::_delete() {
+BOOL daNpc_Ob1_c::_delete() {
     /* Nonmatching */
 }
 
@@ -373,28 +373,28 @@ void daNpc_Ob1_c::CreateHeap() {
 }
 
 /* 00003BE8-00003C08       .text daNpc_Ob1_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Ob1_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_Ob1_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_Ob1_c*)i_this)->_create();
 }
 
 /* 00003C08-00003C28       .text daNpc_Ob1_Delete__FP11daNpc_Ob1_c */
-static BOOL daNpc_Ob1_Delete(daNpc_Ob1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Ob1_Delete(daNpc_Ob1_c* i_this) {
+    return ((daNpc_Ob1_c*)i_this)->_delete();
 }
 
 /* 00003C28-00003C48       .text daNpc_Ob1_Execute__FP11daNpc_Ob1_c */
-static BOOL daNpc_Ob1_Execute(daNpc_Ob1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Ob1_Execute(daNpc_Ob1_c* i_this) {
+    return ((daNpc_Ob1_c*)i_this)->_execute();
 }
 
 /* 00003C48-00003C68       .text daNpc_Ob1_Draw__FP11daNpc_Ob1_c */
-static BOOL daNpc_Ob1_Draw(daNpc_Ob1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Ob1_Draw(daNpc_Ob1_c* i_this) {
+    return ((daNpc_Ob1_c*)i_this)->_draw();
 }
 
 /* 00003C68-00003C70       .text daNpc_Ob1_IsDelete__FP11daNpc_Ob1_c */
 static BOOL daNpc_Ob1_IsDelete(daNpc_Ob1_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daNpc_Ob1_Method = {

--- a/src/d/actor/d_a_npc_p1.cpp
+++ b/src/d/actor/d_a_npc_p1.cpp
@@ -146,8 +146,8 @@ static BOOL nodeCallBack1(J3DNode*, int) {
 }
 
 /* 00002A7C-00002A9C       .text daNpc_P1_Draw__FP10daNpc_P1_c */
-static BOOL daNpc_P1_Draw(daNpc_P1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_P1_Draw(daNpc_P1_c* i_this) {
+    return ((daNpc_P1_c*)i_this)->_draw();
 }
 
 /* 00002A9C-00002ABC       .text CheckCreateHeap__FP10fopAc_ac_c */
@@ -171,7 +171,7 @@ void daNpc_P1_c::CreateHeap() {
 }
 
 /* 00003D6C-00003DF8       .text _delete__10daNpc_P1_cFv */
-bool daNpc_P1_c::_delete() {
+BOOL daNpc_P1_c::_delete() {
     /* Nonmatching */
 }
 
@@ -186,12 +186,12 @@ void daNpc_P1_c::kaji_anm() {
 }
 
 /* 000043CC-0000458C       .text _execute__10daNpc_P1_cFv */
-bool daNpc_P1_c::_execute() {
+BOOL daNpc_P1_c::_execute() {
     /* Nonmatching */
 }
 
 /* 0000458C-00004814       .text _draw__10daNpc_P1_cFv */
-bool daNpc_P1_c::_draw() {
+BOOL daNpc_P1_c::_draw() {
     /* Nonmatching */
 }
 
@@ -201,23 +201,24 @@ void daNpc_P1_c::lookBack() {
 }
 
 /* 00004BA0-00004BC4       .text daNpc_P1_Execute__FP10daNpc_P1_c */
-static BOOL daNpc_P1_Execute(daNpc_P1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_P1_Execute(daNpc_P1_c* i_this) {
+    ((daNpc_P1_c*)i_this)->_execute();
+    return TRUE;
 }
 
 /* 00004BC4-00004BCC       .text daNpc_P1_IsDelete__FP10daNpc_P1_c */
 static BOOL daNpc_P1_IsDelete(daNpc_P1_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00004BCC-00004BEC       .text daNpc_P1_Delete__FP10daNpc_P1_c */
-static BOOL daNpc_P1_Delete(daNpc_P1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_P1_Delete(daNpc_P1_c* i_this) {
+    return ((daNpc_P1_c*)i_this)->_delete();
 }
 
 /* 00004BEC-00004C0C       .text daNpc_P1_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_P1_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_P1_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_P1_c*)i_this)->_create();
 }
 
 static actor_method_class l_daNpc_P1_Method = {

--- a/src/d/actor/d_a_npc_p2.cpp
+++ b/src/d/actor/d_a_npc_p2.cpp
@@ -304,28 +304,28 @@ bool daNpc_P2_c::_delete() {
 }
 
 /* 00004D54-00004D74       .text daNpc_P2Create__FPv */
-static s32 daNpc_P2Create(void*) {
-    /* Nonmatching */
+static s32 daNpc_P2Create(void* i_this) {
+    return ((daNpc_P2_c*)i_this)->_create();
 }
 
 /* 00004D74-00004D98       .text daNpc_P2Delete__FPv */
-static BOOL daNpc_P2Delete(void*) {
-    /* Nonmatching */
+static BOOL daNpc_P2Delete(void* i_this) {
+    return ((daNpc_P2_c*)i_this)->_delete();
 }
 
 /* 00004D98-00004DBC       .text daNpc_P2Execute__FPv */
-static BOOL daNpc_P2Execute(void*) {
-    /* Nonmatching */
+static BOOL daNpc_P2Execute(void* i_this) {
+    return ((daNpc_P2_c*)i_this)->_execute();
 }
 
 /* 00004DBC-00004DE0       .text daNpc_P2Draw__FPv */
-static BOOL daNpc_P2Draw(void*) {
-    /* Nonmatching */
+static BOOL daNpc_P2Draw(void* i_this) {
+    return ((daNpc_P2_c*)i_this)->_draw();
 }
 
 /* 00004DE0-00004DE8       .text daNpc_P2IsDelete__FPv */
 static BOOL daNpc_P2IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00005238-00005528       .text cutProc__10daNpc_P2_cFv */

--- a/src/d/actor/d_a_npc_pf1.cpp
+++ b/src/d/actor/d_a_npc_pf1.cpp
@@ -308,17 +308,17 @@ void daNpc_Pf1_c::shadowDraw() {
 }
 
 /* 00002C5C-00002D30       .text _draw__11daNpc_Pf1_cFv */
-bool daNpc_Pf1_c::_draw() {
+BOOL daNpc_Pf1_c::_draw() {
     /* Nonmatching */
 }
 
 /* 00002D30-00002F94       .text _execute__11daNpc_Pf1_cFv */
-bool daNpc_Pf1_c::_execute() {
+BOOL daNpc_Pf1_c::_execute() {
     /* Nonmatching */
 }
 
 /* 00002F94-00002FF8       .text _delete__11daNpc_Pf1_cFv */
-bool daNpc_Pf1_c::_delete() {
+BOOL daNpc_Pf1_c::_delete() {
     /* Nonmatching */
 }
 
@@ -338,28 +338,28 @@ void daNpc_Pf1_c::CreateHeap() {
 }
 
 /* 0000381C-0000383C       .text daNpc_Pf1_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Pf1_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_Pf1_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_Pf1_c*)i_this)->_create();
 }
 
 /* 0000383C-0000385C       .text daNpc_Pf1_Delete__FP11daNpc_Pf1_c */
-static BOOL daNpc_Pf1_Delete(daNpc_Pf1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Pf1_Delete(daNpc_Pf1_c* i_this) {
+    return ((daNpc_Pf1_c*)i_this)->_delete();
 }
 
 /* 0000385C-0000387C       .text daNpc_Pf1_Execute__FP11daNpc_Pf1_c */
-static BOOL daNpc_Pf1_Execute(daNpc_Pf1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Pf1_Execute(daNpc_Pf1_c* i_this) {
+    return ((daNpc_Pf1_c*)i_this)->_execute();
 }
 
 /* 0000387C-0000389C       .text daNpc_Pf1_Draw__FP11daNpc_Pf1_c */
-static BOOL daNpc_Pf1_Draw(daNpc_Pf1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Pf1_Draw(daNpc_Pf1_c* i_this) {
+    return ((daNpc_Pf1_c*)i_this)->_draw();
 }
 
 /* 0000389C-000038A4       .text daNpc_Pf1_IsDelete__FP11daNpc_Pf1_c */
 static BOOL daNpc_Pf1_IsDelete(daNpc_Pf1_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daNpc_Pf1_Method = {

--- a/src/d/actor/d_a_npc_pm1.cpp
+++ b/src/d/actor/d_a_npc_pm1.cpp
@@ -194,17 +194,17 @@ void daNpc_Pm1_c::demo() {
 }
 
 /* 00001558-000016BC       .text _draw__11daNpc_Pm1_cFv */
-bool daNpc_Pm1_c::_draw() {
+BOOL daNpc_Pm1_c::_draw() {
     /* Nonmatching */
 }
 
 /* 000016BC-00001818       .text _execute__11daNpc_Pm1_cFv */
-bool daNpc_Pm1_c::_execute() {
+BOOL daNpc_Pm1_c::_execute() {
     /* Nonmatching */
 }
 
 /* 00001818-0000189C       .text _delete__11daNpc_Pm1_cFv */
-bool daNpc_Pm1_c::_delete() {
+BOOL daNpc_Pm1_c::_delete() {
     /* Nonmatching */
 }
 
@@ -224,28 +224,28 @@ void daNpc_Pm1_c::CreateHeap() {
 }
 
 /* 00002168-00002188       .text daNpc_Pm1_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Pm1_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_Pm1_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_Pm1_c*)i_this)->_create();
 }
 
 /* 00002188-000021A8       .text daNpc_Pm1_Delete__FP11daNpc_Pm1_c */
-static BOOL daNpc_Pm1_Delete(daNpc_Pm1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Pm1_Delete(daNpc_Pm1_c* i_this) {
+    return ((daNpc_Pm1_c*)i_this)->_delete();
 }
 
 /* 000021A8-000021C8       .text daNpc_Pm1_Execute__FP11daNpc_Pm1_c */
-static BOOL daNpc_Pm1_Execute(daNpc_Pm1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Pm1_Execute(daNpc_Pm1_c* i_this) {
+    return ((daNpc_Pm1_c*)i_this)->_execute();
 }
 
 /* 000021C8-000021E8       .text daNpc_Pm1_Draw__FP11daNpc_Pm1_c */
-static BOOL daNpc_Pm1_Draw(daNpc_Pm1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Pm1_Draw(daNpc_Pm1_c* i_this) {
+    return ((daNpc_Pm1_c*)i_this)->_draw();
 }
 
 /* 000021E8-000021F0       .text daNpc_Pm1_IsDelete__FP11daNpc_Pm1_c */
 static BOOL daNpc_Pm1_IsDelete(daNpc_Pm1_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daNpc_Pm1_Method = {

--- a/src/d/actor/d_a_npc_rsh1.cpp
+++ b/src/d/actor/d_a_npc_rsh1.cpp
@@ -271,17 +271,17 @@ void daNpc_Rsh1_c::dummy_action(void*) {
 }
 
 /* 00003F08-00004040       .text _draw__12daNpc_Rsh1_cFv */
-bool daNpc_Rsh1_c::_draw() {
+BOOL daNpc_Rsh1_c::_draw() {
     /* Nonmatching */
 }
 
 /* 00004040-0000427C       .text _execute__12daNpc_Rsh1_cFv */
-bool daNpc_Rsh1_c::_execute() {
+BOOL daNpc_Rsh1_c::_execute() {
     /* Nonmatching */
 }
 
 /* 0000427C-00004308       .text _delete__12daNpc_Rsh1_cFv */
-bool daNpc_Rsh1_c::_delete() {
+BOOL daNpc_Rsh1_c::_delete() {
     /* Nonmatching */
 }
 
@@ -306,28 +306,28 @@ void daNpc_Rsh1_c::set_mtx() {
 }
 
 /* 00004A28-00004A48       .text daNpc_Rsh1_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Rsh1_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_Rsh1_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_Rsh1_c*)i_this)->_create();
 }
 
 /* 00004A48-00004A68       .text daNpc_Rsh1_Delete__FP12daNpc_Rsh1_c */
-static BOOL daNpc_Rsh1_Delete(daNpc_Rsh1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Rsh1_Delete(daNpc_Rsh1_c* i_this) {
+    return ((daNpc_Rsh1_c*)i_this)->_delete();
 }
 
 /* 00004A68-00004A88       .text daNpc_Rsh1_Execute__FP12daNpc_Rsh1_c */
-static BOOL daNpc_Rsh1_Execute(daNpc_Rsh1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Rsh1_Execute(daNpc_Rsh1_c* i_this) {
+    return ((daNpc_Rsh1_c*)i_this)->_execute();
 }
 
 /* 00004A88-00004AA8       .text daNpc_Rsh1_Draw__FP12daNpc_Rsh1_c */
-static BOOL daNpc_Rsh1_Draw(daNpc_Rsh1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Rsh1_Draw(daNpc_Rsh1_c* i_this) {
+    return ((daNpc_Rsh1_c*)i_this)->_draw();
 }
 
 /* 00004AA8-00004AB0       .text daNpc_Rsh1_IsDelete__FP12daNpc_Rsh1_c */
 static BOOL daNpc_Rsh1_IsDelete(daNpc_Rsh1_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daNpc_Rsh1_Method = {

--- a/src/d/actor/d_a_npc_sarace.cpp
+++ b/src/d/actor/d_a_npc_sarace.cpp
@@ -141,17 +141,17 @@ void daNpc_Sarace_c::set_mtx() {
 }
 
 /* 000017E0-00001938       .text _draw__14daNpc_Sarace_cFv */
-bool daNpc_Sarace_c::_draw() {
+BOOL daNpc_Sarace_c::_draw() {
     /* Nonmatching */
 }
 
 /* 00001938-00001A68       .text _execute__14daNpc_Sarace_cFv */
-bool daNpc_Sarace_c::_execute() {
+BOOL daNpc_Sarace_c::_execute() {
     /* Nonmatching */
 }
 
 /* 00001A68-00001AE0       .text _delete__14daNpc_Sarace_cFv */
-bool daNpc_Sarace_c::_delete() {
+BOOL daNpc_Sarace_c::_delete() {
     /* Nonmatching */
 }
 
@@ -171,28 +171,28 @@ void daNpc_Sarace_c::CreateHeap() {
 }
 
 /* 00002498-000024B8       .text daNpc_Sarace_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Sarace_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_Sarace_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_Sarace_c*)i_this)->_create();
 }
 
 /* 000024B8-000024D8       .text daNpc_Sarace_Delete__FP14daNpc_Sarace_c */
-static BOOL daNpc_Sarace_Delete(daNpc_Sarace_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Sarace_Delete(daNpc_Sarace_c* i_this) {
+    return ((daNpc_Sarace_c*)i_this)->_delete();
 }
 
 /* 000024D8-000024F8       .text daNpc_Sarace_Execute__FP14daNpc_Sarace_c */
-static BOOL daNpc_Sarace_Execute(daNpc_Sarace_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Sarace_Execute(daNpc_Sarace_c* i_this) {
+    return ((daNpc_Sarace_c*)i_this)->_execute();
 }
 
 /* 000024F8-00002518       .text daNpc_Sarace_Draw__FP14daNpc_Sarace_c */
-static BOOL daNpc_Sarace_Draw(daNpc_Sarace_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Sarace_Draw(daNpc_Sarace_c* i_this) {
+    return ((daNpc_Sarace_c*)i_this)->_draw();
 }
 
 /* 00002518-00002520       .text daNpc_Sarace_IsDelete__FP14daNpc_Sarace_c */
 static BOOL daNpc_Sarace_IsDelete(daNpc_Sarace_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daNpc_Sarace_Method = {

--- a/src/d/actor/d_a_npc_so.cpp
+++ b/src/d/actor/d_a_npc_so.cpp
@@ -368,28 +368,28 @@ bool daNpc_So_c::_delete() {
 }
 
 /* 00004754-00004774       .text daNpc_SoCreate__FPv */
-static s32 daNpc_SoCreate(void*) {
-    /* Nonmatching */
+static s32 daNpc_SoCreate(void* i_this) {
+    return ((daNpc_So_c*)i_this)->_create();
 }
 
 /* 00004774-00004798       .text daNpc_SoDelete__FPv */
-static BOOL daNpc_SoDelete(void*) {
-    /* Nonmatching */
+static BOOL daNpc_SoDelete(void* i_this) {
+    return ((daNpc_So_c*)i_this)->_delete();
 }
 
 /* 00004798-000047BC       .text daNpc_SoExecute__FPv */
-static BOOL daNpc_SoExecute(void*) {
-    /* Nonmatching */
+static BOOL daNpc_SoExecute(void* i_this) {
+    return ((daNpc_So_c*)i_this)->_execute();
 }
 
 /* 000047BC-000047E0       .text daNpc_SoDraw__FPv */
-static BOOL daNpc_SoDraw(void*) {
-    /* Nonmatching */
+static BOOL daNpc_SoDraw(void* i_this) {
+    return ((daNpc_So_c*)i_this)->_draw();
 }
 
 /* 000047E0-000047E8       .text daNpc_SoIsDelete__FPv */
 static BOOL daNpc_SoIsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 #include "d/actor/d_a_npc_so_cut.inc"

--- a/src/d/actor/d_a_npc_sv.cpp
+++ b/src/d/actor/d_a_npc_sv.cpp
@@ -230,28 +230,28 @@ void daNpcSv_c::isTalkOK() {
 }
 
 /* 00002958-00002978       .text daNpc_PeopleCreate__FPv */
-static s32 daNpc_PeopleCreate(void*) {
-    /* Nonmatching */
+static s32 daNpc_PeopleCreate(void* i_this) {
+    return ((daNpcSv_c*)i_this)->_create();
 }
 
 /* 00002978-0000299C       .text daNpc_PeopleDelete__FPv */
-static BOOL daNpc_PeopleDelete(void*) {
-    /* Nonmatching */
+static BOOL daNpc_PeopleDelete(void* i_this) {
+    return ((daNpcSv_c*)i_this)->_delete();
 }
 
 /* 0000299C-000029C0       .text daNpc_PeopleExecute__FPv */
-static BOOL daNpc_PeopleExecute(void*) {
-    /* Nonmatching */
+static BOOL daNpc_PeopleExecute(void* i_this) {
+    return ((daNpcSv_c*)i_this)->_execute();
 }
 
 /* 000029C0-000029E4       .text daNpc_PeopleDraw__FPv */
-static BOOL daNpc_PeopleDraw(void*) {
-    /* Nonmatching */
+static BOOL daNpc_PeopleDraw(void* i_this) {
+    return ((daNpcSv_c*)i_this)->_draw();
 }
 
 /* 000029E4-000029EC       .text daNpc_PeopleIsDelete__FPv */
 static BOOL daNpc_PeopleIsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daNpc_PeopleMethodTable = {

--- a/src/d/actor/d_a_npc_tc.cpp
+++ b/src/d/actor/d_a_npc_tc.cpp
@@ -264,7 +264,7 @@ void daNpc_Tc_c::set_mtx() {
 }
 
 /* 000038A0-00003A40       .text _draw__10daNpc_Tc_cFv */
-bool daNpc_Tc_c::_draw() {
+BOOL daNpc_Tc_c::_draw() {
     /* Nonmatching */
 }
 
@@ -274,12 +274,12 @@ void daNpc_Tc_c::setTower() {
 }
 
 /* 00003BE0-00003E90       .text _execute__10daNpc_Tc_cFv */
-bool daNpc_Tc_c::_execute() {
+BOOL daNpc_Tc_c::_execute() {
     /* Nonmatching */
 }
 
 /* 00003E90-00003F1C       .text _delete__10daNpc_Tc_cFv */
-bool daNpc_Tc_c::_delete() {
+BOOL daNpc_Tc_c::_delete() {
     /* Nonmatching */
 }
 
@@ -304,28 +304,28 @@ void daNpc_Tc_c::_createHeap() {
 }
 
 /* 000047DC-000047FC       .text daNpc_Tc_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Tc_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_Tc_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_Tc_c*)i_this)->_create();
 }
 
 /* 000047FC-0000481C       .text daNpc_Tc_Delete__FP10daNpc_Tc_c */
-static BOOL daNpc_Tc_Delete(daNpc_Tc_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Tc_Delete(daNpc_Tc_c* i_this) {
+    return ((daNpc_Tc_c*)i_this)->_delete();
 }
 
 /* 0000481C-0000483C       .text daNpc_Tc_Execute__FP10daNpc_Tc_c */
-static BOOL daNpc_Tc_Execute(daNpc_Tc_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Tc_Execute(daNpc_Tc_c* i_this) {
+    return ((daNpc_Tc_c*)i_this)->_execute();
 }
 
 /* 0000483C-0000485C       .text daNpc_Tc_Draw__FP10daNpc_Tc_c */
-static BOOL daNpc_Tc_Draw(daNpc_Tc_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Tc_Draw(daNpc_Tc_c* i_this) {
+    return ((daNpc_Tc_c*)i_this)->_draw();
 }
 
 /* 0000485C-00004864       .text daNpc_Tc_IsDelete__FP10daNpc_Tc_c */
 static BOOL daNpc_Tc_IsDelete(daNpc_Tc_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00004BAC-00004E6C       .text next_msgStatusNormal2__10daNpc_Tc_cFPUl */

--- a/src/d/actor/d_a_npc_tt.cpp
+++ b/src/d/actor/d_a_npc_tt.cpp
@@ -199,17 +199,17 @@ void daNpc_Tt_c::ke_execute() {
 }
 
 /* 00001E04-00001F84       .text _draw__10daNpc_Tt_cFv */
-bool daNpc_Tt_c::_draw() {
+BOOL daNpc_Tt_c::_draw() {
     /* Nonmatching */
 }
 
 /* 00001F84-00002158       .text _execute__10daNpc_Tt_cFv */
-bool daNpc_Tt_c::_execute() {
+BOOL daNpc_Tt_c::_execute() {
     /* Nonmatching */
 }
 
 /* 00002158-000021A8       .text _delete__10daNpc_Tt_cFv */
-bool daNpc_Tt_c::_delete() {
+BOOL daNpc_Tt_c::_delete() {
     /* Nonmatching */
 }
 
@@ -229,28 +229,28 @@ void daNpc_Tt_c::CreateHeap() {
 }
 
 /* 00002AB0-00002AD0       .text daNpc_Tt_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Tt_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_Tt_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_Tt_c*)i_this)->_create();
 }
 
 /* 00002AD0-00002AF0       .text daNpc_Tt_Delete__FP10daNpc_Tt_c */
-static BOOL daNpc_Tt_Delete(daNpc_Tt_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Tt_Delete(daNpc_Tt_c* i_this) {
+    return ((daNpc_Tt_c*)i_this)->_delete();
 }
 
 /* 00002AF0-00002B10       .text daNpc_Tt_Execute__FP10daNpc_Tt_c */
-static BOOL daNpc_Tt_Execute(daNpc_Tt_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Tt_Execute(daNpc_Tt_c* i_this) {
+    return ((daNpc_Tt_c*)i_this)->_execute();
 }
 
 /* 00002B10-00002B30       .text daNpc_Tt_Draw__FP10daNpc_Tt_c */
-static BOOL daNpc_Tt_Draw(daNpc_Tt_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Tt_Draw(daNpc_Tt_c* i_this) {
+    return ((daNpc_Tt_c*)i_this)->_draw();
 }
 
 /* 00002B30-00002B38       .text daNpc_Tt_IsDelete__FP10daNpc_Tt_c */
 static BOOL daNpc_Tt_IsDelete(daNpc_Tt_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 #include "d/actor/d_a_npc_tt_anm.inc"

--- a/src/d/actor/d_a_npc_uk.cpp
+++ b/src/d/actor/d_a_npc_uk.cpp
@@ -304,17 +304,17 @@ void daNpc_Uk_c::visit_action(void*) {
 }
 
 /* 00004774-00004A20       .text _draw__10daNpc_Uk_cFv */
-bool daNpc_Uk_c::_draw() {
+BOOL daNpc_Uk_c::_draw() {
     /* Nonmatching */
 }
 
 /* 00004A20-00004CE4       .text _execute__10daNpc_Uk_cFv */
-bool daNpc_Uk_c::_execute() {
+BOOL daNpc_Uk_c::_execute() {
     /* Nonmatching */
 }
 
 /* 00004CE4-00004D34       .text _delete__10daNpc_Uk_cFv */
-bool daNpc_Uk_c::_delete() {
+BOOL daNpc_Uk_c::_delete() {
     /* Nonmatching */
 }
 
@@ -334,28 +334,28 @@ void daNpc_Uk_c::CreateHeap() {
 }
 
 /* 00005728-00005748       .text daNpc_Uk_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Uk_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_Uk_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_Uk_c*)i_this)->_create();
 }
 
 /* 00005748-00005768       .text daNpc_Uk_Delete__FP10daNpc_Uk_c */
-static BOOL daNpc_Uk_Delete(daNpc_Uk_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Uk_Delete(daNpc_Uk_c* i_this) {
+    return ((daNpc_Uk_c*)i_this)->_delete();
 }
 
 /* 00005768-00005788       .text daNpc_Uk_Execute__FP10daNpc_Uk_c */
-static BOOL daNpc_Uk_Execute(daNpc_Uk_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Uk_Execute(daNpc_Uk_c* i_this) {
+    return ((daNpc_Uk_c*)i_this)->_execute();
 }
 
 /* 00005788-000057A8       .text daNpc_Uk_Draw__FP10daNpc_Uk_c */
-static BOOL daNpc_Uk_Draw(daNpc_Uk_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Uk_Draw(daNpc_Uk_c* i_this) {
+    return ((daNpc_Uk_c*)i_this)->_draw();
 }
 
 /* 000057A8-000057B0       .text daNpc_Uk_IsDelete__FP10daNpc_Uk_c */
 static BOOL daNpc_Uk_IsDelete(daNpc_Uk_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daNpc_Uk_Method = {

--- a/src/d/actor/d_a_npc_ym1.cpp
+++ b/src/d/actor/d_a_npc_ym1.cpp
@@ -373,17 +373,17 @@ void daNpc_Ym1_c::shadowDraw() {
 }
 
 /* 0000359C-000037A0       .text _draw__11daNpc_Ym1_cFv */
-bool daNpc_Ym1_c::_draw() {
+BOOL daNpc_Ym1_c::_draw() {
     /* Nonmatching */
 }
 
 /* 000037A0-00003A5C       .text _execute__11daNpc_Ym1_cFv */
-bool daNpc_Ym1_c::_execute() {
+BOOL daNpc_Ym1_c::_execute() {
     /* Nonmatching */
 }
 
 /* 00003A5C-00003AB0       .text _delete__11daNpc_Ym1_cFv */
-bool daNpc_Ym1_c::_delete() {
+BOOL daNpc_Ym1_c::_delete() {
     /* Nonmatching */
 }
 
@@ -413,28 +413,28 @@ void daNpc_Ym1_c::CreateHeap() {
 }
 
 /* 000045F8-00004618       .text daNpc_Ym1_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Ym1_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_Ym1_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_Ym1_c*)i_this)->_create();
 }
 
 /* 00004618-00004638       .text daNpc_Ym1_Delete__FP11daNpc_Ym1_c */
-static BOOL daNpc_Ym1_Delete(daNpc_Ym1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Ym1_Delete(daNpc_Ym1_c* i_this) {
+    return ((daNpc_Ym1_c*)i_this)->_delete();
 }
 
 /* 00004638-00004658       .text daNpc_Ym1_Execute__FP11daNpc_Ym1_c */
-static BOOL daNpc_Ym1_Execute(daNpc_Ym1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Ym1_Execute(daNpc_Ym1_c* i_this) {
+    return ((daNpc_Ym1_c*)i_this)->_execute();
 }
 
 /* 00004658-00004678       .text daNpc_Ym1_Draw__FP11daNpc_Ym1_c */
-static BOOL daNpc_Ym1_Draw(daNpc_Ym1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Ym1_Draw(daNpc_Ym1_c* i_this) {
+    return ((daNpc_Ym1_c*)i_this)->_draw();
 }
 
 /* 00004678-00004680       .text daNpc_Ym1_IsDelete__FP11daNpc_Ym1_c */
 static BOOL daNpc_Ym1_IsDelete(daNpc_Ym1_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daNpc_Ym1_Method = {

--- a/src/d/actor/d_a_npc_yw1.cpp
+++ b/src/d/actor/d_a_npc_yw1.cpp
@@ -358,17 +358,17 @@ void daNpc_Yw1_c::shadowDraw() {
 }
 
 /* 00003B4C-00003C84       .text _draw__11daNpc_Yw1_cFv */
-bool daNpc_Yw1_c::_draw() {
+BOOL daNpc_Yw1_c::_draw() {
     /* Nonmatching */
 }
 
 /* 00003C84-00003EDC       .text _execute__11daNpc_Yw1_cFv */
-bool daNpc_Yw1_c::_execute() {
+BOOL daNpc_Yw1_c::_execute() {
     /* Nonmatching */
 }
 
 /* 00003EDC-00003F38       .text _delete__11daNpc_Yw1_cFv */
-bool daNpc_Yw1_c::_delete() {
+BOOL daNpc_Yw1_c::_delete() {
     /* Nonmatching */
 }
 
@@ -393,28 +393,28 @@ void daNpc_Yw1_c::CreateHeap() {
 }
 
 /* 000049D0-000049F0       .text daNpc_Yw1_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Yw1_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_Yw1_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_Yw1_c*)i_this)->_create();
 }
 
 /* 000049F0-00004A10       .text daNpc_Yw1_Delete__FP11daNpc_Yw1_c */
-static BOOL daNpc_Yw1_Delete(daNpc_Yw1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Yw1_Delete(daNpc_Yw1_c* i_this) {
+    return ((daNpc_Yw1_c*)i_this)->_delete();
 }
 
 /* 00004A10-00004A30       .text daNpc_Yw1_Execute__FP11daNpc_Yw1_c */
-static BOOL daNpc_Yw1_Execute(daNpc_Yw1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Yw1_Execute(daNpc_Yw1_c* i_this) {
+    return ((daNpc_Yw1_c*)i_this)->_execute();
 }
 
 /* 00004A30-00004A50       .text daNpc_Yw1_Draw__FP11daNpc_Yw1_c */
-static BOOL daNpc_Yw1_Draw(daNpc_Yw1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Yw1_Draw(daNpc_Yw1_c* i_this) {
+    return ((daNpc_Yw1_c*)i_this)->_draw();
 }
 
 /* 00004A50-00004A58       .text daNpc_Yw1_IsDelete__FP11daNpc_Yw1_c */
 static BOOL daNpc_Yw1_IsDelete(daNpc_Yw1_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daNpc_Yw1_Method = {

--- a/src/d/actor/d_a_npc_zk1.cpp
+++ b/src/d/actor/d_a_npc_zk1.cpp
@@ -238,17 +238,17 @@ void daNpc_Zk1_c::shadowDraw() {
 }
 
 /* 00001BAC-00001C80       .text _draw__11daNpc_Zk1_cFv */
-bool daNpc_Zk1_c::_draw() {
+BOOL daNpc_Zk1_c::_draw() {
     /* Nonmatching */
 }
 
 /* 00001C80-00001EA8       .text _execute__11daNpc_Zk1_cFv */
-bool daNpc_Zk1_c::_execute() {
+BOOL daNpc_Zk1_c::_execute() {
     /* Nonmatching */
 }
 
 /* 00001EA8-00001EFC       .text _delete__11daNpc_Zk1_cFv */
-bool daNpc_Zk1_c::_delete() {
+BOOL daNpc_Zk1_c::_delete() {
     /* Nonmatching */
 }
 
@@ -268,28 +268,28 @@ void daNpc_Zk1_c::CreateHeap() {
 }
 
 /* 0000270C-0000272C       .text daNpc_Zk1_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Zk1_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_Zk1_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_Zk1_c*)i_this)->_create();
 }
 
 /* 0000272C-0000274C       .text daNpc_Zk1_Delete__FP11daNpc_Zk1_c */
-static BOOL daNpc_Zk1_Delete(daNpc_Zk1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Zk1_Delete(daNpc_Zk1_c* i_this) {
+    return ((daNpc_Zk1_c*)i_this)->_delete();
 }
 
 /* 0000274C-0000276C       .text daNpc_Zk1_Execute__FP11daNpc_Zk1_c */
-static BOOL daNpc_Zk1_Execute(daNpc_Zk1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Zk1_Execute(daNpc_Zk1_c* i_this) {
+    return ((daNpc_Zk1_c*)i_this)->_execute();
 }
 
 /* 0000276C-0000278C       .text daNpc_Zk1_Draw__FP11daNpc_Zk1_c */
-static BOOL daNpc_Zk1_Draw(daNpc_Zk1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Zk1_Draw(daNpc_Zk1_c* i_this) {
+    return ((daNpc_Zk1_c*)i_this)->_draw();
 }
 
 /* 0000278C-00002794       .text daNpc_Zk1_IsDelete__FP11daNpc_Zk1_c */
 static BOOL daNpc_Zk1_IsDelete(daNpc_Zk1_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daNpc_Zk1_Method = {

--- a/src/d/actor/d_a_npc_zl1.cpp
+++ b/src/d/actor/d_a_npc_zl1.cpp
@@ -619,17 +619,17 @@ void daNpc_Zl1_c::shadowDraw() {
 }
 
 /* 000063DC-000069D8       .text _draw__11daNpc_Zl1_cFv */
-bool daNpc_Zl1_c::_draw() {
+BOOL daNpc_Zl1_c::_draw() {
     /* Nonmatching */
 }
 
 /* 000069D8-00006C88       .text _execute__11daNpc_Zl1_cFv */
-bool daNpc_Zl1_c::_execute() {
+BOOL daNpc_Zl1_c::_execute() {
     /* Nonmatching */
 }
 
 /* 00006C88-00006CF4       .text _delete__11daNpc_Zl1_cFv */
-bool daNpc_Zl1_c::_delete() {
+BOOL daNpc_Zl1_c::_delete() {
     /* Nonmatching */
 }
 
@@ -654,28 +654,28 @@ void daNpc_Zl1_c::CreateHeap() {
 }
 
 /* 00007974-00007994       .text daNpc_Zl1_Create__FP10fopAc_ac_c */
-static cPhs_State daNpc_Zl1_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daNpc_Zl1_Create(fopAc_ac_c* i_this) {
+    return ((daNpc_Zl1_c*)i_this)->_create();
 }
 
 /* 00007994-000079B4       .text daNpc_Zl1_Delete__FP11daNpc_Zl1_c */
-static BOOL daNpc_Zl1_Delete(daNpc_Zl1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Zl1_Delete(daNpc_Zl1_c* i_this) {
+    return ((daNpc_Zl1_c*)i_this)->_delete();
 }
 
 /* 000079B4-000079D4       .text daNpc_Zl1_Execute__FP11daNpc_Zl1_c */
-static BOOL daNpc_Zl1_Execute(daNpc_Zl1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Zl1_Execute(daNpc_Zl1_c* i_this) {
+    return ((daNpc_Zl1_c*)i_this)->_execute();
 }
 
 /* 000079D4-000079F4       .text daNpc_Zl1_Draw__FP11daNpc_Zl1_c */
-static BOOL daNpc_Zl1_Draw(daNpc_Zl1_c*) {
-    /* Nonmatching */
+static BOOL daNpc_Zl1_Draw(daNpc_Zl1_c* i_this) {
+    return ((daNpc_Zl1_c*)i_this)->_draw();
 }
 
 /* 000079F4-000079FC       .text daNpc_Zl1_IsDelete__FP11daNpc_Zl1_c */
 static BOOL daNpc_Zl1_IsDelete(daNpc_Zl1_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daNpc_Zl1_Method = {

--- a/src/d/actor/d_a_nz.cpp
+++ b/src/d/actor/d_a_nz.cpp
@@ -156,7 +156,7 @@ static BOOL daNZ_Execute(nz_class*) {
 
 /* 00007B50-00007B58       .text daNZ_IsDelete__FP8nz_class */
 static BOOL daNZ_IsDelete(nz_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00007B58-00007BE0       .text daNZ_Delete__FP8nz_class */

--- a/src/d/actor/d_a_nzg.cpp
+++ b/src/d/actor/d_a_nzg.cpp
@@ -30,7 +30,7 @@ static BOOL daNZG_Execute(nzg_class*) {
 
 /* 000004D0-000004D8       .text daNZG_IsDelete__FP9nzg_class */
 static BOOL daNZG_IsDelete(nzg_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 000004D8-00000508       .text daNZG_Delete__FP9nzg_class */

--- a/src/d/actor/d_a_obj_Itnak.cpp
+++ b/src/d/actor/d_a_obj_Itnak.cpp
@@ -60,28 +60,28 @@ bool daObjItnak::Act_c::_draw() {
 namespace daObjItnak {
 namespace {
 /* 0000123C-0000125C       .text Mthd_Create__Q210daObjItnak27@unnamed@d_a_obj_Itnak_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjItnak::Act_c*)i_this)->_create();
 }
 
 /* 0000125C-00001280       .text Mthd_Delete__Q210daObjItnak27@unnamed@d_a_obj_Itnak_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjItnak::Act_c*)i_this)->_delete();
 }
 
 /* 00001280-000012A4       .text Mthd_Execute__Q210daObjItnak27@unnamed@d_a_obj_Itnak_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjItnak::Act_c*)i_this)->_execute();
 }
 
 /* 000012A4-000012C8       .text Mthd_Draw__Q210daObjItnak27@unnamed@d_a_obj_Itnak_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daObjItnak::Act_c*)i_this)->_draw();
 }
 
 /* 000012C8-000012D0       .text Mthd_IsDelete__Q210daObjItnak27@unnamed@d_a_obj_Itnak_cpp@FPv */
 BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class Mthd_Table = {

--- a/src/d/actor/d_a_obj_Vds.cpp
+++ b/src/d/actor/d_a_obj_Vds.cpp
@@ -130,28 +130,28 @@ bool daObjVds::Act_c::_draw() {
 namespace daObjVds {
 namespace {
 /* 000015A8-000015C8       .text Mthd_Create__Q28daObjVds25@unnamed@d_a_obj_Vds_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjVds::Act_c*)i_this)->_create();
 }
 
 /* 000015C8-000015EC       .text Mthd_Delete__Q28daObjVds25@unnamed@d_a_obj_Vds_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjVds::Act_c*)i_this)->_delete();
 }
 
 /* 000015EC-00001610       .text Mthd_Execute__Q28daObjVds25@unnamed@d_a_obj_Vds_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjVds::Act_c*)i_this)->_execute();
 }
 
 /* 00001610-00001634       .text Mthd_Draw__Q28daObjVds25@unnamed@d_a_obj_Vds_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daObjVds::Act_c*)i_this)->_draw();
 }
 
 /* 00001634-0000163C       .text Mthd_IsDelete__Q28daObjVds25@unnamed@d_a_obj_Vds_cpp@FPv */
 BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class Mthd_Table = {

--- a/src/d/actor/d_a_obj_YLzou.cpp
+++ b/src/d/actor/d_a_obj_YLzou.cpp
@@ -178,28 +178,28 @@ bool daObjYLzou_c::_draw() {
 }
 
 /* 00001834-00001854       .text daObjYLzou_Create__FP10fopAc_ac_c */
-static cPhs_State daObjYLzou_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daObjYLzou_Create(fopAc_ac_c* i_this) {
+    return ((daObjYLzou_c*)i_this)->_create();
 }
 
 /* 00001854-00001878       .text daObjYLzou_Delete__FP12daObjYLzou_c */
-static BOOL daObjYLzou_Delete(daObjYLzou_c*) {
-    /* Nonmatching */
+static BOOL daObjYLzou_Delete(daObjYLzou_c* i_this) {
+    return ((daObjYLzou_c*)i_this)->_delete();
 }
 
 /* 00001878-0000189C       .text daObjYLzou_Execute__FP12daObjYLzou_c */
-static BOOL daObjYLzou_Execute(daObjYLzou_c*) {
-    /* Nonmatching */
+static BOOL daObjYLzou_Execute(daObjYLzou_c* i_this) {
+    return ((daObjYLzou_c*)i_this)->_execute();
 }
 
 /* 0000189C-000018C0       .text daObjYLzou_Draw__FP12daObjYLzou_c */
-static BOOL daObjYLzou_Draw(daObjYLzou_c*) {
-    /* Nonmatching */
+static BOOL daObjYLzou_Draw(daObjYLzou_c* i_this) {
+    return ((daObjYLzou_c*)i_this)->_draw();
 }
 
 /* 000018C0-000018C8       .text daObjYLzou_IsDelete__FP12daObjYLzou_c */
 static BOOL daObjYLzou_IsDelete(daObjYLzou_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daObjYLzou_Method = {

--- a/src/d/actor/d_a_obj_ajav.cpp
+++ b/src/d/actor/d_a_obj_ajav.cpp
@@ -190,28 +190,28 @@ bool daObjAjav::Act_c::_draw() {
 namespace daObjAjav {
 namespace {
 /* 00002DCC-00002DEC       .text Mthd_Create__Q29daObjAjav26@unnamed@d_a_obj_ajav_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjAjav::Act_c*)i_this)->_create();
 }
 
 /* 00002DEC-00002E10       .text Mthd_Delete__Q29daObjAjav26@unnamed@d_a_obj_ajav_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjAjav::Act_c*)i_this)->_delete();
 }
 
 /* 00002E10-00002E34       .text Mthd_Execute__Q29daObjAjav26@unnamed@d_a_obj_ajav_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjAjav::Act_c*)i_this)->_execute();
 }
 
 /* 00002E34-00002E58       .text Mthd_Draw__Q29daObjAjav26@unnamed@d_a_obj_ajav_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daObjAjav::Act_c*)i_this)->_draw();
 }
 
 /* 00002E58-00002E60       .text Mthd_IsDelete__Q29daObjAjav26@unnamed@d_a_obj_ajav_cpp@FPv */
 BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class Mthd_Table = {

--- a/src/d/actor/d_a_obj_apzl.cpp
+++ b/src/d/actor/d_a_obj_apzl.cpp
@@ -93,8 +93,8 @@ static BOOL daObjApzl_Delete(void*) {
 }
 
 /* 00001894-000018B8       .text daObjApzl_Draw__FPv */
-static BOOL daObjApzl_Draw(void*) {
-    /* Nonmatching */
+static BOOL daObjApzl_Draw(void* i_this) {
+    return ((daObjApzl_c*)i_this)->_draw();
 }
 
 /* 000018B8-00001B00       .text _draw__11daObjApzl_cFv */
@@ -103,8 +103,8 @@ bool daObjApzl_c::_draw() {
 }
 
 /* 00001B00-00001B24       .text daObjApzl_Execute__FPv */
-static BOOL daObjApzl_Execute(void*) {
-    /* Nonmatching */
+static BOOL daObjApzl_Execute(void* i_this) {
+    return ((daObjApzl_c*)i_this)->_execute();
 }
 
 /* 00001B24-00001E8C       .text _execute__11daObjApzl_cFv */
@@ -114,7 +114,7 @@ bool daObjApzl_c::_execute() {
 
 /* 00001E8C-00001E94       .text daObjApzl_IsDelete__FPv */
 static BOOL daObjApzl_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daObj_ApzlMethodTable = {

--- a/src/d/actor/d_a_obj_ashut.cpp
+++ b/src/d/actor/d_a_obj_ashut.cpp
@@ -110,28 +110,28 @@ BOOL daObjAshut::Act_c::Draw() {
 namespace daObjAshut {
 namespace {
 /* 00000D6C-00000D8C       .text Mthd_Create__Q210daObjAshut27@unnamed@d_a_obj_ashut_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjAshut::Act_c*)i_this)->Mthd_Create();
 }
 
 /* 00000D8C-00000DAC       .text Mthd_Delete__Q210daObjAshut27@unnamed@d_a_obj_ashut_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjAshut::Act_c*)i_this)->Mthd_Delete();
 }
 
 /* 00000DAC-00000DCC       .text Mthd_Execute__Q210daObjAshut27@unnamed@d_a_obj_ashut_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjAshut::Act_c*)i_this)->MoveBGExecute();
 }
 
 /* 00000DCC-00000DF8       .text Mthd_Draw__Q210daObjAshut27@unnamed@d_a_obj_ashut_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daObjAshut::Act_c*)i_this)->Draw();
 }
 
 /* 00000DF8-00000E24       .text Mthd_IsDelete__Q210daObjAshut27@unnamed@d_a_obj_ashut_cpp@FPv */
-BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+BOOL Mthd_IsDelete(void* i_this) {
+    return ((daObjAshut::Act_c*)i_this)->IsDelete();
 }
 
 static actor_method_class Mthd_Table = {

--- a/src/d/actor/d_a_obj_auzu.cpp
+++ b/src/d/actor/d_a_obj_auzu.cpp
@@ -75,28 +75,28 @@ bool daObjAuzu::Act_c::_draw() {
 namespace daObjAuzu {
 namespace {
 /* 00000C38-00000C58       .text Mthd_Create__Q29daObjAuzu26@unnamed@d_a_obj_auzu_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjAuzu::Act_c*)i_this)->_create();
 }
 
 /* 00000C58-00000C7C       .text Mthd_Delete__Q29daObjAuzu26@unnamed@d_a_obj_auzu_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjAuzu::Act_c*)i_this)->_delete();
 }
 
 /* 00000C7C-00000CA0       .text Mthd_Execute__Q29daObjAuzu26@unnamed@d_a_obj_auzu_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjAuzu::Act_c*)i_this)->_execute();
 }
 
 /* 00000CA0-00000CC4       .text Mthd_Draw__Q29daObjAuzu26@unnamed@d_a_obj_auzu_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daObjAuzu::Act_c*)i_this)->_draw();
 }
 
 /* 00000CC4-00000CCC       .text Mthd_IsDelete__Q29daObjAuzu26@unnamed@d_a_obj_auzu_cpp@FPv */
 BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class Mthd_Table = {

--- a/src/d/actor/d_a_obj_aygr.cpp
+++ b/src/d/actor/d_a_obj_aygr.cpp
@@ -55,28 +55,28 @@ BOOL daObjAygr::Act_c::Draw() {
 namespace daObjAygr {
 namespace {
 /* 0000079C-000007BC       .text Mthd_Create__Q29daObjAygr26@unnamed@d_a_obj_aygr_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjAygr::Act_c*)i_this)->Mthd_Create();
 }
 
 /* 000007BC-000007DC       .text Mthd_Delete__Q29daObjAygr26@unnamed@d_a_obj_aygr_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjAygr::Act_c*)i_this)->Mthd_Delete();
 }
 
 /* 000007DC-000007FC       .text Mthd_Execute__Q29daObjAygr26@unnamed@d_a_obj_aygr_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjAygr::Act_c*)i_this)->MoveBGExecute();
 }
 
 /* 000007FC-00000828       .text Mthd_Draw__Q29daObjAygr26@unnamed@d_a_obj_aygr_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daObjAygr::Act_c*)i_this)->Draw();
 }
 
 /* 00000828-00000854       .text Mthd_IsDelete__Q29daObjAygr26@unnamed@d_a_obj_aygr_cpp@FPv */
-BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+BOOL Mthd_IsDelete(void* i_this) {
+    return ((daObjAygr::Act_c*)i_this)->IsDelete();
 }
 
 static actor_method_class Mthd_Aygr = {

--- a/src/d/actor/d_a_obj_balancelift.cpp
+++ b/src/d/actor/d_a_obj_balancelift.cpp
@@ -96,8 +96,8 @@ static BOOL daBalanceliftDelete(void*) {
 }
 
 /* 00001318-0000133C       .text daBalanceliftExecute__FPv */
-static BOOL daBalanceliftExecute(void*) {
-    /* Nonmatching */
+static BOOL daBalanceliftExecute(void* i_this) {
+    return ((daBalancelift_c*)i_this)->_execute();
 }
 
 /* 0000133C-000016F0       .text _execute__15daBalancelift_cFv */
@@ -112,7 +112,7 @@ static BOOL daBalanceliftDraw(void*) {
 
 /* 00001774-0000177C       .text daBalanceliftIsDelete__FPv */
 static BOOL daBalanceliftIsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daBalanceliftMethodTable = {

--- a/src/d/actor/d_a_obj_bemos.cpp
+++ b/src/d/actor/d_a_obj_bemos.cpp
@@ -250,8 +250,8 @@ void daBemos_c::getBeamActor() {
 }
 
 /* 00003F70-00003F90       .text daBemosCreate__FPv */
-static s32 daBemosCreate(void*) {
-    /* Nonmatching */
+static s32 daBemosCreate(void* i_this) {
+    return ((daBemos_c*)i_this)->_create();
 }
 
 /* 00003F90-0000403C       .text _create__9daBemos_cFv */
@@ -276,7 +276,7 @@ static BOOL daBemosDraw(void*) {
 
 /* 00004E10-00004E18       .text daBemosIsDelete__FPv */
 static BOOL daBemosIsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daBemosMethodTable = {

--- a/src/d/actor/d_a_obj_canon.cpp
+++ b/src/d/actor/d_a_obj_canon.cpp
@@ -189,28 +189,28 @@ bool daObj_Canon_c::_delete() {
 }
 
 /* 00001C50-00001C70       .text daObj_CanonCreate__FPv */
-static s32 daObj_CanonCreate(void*) {
-    /* Nonmatching */
+static s32 daObj_CanonCreate(void* i_this) {
+    return ((daObj_Canon_c*)i_this)->_create();
 }
 
 /* 00001C70-00001C94       .text daObj_CanonDelete__FPv */
-static BOOL daObj_CanonDelete(void*) {
-    /* Nonmatching */
+static BOOL daObj_CanonDelete(void* i_this) {
+    return ((daObj_Canon_c*)i_this)->_delete();
 }
 
 /* 00001C94-00001CB8       .text daObj_CanonExecute__FPv */
-static BOOL daObj_CanonExecute(void*) {
-    /* Nonmatching */
+static BOOL daObj_CanonExecute(void* i_this) {
+    return ((daObj_Canon_c*)i_this)->_execute();
 }
 
 /* 00001CB8-00001CDC       .text daObj_CanonDraw__FPv */
-static BOOL daObj_CanonDraw(void*) {
-    /* Nonmatching */
+static BOOL daObj_CanonDraw(void* i_this) {
+    return ((daObj_Canon_c*)i_this)->_draw();
 }
 
 /* 00001CDC-00001CE4       .text daObj_CanonIsDelete__FPv */
 static BOOL daObj_CanonIsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daObj_CanonMethodTable = {

--- a/src/d/actor/d_a_obj_coming.cpp
+++ b/src/d/actor/d_a_obj_coming.cpp
@@ -145,28 +145,28 @@ bool daObjComing::Act_c::_draw() {
 namespace daObjComing {
 namespace {
 /* 00001318-00001338       .text Mthd_Create__Q211daObjComing28@unnamed@d_a_obj_coming_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjComing::Act_c*)i_this)->_create();
 }
 
 /* 00001338-0000135C       .text Mthd_Delete__Q211daObjComing28@unnamed@d_a_obj_coming_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjComing::Act_c*)i_this)->_delete();
 }
 
 /* 0000135C-00001380       .text Mthd_Execute__Q211daObjComing28@unnamed@d_a_obj_coming_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjComing::Act_c*)i_this)->_execute();
 }
 
 /* 00001380-000013A4       .text Mthd_Draw__Q211daObjComing28@unnamed@d_a_obj_coming_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daObjComing::Act_c*)i_this)->_draw();
 }
 
 /* 000013A4-000013AC       .text Mthd_IsDelete__Q211daObjComing28@unnamed@d_a_obj_coming_cpp@FPv */
 BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class Mthd_Table = {

--- a/src/d/actor/d_a_obj_demo_barrel.cpp
+++ b/src/d/actor/d_a_obj_demo_barrel.cpp
@@ -49,7 +49,7 @@ static BOOL daObj_Demo_BarrelDraw(void*) {
 
 /* 00000814-0000081C       .text daObj_Demo_BarrelIsDelete__FPv */
 static BOOL daObj_Demo_BarrelIsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daObj_Demo_BarrelMethodTable = {

--- a/src/d/actor/d_a_obj_drift.cpp
+++ b/src/d/actor/d_a_obj_drift.cpp
@@ -100,28 +100,28 @@ BOOL daObjDrift::Act_c::Draw() {
 namespace daObjDrift {
 namespace {
 /* 00001270-00001290       .text Mthd_Create__Q210daObjDrift27@unnamed@d_a_obj_drift_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjDrift::Act_c*)i_this)->Mthd_Create();
 }
 
 /* 00001290-000012B0       .text Mthd_Delete__Q210daObjDrift27@unnamed@d_a_obj_drift_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjDrift::Act_c*)i_this)->Mthd_Delete();
 }
 
 /* 000012B0-000012D0       .text Mthd_Execute__Q210daObjDrift27@unnamed@d_a_obj_drift_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjDrift::Act_c*)i_this)->MoveBGExecute();
 }
 
 /* 000012D0-000012FC       .text Mthd_Draw__Q210daObjDrift27@unnamed@d_a_obj_drift_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daObjDrift::Act_c*)i_this)->Draw();
 }
 
 /* 000012FC-00001328       .text Mthd_IsDelete__Q210daObjDrift27@unnamed@d_a_obj_drift_cpp@FPv */
-BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+BOOL Mthd_IsDelete(void* i_this) {
+    return ((daObjDrift::Act_c*)i_this)->IsDelete();
 }
 
 static actor_method_class Mthd_Table = {

--- a/src/d/actor/d_a_obj_eff.cpp
+++ b/src/d/actor/d_a_obj_eff.cpp
@@ -225,28 +225,28 @@ bool daObjEff::Act_c::_execute() {
 namespace daObjEff {
 namespace {
 /* 000014C0-000014E0       .text Mthd_Create__Q28daObjEff25@unnamed@d_a_obj_eff_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjEff::Act_c*)i_this)->_create();
 }
 
 /* 000014E0-00001504       .text Mthd_Delete__Q28daObjEff25@unnamed@d_a_obj_eff_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjEff::Act_c*)i_this)->_delete();
 }
 
 /* 00001504-00001528       .text Mthd_Execute__Q28daObjEff25@unnamed@d_a_obj_eff_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjEff::Act_c*)i_this)->_execute();
 }
 
 /* 00001528-00001530       .text Mthd_Draw__Q28daObjEff25@unnamed@d_a_obj_eff_cpp@FPv */
 BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00001530-00001538       .text Mthd_IsDelete__Q28daObjEff25@unnamed@d_a_obj_eff_cpp@FPv */
 BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class Mthd_Table = {

--- a/src/d/actor/d_a_obj_ekskz.cpp
+++ b/src/d/actor/d_a_obj_ekskz.cpp
@@ -87,28 +87,28 @@ BOOL daObjEkskz::Act_c::Draw() {
 namespace daObjEkskz {
 namespace {
 /* 00001124-00001144       .text Mthd_Create__Q210daObjEkskz27@unnamed@d_a_obj_ekskz_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjEkskz::Act_c*)i_this)->Mthd_Create();
 }
 
 /* 00001144-00001164       .text Mthd_Delete__Q210daObjEkskz27@unnamed@d_a_obj_ekskz_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjEkskz::Act_c*)i_this)->Mthd_Delete();
 }
 
 /* 00001164-00001184       .text Mthd_Execute__Q210daObjEkskz27@unnamed@d_a_obj_ekskz_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjEkskz::Act_c*)i_this)->MoveBGExecute();
 }
 
 /* 00001184-000011B0       .text Mthd_Draw__Q210daObjEkskz27@unnamed@d_a_obj_ekskz_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daObjEkskz::Act_c*)i_this)->Draw();
 }
 
 /* 000011B0-000011DC       .text Mthd_IsDelete__Q210daObjEkskz27@unnamed@d_a_obj_ekskz_cpp@FPv */
-BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+BOOL Mthd_IsDelete(void* i_this) {
+    return ((daObjEkskz::Act_c*)i_this)->IsDelete();
 }
 
 static actor_method_class Mthd_Ekskz = {

--- a/src/d/actor/d_a_obj_firewall.cpp
+++ b/src/d/actor/d_a_obj_firewall.cpp
@@ -128,28 +128,28 @@ bool daObjFirewall_c::_draw() {
 }
 
 /* 00001CD4-00001CF4       .text daObjFirewall_Create__FP10fopAc_ac_c */
-static cPhs_State daObjFirewall_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daObjFirewall_Create(fopAc_ac_c* i_this) {
+    return ((daObjFirewall_c*)i_this)->_create();
 }
 
 /* 00001CF4-00001D18       .text daObjFirewall_Delete__FP15daObjFirewall_c */
-static BOOL daObjFirewall_Delete(daObjFirewall_c*) {
-    /* Nonmatching */
+static BOOL daObjFirewall_Delete(daObjFirewall_c* i_this) {
+    return ((daObjFirewall_c*)i_this)->_delete();
 }
 
 /* 00001D18-00001D3C       .text daObjFirewall_Execute__FP15daObjFirewall_c */
-static BOOL daObjFirewall_Execute(daObjFirewall_c*) {
-    /* Nonmatching */
+static BOOL daObjFirewall_Execute(daObjFirewall_c* i_this) {
+    return ((daObjFirewall_c*)i_this)->_execute();
 }
 
 /* 00001D3C-00001D60       .text daObjFirewall_Draw__FP15daObjFirewall_c */
-static BOOL daObjFirewall_Draw(daObjFirewall_c*) {
-    /* Nonmatching */
+static BOOL daObjFirewall_Draw(daObjFirewall_c* i_this) {
+    return ((daObjFirewall_c*)i_this)->_draw();
 }
 
 /* 00001D60-00001D68       .text daObjFirewall_IsDelete__FP15daObjFirewall_c */
 static BOOL daObjFirewall_IsDelete(daObjFirewall_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daObjFirewall_Method = {

--- a/src/d/actor/d_a_obj_ftree.cpp
+++ b/src/d/actor/d_a_obj_ftree.cpp
@@ -350,13 +350,13 @@ bool daObjFtree::Act_c::_draw() {
 namespace daObjFtree {
 namespace {
 /* 0000455C-0000457C       .text Mthd_Create__Q210daObjFtree27@unnamed@d_a_obj_ftree_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjFtree::Act_c*)i_this)->_create();
 }
 
 /* 0000457C-000045A0       .text Mthd_Delete__Q210daObjFtree27@unnamed@d_a_obj_ftree_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjFtree::Act_c*)i_this)->_delete();
 }
 
 /* 000045A0-000045C4       .text Mthd_Execute__Q210daObjFtree27@unnamed@d_a_obj_ftree_cpp@FPv */
@@ -365,13 +365,13 @@ BOOL Mthd_Execute(void*) {
 }
 
 /* 000045C4-000045E8       .text Mthd_Draw__Q210daObjFtree27@unnamed@d_a_obj_ftree_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daObjFtree::Act_c*)i_this)->_draw();
 }
 
 /* 000045E8-000045F0       .text Mthd_IsDelete__Q210daObjFtree27@unnamed@d_a_obj_ftree_cpp@FPv */
 BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class Mthd_Table = {

--- a/src/d/actor/d_a_obj_gnnbtltaki.cpp
+++ b/src/d/actor/d_a_obj_gnnbtltaki.cpp
@@ -44,28 +44,28 @@ bool daObjGnnbtaki_c::_draw() {
 
 namespace {
 /* 000005CC-000005EC       .text Mthd_Create__32@unnamed@d_a_obj_gnnbtltaki_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjGnnbtaki_c*)i_this)->_create();
 }
 
 /* 000005EC-00000610       .text Mthd_Delete__32@unnamed@d_a_obj_gnnbtltaki_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjGnnbtaki_c*)i_this)->_delete();
 }
 
 /* 00000610-00000634       .text Mthd_Execute__32@unnamed@d_a_obj_gnnbtltaki_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjGnnbtaki_c*)i_this)->_execute();
 }
 
 /* 00000634-00000658       .text Mthd_Draw__32@unnamed@d_a_obj_gnnbtltaki_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daObjGnnbtaki_c*)i_this)->_draw();
 }
 
 /* 00000658-00000660       .text Mthd_IsDelete__32@unnamed@d_a_obj_gnnbtltaki_cpp@FPv */
 BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class Gnnbtaki_Mthd_Table = {

--- a/src/d/actor/d_a_obj_gnndemotakie.cpp
+++ b/src/d/actor/d_a_obj_gnndemotakie.cpp
@@ -44,28 +44,28 @@ bool daObjGnntakie_c::_draw() {
 
 namespace {
 /* 00000494-000004B4       .text Mthd_Create__34@unnamed@d_a_obj_gnndemotakie_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjGnntakie_c*)i_this)->_create();
 }
 
 /* 000004B4-000004D8       .text Mthd_Delete__34@unnamed@d_a_obj_gnndemotakie_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjGnntakie_c*)i_this)->_delete();
 }
 
 /* 000004D8-000004FC       .text Mthd_Execute__34@unnamed@d_a_obj_gnndemotakie_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjGnntakie_c*)i_this)->_execute();
 }
 
 /* 000004FC-00000520       .text Mthd_Draw__34@unnamed@d_a_obj_gnndemotakie_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daObjGnntakie_c*)i_this)->_draw();
 }
 
 /* 00000520-00000528       .text Mthd_IsDelete__34@unnamed@d_a_obj_gnndemotakie_cpp@FPv */
 BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class Gnntakie_Mthd_Table = {

--- a/src/d/actor/d_a_obj_gnndemotakis.cpp
+++ b/src/d/actor/d_a_obj_gnndemotakis.cpp
@@ -44,28 +44,28 @@ bool daObjGnntakis_c::_draw() {
 
 namespace {
 /* 0000058C-000005AC       .text Mthd_Create__34@unnamed@d_a_obj_gnndemotakis_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjGnntakis_c*)i_this)->_create();
 }
 
 /* 000005AC-000005D0       .text Mthd_Delete__34@unnamed@d_a_obj_gnndemotakis_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjGnntakis_c*)i_this)->_delete();
 }
 
 /* 000005D0-000005F4       .text Mthd_Execute__34@unnamed@d_a_obj_gnndemotakis_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjGnntakis_c*)i_this)->_execute();
 }
 
 /* 000005F4-00000618       .text Mthd_Draw__34@unnamed@d_a_obj_gnndemotakis_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daObjGnntakis_c*)i_this)->_draw();
 }
 
 /* 00000618-00000620       .text Mthd_IsDelete__34@unnamed@d_a_obj_gnndemotakis_cpp@FPv */
 BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class Gnntakis_Mthd_Table = {

--- a/src/d/actor/d_a_obj_gtaki.cpp
+++ b/src/d/actor/d_a_obj_gtaki.cpp
@@ -65,8 +65,8 @@ void daObjGtaki_c::set_mtx() {
 }
 
 /* 00000684-000006A4       .text daObjGtaki_Create__FPv */
-static cPhs_State daObjGtaki_Create(void*) {
-    /* Nonmatching */
+static cPhs_State daObjGtaki_Create(void* i_this) {
+    return ((daObjGtaki_c*)i_this)->_create();
 }
 
 /* 000006A4-0000087C       .text _create__12daObjGtaki_cFv */
@@ -91,7 +91,7 @@ static BOOL daObjGtaki_Execute(void*) {
 
 /* 00000C64-00000C6C       .text daObjGtaki_IsDelete__FPv */
 static BOOL daObjGtaki_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daObj_GtakiMethodTable = {

--- a/src/d/actor/d_a_obj_hami2.cpp
+++ b/src/d/actor/d_a_obj_hami2.cpp
@@ -91,28 +91,28 @@ BOOL daObjHami2::Act_c::Draw() {
 namespace daObjHami2 {
 namespace {
 /* 00000B58-00000B78       .text Mthd_Create__Q210daObjHami227@unnamed@d_a_obj_hami2_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjHami2::Act_c*)i_this)->Mthd_Create();
 }
 
 /* 00000B78-00000B98       .text Mthd_Delete__Q210daObjHami227@unnamed@d_a_obj_hami2_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjHami2::Act_c*)i_this)->Mthd_Delete();
 }
 
 /* 00000B98-00000BB8       .text Mthd_Execute__Q210daObjHami227@unnamed@d_a_obj_hami2_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjHami2::Act_c*)i_this)->MoveBGExecute();
 }
 
 /* 00000BB8-00000BE4       .text Mthd_Draw__Q210daObjHami227@unnamed@d_a_obj_hami2_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daObjHami2::Act_c*)i_this)->Draw();
 }
 
 /* 00000BE4-00000C10       .text Mthd_IsDelete__Q210daObjHami227@unnamed@d_a_obj_hami2_cpp@FPv */
-BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+BOOL Mthd_IsDelete(void* i_this) {
+    return ((daObjHami2::Act_c*)i_this)->IsDelete();
 }
 
 static actor_method_class Mthd_Hami2 = {

--- a/src/d/actor/d_a_obj_hami3.cpp
+++ b/src/d/actor/d_a_obj_hami3.cpp
@@ -91,28 +91,28 @@ BOOL daObjHami3::Act_c::Draw() {
 namespace daObjHami3 {
 namespace {
 /* 00000A94-00000AB4       .text Mthd_Create__Q210daObjHami327@unnamed@d_a_obj_hami3_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjHami3::Act_c*)i_this)->Mthd_Create();
 }
 
 /* 00000AB4-00000AD4       .text Mthd_Delete__Q210daObjHami327@unnamed@d_a_obj_hami3_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjHami3::Act_c*)i_this)->Mthd_Delete();
 }
 
 /* 00000AD4-00000AF4       .text Mthd_Execute__Q210daObjHami327@unnamed@d_a_obj_hami3_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjHami3::Act_c*)i_this)->MoveBGExecute();
 }
 
 /* 00000AF4-00000B20       .text Mthd_Draw__Q210daObjHami327@unnamed@d_a_obj_hami3_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daObjHami3::Act_c*)i_this)->Draw();
 }
 
 /* 00000B20-00000B4C       .text Mthd_IsDelete__Q210daObjHami327@unnamed@d_a_obj_hami3_cpp@FPv */
-BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+BOOL Mthd_IsDelete(void* i_this) {
+    return ((daObjHami3::Act_c*)i_this)->IsDelete();
 }
 
 static actor_method_class Mthd_Hami3 = {

--- a/src/d/actor/d_a_obj_hami4.cpp
+++ b/src/d/actor/d_a_obj_hami4.cpp
@@ -69,7 +69,7 @@ static BOOL daObjHami4_Execute(void*) {
 
 /* 00000A58-00000A60       .text daObjHami4_IsDelete__FPv */
 static BOOL daObjHami4_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daObj_Hami4MethodTable = {

--- a/src/d/actor/d_a_obj_hcbh.cpp
+++ b/src/d/actor/d_a_obj_hcbh.cpp
@@ -88,28 +88,28 @@ bool daObjHcbh_c::_draw() {
 }
 
 /* 0000197C-0000199C       .text daObjHcbh_Create__FP10fopAc_ac_c */
-static cPhs_State daObjHcbh_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daObjHcbh_Create(fopAc_ac_c* i_this) {
+    return ((daObjHcbh_c*)i_this)->_create();
 }
 
 /* 0000199C-000019C0       .text daObjHcbh_Delete__FP11daObjHcbh_c */
-static BOOL daObjHcbh_Delete(daObjHcbh_c*) {
-    /* Nonmatching */
+static BOOL daObjHcbh_Delete(daObjHcbh_c* i_this) {
+    return ((daObjHcbh_c*)i_this)->_delete();
 }
 
 /* 000019C0-000019E4       .text daObjHcbh_Execute__FP11daObjHcbh_c */
-static BOOL daObjHcbh_Execute(daObjHcbh_c*) {
-    /* Nonmatching */
+static BOOL daObjHcbh_Execute(daObjHcbh_c* i_this) {
+    return ((daObjHcbh_c*)i_this)->_execute();
 }
 
 /* 000019E4-00001A08       .text daObjHcbh_Draw__FP11daObjHcbh_c */
-static BOOL daObjHcbh_Draw(daObjHcbh_c*) {
-    /* Nonmatching */
+static BOOL daObjHcbh_Draw(daObjHcbh_c* i_this) {
+    return ((daObjHcbh_c*)i_this)->_draw();
 }
 
 /* 00001A08-00001A10       .text daObjHcbh_IsDelete__FP11daObjHcbh_c */
 static BOOL daObjHcbh_IsDelete(daObjHcbh_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daObjHcbh_Method = {

--- a/src/d/actor/d_a_obj_hlift.cpp
+++ b/src/d/actor/d_a_obj_hlift.cpp
@@ -130,28 +130,28 @@ BOOL daObjHlift::Act_c::Draw() {
 namespace daObjHlift {
 namespace {
 /* 00001090-000010B0       .text Mthd_Create__Q210daObjHlift27@unnamed@d_a_obj_hlift_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjHlift::Act_c*)i_this)->Mthd_Create();
 }
 
 /* 000010B0-000010D0       .text Mthd_Delete__Q210daObjHlift27@unnamed@d_a_obj_hlift_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjHlift::Act_c*)i_this)->Mthd_Delete();
 }
 
 /* 000010D0-000010F0       .text Mthd_Execute__Q210daObjHlift27@unnamed@d_a_obj_hlift_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjHlift::Act_c*)i_this)->MoveBGExecute();
 }
 
 /* 000010F0-0000111C       .text Mthd_Draw__Q210daObjHlift27@unnamed@d_a_obj_hlift_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daObjHlift::Act_c*)i_this)->Draw();
 }
 
 /* 0000111C-00001148       .text Mthd_IsDelete__Q210daObjHlift27@unnamed@d_a_obj_hlift_cpp@FPv */
-BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+BOOL Mthd_IsDelete(void* i_this) {
+    return ((daObjHlift::Act_c*)i_this)->IsDelete();
 }
 
 static actor_method_class Mthd_Table = {

--- a/src/d/actor/d_a_obj_hsehi1.cpp
+++ b/src/d/actor/d_a_obj_hsehi1.cpp
@@ -253,28 +253,29 @@ BOOL daObj_hsh_c::draw() {
 }
 
 /* 00002158-00002178       .text daObj_hsh_Draw__FP11daObj_hsh_c */
-static BOOL daObj_hsh_Draw(daObj_hsh_c*) {
-    /* Nonmatching */
+static BOOL daObj_hsh_Draw(daObj_hsh_c* i_this) {
+    return ((daObj_hsh_c*)i_this)->draw();
 }
 
 /* 00002178-00002198       .text daObj_hsh_Execute__FP11daObj_hsh_c */
-static BOOL daObj_hsh_Execute(daObj_hsh_c*) {
-    /* Nonmatching */
+static BOOL daObj_hsh_Execute(daObj_hsh_c* i_this) {
+    return ((daObj_hsh_c*)i_this)->execute();
 }
 
 /* 00002198-000021A0       .text daObj_hsh_IsDelete__FP11daObj_hsh_c */
 static BOOL daObj_hsh_IsDelete(daObj_hsh_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 000021A0-000021C8       .text daObj_hsh_Delete__FP11daObj_hsh_c */
-static BOOL daObj_hsh_Delete(daObj_hsh_c*) {
-    /* Nonmatching */
+static BOOL daObj_hsh_Delete(daObj_hsh_c* i_this) {
+    ((daObj_hsh_c*)i_this)->~daObj_hsh_c();
+    return TRUE;
 }
 
 /* 000021C8-000021E8       .text daObj_hsh_Create__FP10fopAc_ac_c */
-static cPhs_State daObj_hsh_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daObj_hsh_Create(fopAc_ac_c* i_this) {
+    return ((daObj_hsh_c*)i_this)->create();
 }
 
 static actor_method_class l_daObj_hsh_Method = {

--- a/src/d/actor/d_a_obj_htetu1.cpp
+++ b/src/d/actor/d_a_obj_htetu1.cpp
@@ -69,28 +69,28 @@ bool daObjHtetu1_c::_draw() {
 
 namespace {
 /* 0000107C-0000109C       .text Mthd_Create__28@unnamed@d_a_obj_htetu1_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjHtetu1_c*)i_this)->_create();
 }
 
 /* 0000109C-000010C0       .text Mthd_Delete__28@unnamed@d_a_obj_htetu1_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjHtetu1_c*)i_this)->_delete();
 }
 
 /* 000010C0-000010E4       .text Mthd_Execute__28@unnamed@d_a_obj_htetu1_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjHtetu1_c*)i_this)->_execute();
 }
 
 /* 000010E4-00001108       .text Mthd_Draw__28@unnamed@d_a_obj_htetu1_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daObjHtetu1_c*)i_this)->_draw();
 }
 
 /* 00001108-00001110       .text Mthd_IsDelete__28@unnamed@d_a_obj_htetu1_cpp@FPv */
 BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class Htetu1_Mthd_Table = {

--- a/src/d/actor/d_a_obj_ice.cpp
+++ b/src/d/actor/d_a_obj_ice.cpp
@@ -85,28 +85,28 @@ void daObjIce_c::setEffectMtx() {
 }
 
 /* 000013A0-000013C0       .text daObjIce_Create__FP10fopAc_ac_c */
-static cPhs_State daObjIce_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daObjIce_Create(fopAc_ac_c* i_this) {
+    return ((daObjIce_c*)i_this)->_create();
 }
 
 /* 000013C0-000013E4       .text daObjIce_Delete__FP10daObjIce_c */
-static BOOL daObjIce_Delete(daObjIce_c*) {
-    /* Nonmatching */
+static BOOL daObjIce_Delete(daObjIce_c* i_this) {
+    return ((daObjIce_c*)i_this)->_delete();
 }
 
 /* 000013E4-00001408       .text daObjIce_Execute__FP10daObjIce_c */
-static BOOL daObjIce_Execute(daObjIce_c*) {
-    /* Nonmatching */
+static BOOL daObjIce_Execute(daObjIce_c* i_this) {
+    return ((daObjIce_c*)i_this)->_execute();
 }
 
 /* 00001408-0000142C       .text daObjIce_Draw__FP10daObjIce_c */
-static BOOL daObjIce_Draw(daObjIce_c*) {
-    /* Nonmatching */
+static BOOL daObjIce_Draw(daObjIce_c* i_this) {
+    return ((daObjIce_c*)i_this)->_draw();
 }
 
 /* 0000142C-00001434       .text daObjIce_IsDelete__FP10daObjIce_c */
 static BOOL daObjIce_IsDelete(daObjIce_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daObjIce_Method = {

--- a/src/d/actor/d_a_obj_ikada.cpp
+++ b/src/d/actor/d_a_obj_ikada.cpp
@@ -309,28 +309,28 @@ bool daObj_Ikada_c::_delete() {
 }
 
 /* 0000543C-0000545C       .text daObj_IkadaCreate__FPv */
-static s32 daObj_IkadaCreate(void*) {
-    /* Nonmatching */
+static s32 daObj_IkadaCreate(void* i_this) {
+    return ((daObj_Ikada_c*)i_this)->_create();
 }
 
 /* 0000545C-00005480       .text daObj_IkadaDelete__FPv */
-static BOOL daObj_IkadaDelete(void*) {
-    /* Nonmatching */
+static BOOL daObj_IkadaDelete(void* i_this) {
+    return ((daObj_Ikada_c*)i_this)->_delete();
 }
 
 /* 00005480-000054A4       .text daObj_IkadaExecute__FPv */
-static BOOL daObj_IkadaExecute(void*) {
-    /* Nonmatching */
+static BOOL daObj_IkadaExecute(void* i_this) {
+    return ((daObj_Ikada_c*)i_this)->_execute();
 }
 
 /* 000054A4-000054C8       .text daObj_IkadaDraw__FPv */
-static BOOL daObj_IkadaDraw(void*) {
-    /* Nonmatching */
+static BOOL daObj_IkadaDraw(void* i_this) {
+    return ((daObj_Ikada_c*)i_this)->_draw();
 }
 
 /* 000054C8-000054D0       .text daObj_IkadaIsDelete__FPv */
 static BOOL daObj_IkadaIsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daObj_IkadaMethodTable = {

--- a/src/d/actor/d_a_obj_jump.cpp
+++ b/src/d/actor/d_a_obj_jump.cpp
@@ -140,28 +140,28 @@ BOOL daObjJump::Act_c::Draw() {
 namespace daObjJump {
 namespace {
 /* 00001594-000015B4       .text Mthd_Create__Q29daObjJump26@unnamed@d_a_obj_jump_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjJump::Act_c*)i_this)->Mthd_Create();
 }
 
 /* 000015B4-000015D4       .text Mthd_Delete__Q29daObjJump26@unnamed@d_a_obj_jump_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjJump::Act_c*)i_this)->Mthd_Delete();
 }
 
 /* 000015D4-000015F4       .text Mthd_Execute__Q29daObjJump26@unnamed@d_a_obj_jump_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjJump::Act_c*)i_this)->MoveBGExecute();
 }
 
 /* 000015F4-00001620       .text Mthd_Draw__Q29daObjJump26@unnamed@d_a_obj_jump_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daObjJump::Act_c*)i_this)->Draw();
 }
 
 /* 00001620-0000164C       .text Mthd_IsDelete__Q29daObjJump26@unnamed@d_a_obj_jump_cpp@FPv */
-BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+BOOL Mthd_IsDelete(void* i_this) {
+    return ((daObjJump::Act_c*)i_this)->IsDelete();
 }
 
 static actor_method_class Mthd_Table = {

--- a/src/d/actor/d_a_obj_kanoke.cpp
+++ b/src/d/actor/d_a_obj_kanoke.cpp
@@ -96,17 +96,17 @@ void daObjKanoke_c::createInit() {
 }
 
 /* 00000B28-00000C0C       .text _delete__13daObjKanoke_cFv */
-bool daObjKanoke_c::_delete() {
+BOOL daObjKanoke_c::_delete() {
     /* Nonmatching */
 }
 
 /* 00000C0C-00000CE0       .text _draw__13daObjKanoke_cFv */
-bool daObjKanoke_c::_draw() {
+BOOL daObjKanoke_c::_draw() {
     /* Nonmatching */
 }
 
 /* 00000CE0-00000E7C       .text _execute__13daObjKanoke_cFv */
-bool daObjKanoke_c::_execute() {
+BOOL daObjKanoke_c::_execute() {
     /* Nonmatching */
 }
 
@@ -191,28 +191,28 @@ void daObjKanoke_c::setMtxHuta(cXyz*) {
 }
 
 /* 00001E4C-00001E6C       .text daObjKanokeCreate__FPv */
-static s32 daObjKanokeCreate(void*) {
-    /* Nonmatching */
+static s32 daObjKanokeCreate(void* i_this) {
+    return ((daObjKanoke_c*)i_this)->_create();
 }
 
 /* 00001E6C-00001E8C       .text daObjKanokeDelete__FPv */
-static BOOL daObjKanokeDelete(void*) {
-    /* Nonmatching */
+static BOOL daObjKanokeDelete(void* i_this) {
+    return ((daObjKanoke_c*)i_this)->_delete();
 }
 
 /* 00001E8C-00001EAC       .text daObjKanokeExecute__FPv */
-static BOOL daObjKanokeExecute(void*) {
-    /* Nonmatching */
+static BOOL daObjKanokeExecute(void* i_this) {
+    return ((daObjKanoke_c*)i_this)->_execute();
 }
 
 /* 00001EAC-00001ECC       .text daObjKanokeDraw__FPv */
-static BOOL daObjKanokeDraw(void*) {
-    /* Nonmatching */
+static BOOL daObjKanokeDraw(void* i_this) {
+    return ((daObjKanoke_c*)i_this)->_draw();
 }
 
 /* 00001ECC-00001ED4       .text daObjKanokeIsDelete__FPv */
 static BOOL daObjKanokeIsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daObjKanokeMethodTable = {

--- a/src/d/actor/d_a_obj_leaves.cpp
+++ b/src/d/actor/d_a_obj_leaves.cpp
@@ -96,28 +96,28 @@ bool daObjLeaves_c::_draw() {
 }
 
 /* 00001290-000012B0       .text daObjLeaves_Create__FP13daObjLeaves_c */
-static cPhs_State daObjLeaves_Create(daObjLeaves_c*) {
-    /* Nonmatching */
+static cPhs_State daObjLeaves_Create(daObjLeaves_c* i_this) {
+    return ((daObjLeaves_c*)i_this)->_create();
 }
 
 /* 000012B0-000012D4       .text daObjLeaves_Delete__FP13daObjLeaves_c */
-static BOOL daObjLeaves_Delete(daObjLeaves_c*) {
-    /* Nonmatching */
+static BOOL daObjLeaves_Delete(daObjLeaves_c* i_this) {
+    return ((daObjLeaves_c*)i_this)->_delete();
 }
 
 /* 000012D4-000012F8       .text daObjLeaves_Execute__FP13daObjLeaves_c */
-static BOOL daObjLeaves_Execute(daObjLeaves_c*) {
-    /* Nonmatching */
+static BOOL daObjLeaves_Execute(daObjLeaves_c* i_this) {
+    return ((daObjLeaves_c*)i_this)->_execute();
 }
 
 /* 000012F8-0000131C       .text daObjLeaves_Draw__FP13daObjLeaves_c */
-static BOOL daObjLeaves_Draw(daObjLeaves_c*) {
-    /* Nonmatching */
+static BOOL daObjLeaves_Draw(daObjLeaves_c* i_this) {
+    return ((daObjLeaves_c*)i_this)->_draw();
 }
 
 /* 0000131C-00001324       .text daObjLeaves_IsDelete__FP13daObjLeaves_c */
 static BOOL daObjLeaves_IsDelete(daObjLeaves_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daObjLeaves_Method = {

--- a/src/d/actor/d_a_obj_light.cpp
+++ b/src/d/actor/d_a_obj_light.cpp
@@ -105,28 +105,28 @@ bool daObjLight::Act_c::_draw() {
 namespace daObjLight {
 namespace {
 /* 00001528-00001548       .text Mthd_Create__Q210daObjLight27@unnamed@d_a_obj_light_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjLight::Act_c*)i_this)->_create();
 }
 
 /* 00001548-0000156C       .text Mthd_Delete__Q210daObjLight27@unnamed@d_a_obj_light_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjLight::Act_c*)i_this)->_delete();
 }
 
 /* 0000156C-00001590       .text Mthd_Execute__Q210daObjLight27@unnamed@d_a_obj_light_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjLight::Act_c*)i_this)->_execute();
 }
 
 /* 00001590-000015B4       .text Mthd_Draw__Q210daObjLight27@unnamed@d_a_obj_light_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daObjLight::Act_c*)i_this)->_draw();
 }
 
 /* 000015B4-000015BC       .text Mthd_IsDelete__Q210daObjLight27@unnamed@d_a_obj_light_cpp@FPv */
 BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class Mthd_Table = {

--- a/src/d/actor/d_a_obj_majyuu_door.cpp
+++ b/src/d/actor/d_a_obj_majyuu_door.cpp
@@ -125,28 +125,28 @@ bool daObj_MjDoor_c::_draw() {
 }
 
 /* 00000F28-00000F48       .text daObj_MjDoorCreate__FPv */
-static s32 daObj_MjDoorCreate(void*) {
-    /* Nonmatching */
+static s32 daObj_MjDoorCreate(void* i_this) {
+    return ((daObj_MjDoor_c*)i_this)->_create();
 }
 
 /* 00000F48-00000F6C       .text daObj_MjDoorDelete__FPv */
-static BOOL daObj_MjDoorDelete(void*) {
-    /* Nonmatching */
+static BOOL daObj_MjDoorDelete(void* i_this) {
+    return ((daObj_MjDoor_c*)i_this)->_delete();
 }
 
 /* 00000F6C-00000F90       .text daObj_MjDoorExecute__FPv */
-static BOOL daObj_MjDoorExecute(void*) {
-    /* Nonmatching */
+static BOOL daObj_MjDoorExecute(void* i_this) {
+    return ((daObj_MjDoor_c*)i_this)->_execute();
 }
 
 /* 00000F90-00000FB4       .text daObj_MjDoorDraw__FPv */
-static BOOL daObj_MjDoorDraw(void*) {
-    /* Nonmatching */
+static BOOL daObj_MjDoorDraw(void* i_this) {
+    return ((daObj_MjDoor_c*)i_this)->_draw();
 }
 
 /* 00000FB4-00000FBC       .text daObj_MjDoorIsDelete__FPv */
 static BOOL daObj_MjDoorIsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daObj_MjDoorMethodTable = {

--- a/src/d/actor/d_a_obj_mkie.cpp
+++ b/src/d/actor/d_a_obj_mkie.cpp
@@ -120,28 +120,28 @@ BOOL daObjMkie::Act_c::Draw() {
 namespace daObjMkie {
 namespace {
 /* 000015B8-000015D8       .text Mthd_Create__Q29daObjMkie26@unnamed@d_a_obj_mkie_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjMkie::Act_c*)i_this)->Mthd_Create();
 }
 
 /* 000015D8-000015F8       .text Mthd_Delete__Q29daObjMkie26@unnamed@d_a_obj_mkie_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjMkie::Act_c*)i_this)->Mthd_Delete();
 }
 
 /* 000015F8-00001618       .text Mthd_Execute__Q29daObjMkie26@unnamed@d_a_obj_mkie_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjMkie::Act_c*)i_this)->MoveBGExecute();
 }
 
 /* 00001618-00001644       .text Mthd_Draw__Q29daObjMkie26@unnamed@d_a_obj_mkie_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daObjMkie::Act_c*)i_this)->Draw();
 }
 
 /* 00001644-00001670       .text Mthd_IsDelete__Q29daObjMkie26@unnamed@d_a_obj_mkie_cpp@FPv */
-BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+BOOL Mthd_IsDelete(void* i_this) {
+    return ((daObjMkie::Act_c*)i_this)->IsDelete();
 }
 
 static actor_method_class Mthd_Table = {

--- a/src/d/actor/d_a_obj_mkiek.cpp
+++ b/src/d/actor/d_a_obj_mkiek.cpp
@@ -101,28 +101,28 @@ BOOL daObjMkiek::Act_c::Draw() {
 namespace daObjMkiek {
 namespace {
 /* 00000E1C-00000E3C       .text Mthd_Create__Q210daObjMkiek27@unnamed@d_a_obj_mkiek_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjMkiek::Act_c*)i_this)->Mthd_Create();
 }
 
 /* 00000E3C-00000E5C       .text Mthd_Delete__Q210daObjMkiek27@unnamed@d_a_obj_mkiek_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjMkiek::Act_c*)i_this)->Mthd_Delete();
 }
 
 /* 00000E5C-00000E7C       .text Mthd_Execute__Q210daObjMkiek27@unnamed@d_a_obj_mkiek_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjMkiek::Act_c*)i_this)->MoveBGExecute();
 }
 
 /* 00000E7C-00000EA8       .text Mthd_Draw__Q210daObjMkiek27@unnamed@d_a_obj_mkiek_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daObjMkiek::Act_c*)i_this)->Draw();
 }
 
 /* 00000EA8-00000ED4       .text Mthd_IsDelete__Q210daObjMkiek27@unnamed@d_a_obj_mkiek_cpp@FPv */
-BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+BOOL Mthd_IsDelete(void* i_this) {
+    return ((daObjMkiek::Act_c*)i_this)->IsDelete();
 }
 
 static actor_method_class Mthd_Table = {

--- a/src/d/actor/d_a_obj_mmrr.cpp
+++ b/src/d/actor/d_a_obj_mmrr.cpp
@@ -100,28 +100,28 @@ bool daObjMmrr::Act_c::_draw() {
 namespace daObjMmrr {
 namespace {
 /* 000017E8-00001808       .text Mthd_Create__Q29daObjMmrr26@unnamed@d_a_obj_mmrr_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjMmrr::Act_c*)i_this)->_create();
 }
 
 /* 00001808-0000182C       .text Mthd_Delete__Q29daObjMmrr26@unnamed@d_a_obj_mmrr_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjMmrr::Act_c*)i_this)->_delete();
 }
 
 /* 0000182C-00001850       .text Mthd_Execute__Q29daObjMmrr26@unnamed@d_a_obj_mmrr_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjMmrr::Act_c*)i_this)->_execute();
 }
 
 /* 00001850-00001874       .text Mthd_Draw__Q29daObjMmrr26@unnamed@d_a_obj_mmrr_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daObjMmrr::Act_c*)i_this)->_draw();
 }
 
 /* 00001874-0000187C       .text Mthd_IsDelete__Q29daObjMmrr26@unnamed@d_a_obj_mmrr_cpp@FPv */
 BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class Mthd_Table = {

--- a/src/d/actor/d_a_obj_msdan.cpp
+++ b/src/d/actor/d_a_obj_msdan.cpp
@@ -25,28 +25,28 @@ BOOL daObjMsdan::Act_c::Mthd_Delete() {
 namespace daObjMsdan {
 namespace {
 /* 000005F0-00000610       .text Mthd_Create__Q210daObjMsdan27@unnamed@d_a_obj_msdan_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjMsdan::Act_c*)i_this)->Mthd_Create();
 }
 
 /* 00000610-00000630       .text Mthd_Delete__Q210daObjMsdan27@unnamed@d_a_obj_msdan_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjMsdan::Act_c*)i_this)->Mthd_Delete();
 }
 
 /* 00000630-00000650       .text Mthd_Execute__Q210daObjMsdan27@unnamed@d_a_obj_msdan_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjMsdan::Act_c*)i_this)->Mthd_Execute();
 }
 
 /* 00000650-00000658       .text Mthd_Draw__Q210daObjMsdan27@unnamed@d_a_obj_msdan_cpp@FPv */
 BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00000658-00000660       .text Mthd_IsDelete__Q210daObjMsdan27@unnamed@d_a_obj_msdan_cpp@FPv */
 BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class Mthd_Msdan = {

--- a/src/d/actor/d_a_obj_msdan2.cpp
+++ b/src/d/actor/d_a_obj_msdan2.cpp
@@ -25,28 +25,28 @@ BOOL daObjMsdan2::Act_c::Mthd_Delete() {
 namespace daObjMsdan2 {
 namespace {
 /* 0000034C-0000036C       .text Mthd_Create__Q211daObjMsdan228@unnamed@d_a_obj_msdan2_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjMsdan2::Act_c*)i_this)->Mthd_Create();
 }
 
 /* 0000036C-0000038C       .text Mthd_Delete__Q211daObjMsdan228@unnamed@d_a_obj_msdan2_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjMsdan2::Act_c*)i_this)->Mthd_Delete();
 }
 
 /* 0000038C-000003AC       .text Mthd_Execute__Q211daObjMsdan228@unnamed@d_a_obj_msdan2_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjMsdan2::Act_c*)i_this)->Mthd_Execute();
 }
 
 /* 000003AC-000003B4       .text Mthd_Draw__Q211daObjMsdan228@unnamed@d_a_obj_msdan2_cpp@FPv */
 BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 000003B4-000003BC       .text Mthd_IsDelete__Q211daObjMsdan228@unnamed@d_a_obj_msdan2_cpp@FPv */
 BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class Mthd_Msdan2 = {

--- a/src/d/actor/d_a_obj_msdan_sub.cpp
+++ b/src/d/actor/d_a_obj_msdan_sub.cpp
@@ -55,28 +55,28 @@ BOOL daObjMsdanSub::Act_c::Draw() {
 namespace daObjMsdanSub {
 namespace {
 /* 00000C54-00000C74       .text Mthd_Create__Q213daObjMsdanSub31@unnamed@d_a_obj_msdan_sub_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjMsdanSub::Act_c*)i_this)->Mthd_Create();
 }
 
 /* 00000C74-00000C94       .text Mthd_Delete__Q213daObjMsdanSub31@unnamed@d_a_obj_msdan_sub_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjMsdanSub::Act_c*)i_this)->Mthd_Delete();
 }
 
 /* 00000C94-00000CB4       .text Mthd_Execute__Q213daObjMsdanSub31@unnamed@d_a_obj_msdan_sub_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjMsdanSub::Act_c*)i_this)->MoveBGExecute();
 }
 
 /* 00000CB4-00000CE0       .text Mthd_Draw__Q213daObjMsdanSub31@unnamed@d_a_obj_msdan_sub_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daObjMsdanSub::Act_c*)i_this)->Draw();
 }
 
 /* 00000CE0-00000D0C       .text Mthd_IsDelete__Q213daObjMsdanSub31@unnamed@d_a_obj_msdan_sub_cpp@FPv */
-BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+BOOL Mthd_IsDelete(void* i_this) {
+    return ((daObjMsdanSub::Act_c*)i_this)->IsDelete();
 }
 
 static actor_method_class Mthd_MsdanSub = {

--- a/src/d/actor/d_a_obj_msdan_sub2.cpp
+++ b/src/d/actor/d_a_obj_msdan_sub2.cpp
@@ -55,28 +55,28 @@ BOOL daObjMsdanSub2::Act_c::Draw() {
 namespace daObjMsdanSub2 {
 namespace {
 /* 000009AC-000009CC       .text Mthd_Create__Q214daObjMsdanSub232@unnamed@d_a_obj_msdan_sub2_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjMsdanSub2::Act_c*)i_this)->Mthd_Create();
 }
 
 /* 000009CC-000009EC       .text Mthd_Delete__Q214daObjMsdanSub232@unnamed@d_a_obj_msdan_sub2_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjMsdanSub2::Act_c*)i_this)->Mthd_Delete();
 }
 
 /* 000009EC-00000A0C       .text Mthd_Execute__Q214daObjMsdanSub232@unnamed@d_a_obj_msdan_sub2_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjMsdanSub2::Act_c*)i_this)->MoveBGExecute();
 }
 
 /* 00000A0C-00000A38       .text Mthd_Draw__Q214daObjMsdanSub232@unnamed@d_a_obj_msdan_sub2_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daObjMsdanSub2::Act_c*)i_this)->Draw();
 }
 
 /* 00000A38-00000A64       .text Mthd_IsDelete__Q214daObjMsdanSub232@unnamed@d_a_obj_msdan_sub2_cpp@FPv */
-BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+BOOL Mthd_IsDelete(void* i_this) {
+    return ((daObjMsdanSub2::Act_c*)i_this)->IsDelete();
 }
 
 static actor_method_class Mthd_MsdanSub2 = {

--- a/src/d/actor/d_a_obj_mshokki.cpp
+++ b/src/d/actor/d_a_obj_mshokki.cpp
@@ -63,28 +63,28 @@ bool daObjMshokki_c::_draw() {
 }
 
 /* 00000E84-00000EA4       .text daObjMshokki_Create__FP10fopAc_ac_c */
-static cPhs_State daObjMshokki_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daObjMshokki_Create(fopAc_ac_c* i_this) {
+    return ((daObjMshokki_c*)i_this)->_create();
 }
 
 /* 00000EA4-00000EC8       .text daObjMshokki_Delete__FP14daObjMshokki_c */
-static BOOL daObjMshokki_Delete(daObjMshokki_c*) {
-    /* Nonmatching */
+static BOOL daObjMshokki_Delete(daObjMshokki_c* i_this) {
+    return ((daObjMshokki_c*)i_this)->_delete();
 }
 
 /* 00000EC8-00000EEC       .text daObjMshokki_Execute__FP14daObjMshokki_c */
-static BOOL daObjMshokki_Execute(daObjMshokki_c*) {
-    /* Nonmatching */
+static BOOL daObjMshokki_Execute(daObjMshokki_c* i_this) {
+    return ((daObjMshokki_c*)i_this)->_execute();
 }
 
 /* 00000EEC-00000F10       .text daObjMshokki_Draw__FP14daObjMshokki_c */
-static BOOL daObjMshokki_Draw(daObjMshokki_c*) {
-    /* Nonmatching */
+static BOOL daObjMshokki_Draw(daObjMshokki_c* i_this) {
+    return ((daObjMshokki_c*)i_this)->_draw();
 }
 
 /* 00000F10-00000F18       .text daObjMshokki_IsDelete__FP14daObjMshokki_c */
 static BOOL daObjMshokki_IsDelete(daObjMshokki_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daObjMshokki_Method = {

--- a/src/d/actor/d_a_obj_nest.cpp
+++ b/src/d/actor/d_a_obj_nest.cpp
@@ -70,28 +70,28 @@ BOOL daObjNest::Act_c::Draw() {
 namespace daObjNest {
 namespace {
 /* 000007FC-0000081C       .text Mthd_Create__Q29daObjNest26@unnamed@d_a_obj_nest_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjNest::Act_c*)i_this)->Mthd_Create();
 }
 
 /* 0000081C-0000083C       .text Mthd_Delete__Q29daObjNest26@unnamed@d_a_obj_nest_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjNest::Act_c*)i_this)->Mthd_Delete();
 }
 
 /* 0000083C-0000085C       .text Mthd_Execute__Q29daObjNest26@unnamed@d_a_obj_nest_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjNest::Act_c*)i_this)->MoveBGExecute();
 }
 
 /* 0000085C-00000888       .text Mthd_Draw__Q29daObjNest26@unnamed@d_a_obj_nest_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daObjNest::Act_c*)i_this)->Draw();
 }
 
 /* 00000888-000008B4       .text Mthd_IsDelete__Q29daObjNest26@unnamed@d_a_obj_nest_cpp@FPv */
-BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+BOOL Mthd_IsDelete(void* i_this) {
+    return ((daObjNest::Act_c*)i_this)->IsDelete();
 }
 
 static actor_method_class Mthd_Table = {

--- a/src/d/actor/d_a_obj_ohatch.cpp
+++ b/src/d/actor/d_a_obj_ohatch.cpp
@@ -73,28 +73,28 @@ bool daObjOhatch_c::_draw() {
 }
 
 /* 00000B64-00000B84       .text daObjOhatch_Create__FP10fopAc_ac_c */
-static cPhs_State daObjOhatch_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daObjOhatch_Create(fopAc_ac_c* i_this) {
+    return ((daObjOhatch_c*)i_this)->_create();
 }
 
 /* 00000B84-00000BA8       .text daObjOhatch_Delete__FP13daObjOhatch_c */
-static BOOL daObjOhatch_Delete(daObjOhatch_c*) {
-    /* Nonmatching */
+static BOOL daObjOhatch_Delete(daObjOhatch_c* i_this) {
+    return ((daObjOhatch_c*)i_this)->_delete();
 }
 
 /* 00000BA8-00000BCC       .text daObjOhatch_Execute__FP13daObjOhatch_c */
-static BOOL daObjOhatch_Execute(daObjOhatch_c*) {
-    /* Nonmatching */
+static BOOL daObjOhatch_Execute(daObjOhatch_c* i_this) {
+    return ((daObjOhatch_c*)i_this)->_execute();
 }
 
 /* 00000BCC-00000BF0       .text daObjOhatch_Draw__FP13daObjOhatch_c */
-static BOOL daObjOhatch_Draw(daObjOhatch_c*) {
-    /* Nonmatching */
+static BOOL daObjOhatch_Draw(daObjOhatch_c* i_this) {
+    return ((daObjOhatch_c*)i_this)->_draw();
 }
 
 /* 00000BF0-00000BF8       .text daObjOhatch_IsDelete__FP13daObjOhatch_c */
 static BOOL daObjOhatch_IsDelete(daObjOhatch_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daObjOhatch_Method = {

--- a/src/d/actor/d_a_obj_ospbox.cpp
+++ b/src/d/actor/d_a_obj_ospbox.cpp
@@ -80,28 +80,28 @@ BOOL daObjOspbox::Act_c::Draw() {
 namespace daObjOspbox {
 namespace {
 /* 000011A4-000011C4       .text Mthd_Create__Q211daObjOspbox28@unnamed@d_a_obj_ospbox_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjOspbox::Act_c*)i_this)->Mthd_Create();
 }
 
 /* 000011C4-000011E4       .text Mthd_Delete__Q211daObjOspbox28@unnamed@d_a_obj_ospbox_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjOspbox::Act_c*)i_this)->Mthd_Delete();
 }
 
 /* 000011E4-00001204       .text Mthd_Execute__Q211daObjOspbox28@unnamed@d_a_obj_ospbox_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjOspbox::Act_c*)i_this)->MoveBGExecute();
 }
 
 /* 00001204-00001230       .text Mthd_Draw__Q211daObjOspbox28@unnamed@d_a_obj_ospbox_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daObjOspbox::Act_c*)i_this)->Draw();
 }
 
 /* 00001230-0000125C       .text Mthd_IsDelete__Q211daObjOspbox28@unnamed@d_a_obj_ospbox_cpp@FPv */
-BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+BOOL Mthd_IsDelete(void* i_this) {
+    return ((daObjOspbox::Act_c*)i_this)->IsDelete();
 }
 
 static actor_method_class Mthd_Table = {

--- a/src/d/actor/d_a_obj_plant.cpp
+++ b/src/d/actor/d_a_obj_plant.cpp
@@ -87,7 +87,7 @@ static BOOL daObjPlant_Execute(void*) {
 
 /* 00000A58-00000A60       .text daObjPlant_IsDelete__FPv */
 static BOOL daObjPlant_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daObj_PlantMethodTable = {

--- a/src/d/actor/d_a_obj_rcloud.cpp
+++ b/src/d/actor/d_a_obj_rcloud.cpp
@@ -68,28 +68,28 @@ bool daObjRcloud_c::_draw() {
 }
 
 /* 00000848-00000868       .text daObjRcloud_Create__FP10fopAc_ac_c */
-static cPhs_State daObjRcloud_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daObjRcloud_Create(fopAc_ac_c* i_this) {
+    return ((daObjRcloud_c*)i_this)->_create();
 }
 
 /* 00000868-0000088C       .text daObjRcloud_Delete__FP13daObjRcloud_c */
-static BOOL daObjRcloud_Delete(daObjRcloud_c*) {
-    /* Nonmatching */
+static BOOL daObjRcloud_Delete(daObjRcloud_c* i_this) {
+    return ((daObjRcloud_c*)i_this)->_delete();
 }
 
 /* 0000088C-000008B0       .text daObjRcloud_Execute__FP13daObjRcloud_c */
-static BOOL daObjRcloud_Execute(daObjRcloud_c*) {
-    /* Nonmatching */
+static BOOL daObjRcloud_Execute(daObjRcloud_c* i_this) {
+    return ((daObjRcloud_c*)i_this)->_execute();
 }
 
 /* 000008B0-000008D4       .text daObjRcloud_Draw__FP13daObjRcloud_c */
-static BOOL daObjRcloud_Draw(daObjRcloud_c*) {
-    /* Nonmatching */
+static BOOL daObjRcloud_Draw(daObjRcloud_c* i_this) {
+    return ((daObjRcloud_c*)i_this)->_draw();
 }
 
 /* 000008D4-000008DC       .text daObjRcloud_IsDelete__FP13daObjRcloud_c */
 static BOOL daObjRcloud_IsDelete(daObjRcloud_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daObjRcloud_Method = {

--- a/src/d/actor/d_a_obj_rflw.cpp
+++ b/src/d/actor/d_a_obj_rflw.cpp
@@ -87,7 +87,7 @@ static BOOL daObjRflw_Execute(void*) {
 
 /* 000009EC-000009F4       .text daObjRflw_IsDelete__FPv */
 static BOOL daObjRflw_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daObj_RflwMethodTable = {

--- a/src/d/actor/d_a_obj_stair.cpp
+++ b/src/d/actor/d_a_obj_stair.cpp
@@ -76,8 +76,8 @@ BOOL daObj_Stair_c::Delete() {
 }
 
 /* 000004B8-000004D8       .text daObj_StairCreate__FPv */
-static s32 daObj_StairCreate(void*) {
-    /* Nonmatching */
+static s32 daObj_StairCreate(void* i_this) {
+    return ((daObj_Stair_c*)i_this)->_create();
 }
 
 /* 000004D8-00000854       .text _create__13daObj_Stair_cFv */
@@ -91,8 +91,8 @@ static BOOL daObj_StairDelete(void*) {
 }
 
 /* 00000AFC-00000B20       .text daObj_StairExecute__FPv */
-static BOOL daObj_StairExecute(void*) {
-    /* Nonmatching */
+static BOOL daObj_StairExecute(void* i_this) {
+    return ((daObj_Stair_c*)i_this)->_execute();
 }
 
 /* 00000B20-00001364       .text _execute__13daObj_Stair_cFv */
@@ -107,7 +107,7 @@ static BOOL daObj_StairDraw(void*) {
 
 /* 0000139C-000013A4       .text daObj_StairIsDelete__FPv */
 static BOOL daObj_StairIsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daObj_StairMethodTable = {

--- a/src/d/actor/d_a_obj_swflat.cpp
+++ b/src/d/actor/d_a_obj_swflat.cpp
@@ -99,28 +99,28 @@ BOOL daObjSwflat::Act_c::IsDelete() {
 namespace daObjSwflat {
 namespace {
 /* 000012DC-000012FC       .text Mthd_Create__Q211daObjSwflat28@unnamed@d_a_obj_swflat_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjSwflat::Act_c*)i_this)->Mthd_Create();
 }
 
 /* 000012FC-0000131C       .text Mthd_Delete__Q211daObjSwflat28@unnamed@d_a_obj_swflat_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjSwflat::Act_c*)i_this)->Mthd_Delete();
 }
 
 /* 0000131C-0000133C       .text Mthd_Execute__Q211daObjSwflat28@unnamed@d_a_obj_swflat_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjSwflat::Act_c*)i_this)->MoveBGExecute();
 }
 
 /* 0000133C-00001368       .text Mthd_Draw__Q211daObjSwflat28@unnamed@d_a_obj_swflat_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daObjSwflat::Act_c*)i_this)->Draw();
 }
 
 /* 00001368-00001394       .text Mthd_IsDelete__Q211daObjSwflat28@unnamed@d_a_obj_swflat_cpp@FPv */
-BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+BOOL Mthd_IsDelete(void* i_this) {
+    return ((daObjSwflat::Act_c*)i_this)->IsDelete();
 }
 
 static actor_method_class Mthd_Table = {

--- a/src/d/actor/d_a_obj_swlight.cpp
+++ b/src/d/actor/d_a_obj_swlight.cpp
@@ -145,28 +145,28 @@ bool daObjSwlight::Act_c::_draw() {
 namespace daObjSwlight {
 namespace {
 /* 00001AC4-00001AE4       .text Mthd_Create__Q212daObjSwlight29@unnamed@d_a_obj_swlight_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjSwlight::Act_c*)i_this)->_create();
 }
 
 /* 00001AE4-00001B08       .text Mthd_Delete__Q212daObjSwlight29@unnamed@d_a_obj_swlight_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjSwlight::Act_c*)i_this)->_delete();
 }
 
 /* 00001B08-00001B2C       .text Mthd_Execute__Q212daObjSwlight29@unnamed@d_a_obj_swlight_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjSwlight::Act_c*)i_this)->_execute();
 }
 
 /* 00001B2C-00001B50       .text Mthd_Draw__Q212daObjSwlight29@unnamed@d_a_obj_swlight_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daObjSwlight::Act_c*)i_this)->_draw();
 }
 
 /* 00001B50-00001B58       .text Mthd_IsDelete__Q212daObjSwlight29@unnamed@d_a_obj_swlight_cpp@FPv */
 BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class Mthd_Table = {

--- a/src/d/actor/d_a_obj_table.cpp
+++ b/src/d/actor/d_a_obj_table.cpp
@@ -55,28 +55,28 @@ BOOL daObjTable::Act_c::Draw() {
 namespace daObjTable {
 namespace {
 /* 00000608-00000628       .text Mthd_Create__Q210daObjTable27@unnamed@d_a_obj_table_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjTable::Act_c*)i_this)->Mthd_Create();
 }
 
 /* 00000628-00000648       .text Mthd_Delete__Q210daObjTable27@unnamed@d_a_obj_table_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjTable::Act_c*)i_this)->Mthd_Delete();
 }
 
 /* 00000648-00000668       .text Mthd_Execute__Q210daObjTable27@unnamed@d_a_obj_table_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjTable::Act_c*)i_this)->MoveBGExecute();
 }
 
 /* 00000668-00000694       .text Mthd_Draw__Q210daObjTable27@unnamed@d_a_obj_table_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daObjTable::Act_c*)i_this)->Draw();
 }
 
 /* 00000694-000006C0       .text Mthd_IsDelete__Q210daObjTable27@unnamed@d_a_obj_table_cpp@FPv */
-BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+BOOL Mthd_IsDelete(void* i_this) {
+    return ((daObjTable::Act_c*)i_this)->IsDelete();
 }
 
 static actor_method_class Mthd_Table = {

--- a/src/d/actor/d_a_obj_table.cpp
+++ b/src/d/actor/d_a_obj_table.cpp
@@ -55,28 +55,28 @@ BOOL daObjTable::Act_c::Draw() {
 namespace daObjTable {
 namespace {
 /* 00000608-00000628       .text Mthd_Create__Q210daObjTable27@unnamed@d_a_obj_table_cpp@FPv */
-cPhs_State Mthd_Create(void* i_this) {
-    return ((daObjTable::Act_c*)i_this)->Mthd_Create();
+cPhs_State Mthd_Create(void*) {
+    /* Nonmatching */
 }
 
 /* 00000628-00000648       .text Mthd_Delete__Q210daObjTable27@unnamed@d_a_obj_table_cpp@FPv */
-BOOL Mthd_Delete(void* i_this) {
-    return ((daObjTable::Act_c*)i_this)->Mthd_Delete();
+BOOL Mthd_Delete(void*) {
+    /* Nonmatching */
 }
 
 /* 00000648-00000668       .text Mthd_Execute__Q210daObjTable27@unnamed@d_a_obj_table_cpp@FPv */
-BOOL Mthd_Execute(void* i_this) {
-    return ((daObjTable::Act_c*)i_this)->MoveBGExecute();
+BOOL Mthd_Execute(void*) {
+    /* Nonmatching */
 }
 
 /* 00000668-00000694       .text Mthd_Draw__Q210daObjTable27@unnamed@d_a_obj_table_cpp@FPv */
-BOOL Mthd_Draw(void* i_this) {
-    return ((daObjTable::Act_c*)i_this)->Draw();
+BOOL Mthd_Draw(void*) {
+    /* Nonmatching */
 }
 
 /* 00000694-000006C0       .text Mthd_IsDelete__Q210daObjTable27@unnamed@d_a_obj_table_cpp@FPv */
-BOOL Mthd_IsDelete(void* i_this) {
-    return ((daObjTable::Act_c*)i_this)->IsDelete();
+BOOL Mthd_IsDelete(void*) {
+    /* Nonmatching */
 }
 
 static actor_method_class Mthd_Table = {

--- a/src/d/actor/d_a_obj_tapestry.cpp
+++ b/src/d/actor/d_a_obj_tapestry.cpp
@@ -318,28 +318,28 @@ bool daObjTapestry_c::_draw() {
 }
 
 /* 00005C44-00005C64       .text daObjTapestry_Create__FP10fopAc_ac_c */
-static cPhs_State daObjTapestry_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daObjTapestry_Create(fopAc_ac_c* i_this) {
+    return ((daObjTapestry_c*)i_this)->_create();
 }
 
 /* 00005C64-00005C88       .text daObjTapestry_Delete__FP15daObjTapestry_c */
-static BOOL daObjTapestry_Delete(daObjTapestry_c*) {
-    /* Nonmatching */
+static BOOL daObjTapestry_Delete(daObjTapestry_c* i_this) {
+    return ((daObjTapestry_c*)i_this)->_delete();
 }
 
 /* 00005C88-00005CAC       .text daObjTapestry_Execute__FP15daObjTapestry_c */
-static BOOL daObjTapestry_Execute(daObjTapestry_c*) {
-    /* Nonmatching */
+static BOOL daObjTapestry_Execute(daObjTapestry_c* i_this) {
+    return ((daObjTapestry_c*)i_this)->_execute();
 }
 
 /* 00005CAC-00005CD0       .text daObjTapestry_Draw__FP15daObjTapestry_c */
-static BOOL daObjTapestry_Draw(daObjTapestry_c*) {
-    /* Nonmatching */
+static BOOL daObjTapestry_Draw(daObjTapestry_c* i_this) {
+    return ((daObjTapestry_c*)i_this)->_draw();
 }
 
 /* 00005CD0-00005CD8       .text daObjTapestry_IsDelete__FP15daObjTapestry_c */
 static BOOL daObjTapestry_IsDelete(daObjTapestry_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daObjTapestry_Method = {

--- a/src/d/actor/d_a_obj_tenmado.cpp
+++ b/src/d/actor/d_a_obj_tenmado.cpp
@@ -55,28 +55,28 @@ BOOL daObjTenmado::Act_c::Draw() {
 namespace daObjTenmado {
 namespace {
 /* 00000750-00000770       .text Mthd_Create__Q212daObjTenmado29@unnamed@d_a_obj_tenmado_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjTenmado::Act_c*)i_this)->Mthd_Create();
 }
 
 /* 00000770-00000790       .text Mthd_Delete__Q212daObjTenmado29@unnamed@d_a_obj_tenmado_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjTenmado::Act_c*)i_this)->Mthd_Delete();
 }
 
 /* 00000790-000007B0       .text Mthd_Execute__Q212daObjTenmado29@unnamed@d_a_obj_tenmado_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjTenmado::Act_c*)i_this)->MoveBGExecute();
 }
 
 /* 000007B0-000007DC       .text Mthd_Draw__Q212daObjTenmado29@unnamed@d_a_obj_tenmado_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daObjTenmado::Act_c*)i_this)->Draw();
 }
 
 /* 000007DC-00000808       .text Mthd_IsDelete__Q212daObjTenmado29@unnamed@d_a_obj_tenmado_cpp@FPv */
-BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+BOOL Mthd_IsDelete(void* i_this) {
+    return ((daObjTenmado::Act_c*)i_this)->IsDelete();
 }
 
 static actor_method_class Mthd_Tenmado = {

--- a/src/d/actor/d_a_obj_tide.cpp
+++ b/src/d/actor/d_a_obj_tide.cpp
@@ -155,28 +155,28 @@ BOOL daObjTide::Act_c::Draw() {
 namespace daObjTide {
 namespace {
 /* 00001DD0-00001DF0       .text Mthd_Create__Q29daObjTide26@unnamed@d_a_obj_tide_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjTide::Act_c*)i_this)->Mthd_Create();
 }
 
 /* 00001DF0-00001E10       .text Mthd_Delete__Q29daObjTide26@unnamed@d_a_obj_tide_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjTide::Act_c*)i_this)->Mthd_Delete();
 }
 
 /* 00001E10-00001E30       .text Mthd_Execute__Q29daObjTide26@unnamed@d_a_obj_tide_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjTide::Act_c*)i_this)->MoveBGExecute();
 }
 
 /* 00001E30-00001E5C       .text Mthd_Draw__Q29daObjTide26@unnamed@d_a_obj_tide_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daObjTide::Act_c*)i_this)->Draw();
 }
 
 /* 00001E5C-00001E88       .text Mthd_IsDelete__Q29daObjTide26@unnamed@d_a_obj_tide_cpp@FPv */
-BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+BOOL Mthd_IsDelete(void* i_this) {
+    return ((daObjTide::Act_c*)i_this)->IsDelete();
 }
 
 static actor_method_class Mthd_Table = {

--- a/src/d/actor/d_a_obj_tntrap.cpp
+++ b/src/d/actor/d_a_obj_tntrap.cpp
@@ -148,28 +148,28 @@ bool daObjTnTrap_c::_draw() {
 }
 
 /* 00001BF0-00001C10       .text daObjTnTrap_Create__FP10fopAc_ac_c */
-static cPhs_State daObjTnTrap_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daObjTnTrap_Create(fopAc_ac_c* i_this) {
+    return ((daObjTnTrap_c*)i_this)->_create();
 }
 
 /* 00001C10-00001C34       .text daObjTnTrap_Delete__FP13daObjTnTrap_c */
-static BOOL daObjTnTrap_Delete(daObjTnTrap_c*) {
-    /* Nonmatching */
+static BOOL daObjTnTrap_Delete(daObjTnTrap_c* i_this) {
+    return ((daObjTnTrap_c*)i_this)->_delete();
 }
 
 /* 00001C34-00001C58       .text daObjTnTrap_Execute__FP13daObjTnTrap_c */
-static BOOL daObjTnTrap_Execute(daObjTnTrap_c*) {
-    /* Nonmatching */
+static BOOL daObjTnTrap_Execute(daObjTnTrap_c* i_this) {
+    return ((daObjTnTrap_c*)i_this)->_execute();
 }
 
 /* 00001C58-00001C7C       .text daObjTnTrap_Draw__FP13daObjTnTrap_c */
-static BOOL daObjTnTrap_Draw(daObjTnTrap_c*) {
-    /* Nonmatching */
+static BOOL daObjTnTrap_Draw(daObjTnTrap_c* i_this) {
+    return ((daObjTnTrap_c*)i_this)->_draw();
 }
 
 /* 00001C7C-00001C84       .text daObjTnTrap_IsDelete__FP13daObjTnTrap_c */
 static BOOL daObjTnTrap_IsDelete(daObjTnTrap_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daObjTnTrap_Method = {

--- a/src/d/actor/d_a_obj_tntrap.cpp
+++ b/src/d/actor/d_a_obj_tntrap.cpp
@@ -148,28 +148,28 @@ bool daObjTnTrap_c::_draw() {
 }
 
 /* 00001BF0-00001C10       .text daObjTnTrap_Create__FP10fopAc_ac_c */
-static cPhs_State daObjTnTrap_Create(fopAc_ac_c* i_this) {
-    return ((daObjTnTrap_c*)i_this)->_create();
+static cPhs_State daObjTnTrap_Create(fopAc_ac_c*) {
+    /* Nonmatching */
 }
 
 /* 00001C10-00001C34       .text daObjTnTrap_Delete__FP13daObjTnTrap_c */
-static BOOL daObjTnTrap_Delete(daObjTnTrap_c* i_this) {
-    return ((daObjTnTrap_c*)i_this)->_delete();
+static BOOL daObjTnTrap_Delete(daObjTnTrap_c*) {
+    /* Nonmatching */
 }
 
 /* 00001C34-00001C58       .text daObjTnTrap_Execute__FP13daObjTnTrap_c */
-static BOOL daObjTnTrap_Execute(daObjTnTrap_c* i_this) {
-    return ((daObjTnTrap_c*)i_this)->_execute();
+static BOOL daObjTnTrap_Execute(daObjTnTrap_c*) {
+    /* Nonmatching */
 }
 
 /* 00001C58-00001C7C       .text daObjTnTrap_Draw__FP13daObjTnTrap_c */
-static BOOL daObjTnTrap_Draw(daObjTnTrap_c* i_this) {
-    return ((daObjTnTrap_c*)i_this)->_draw();
+static BOOL daObjTnTrap_Draw(daObjTnTrap_c*) {
+    /* Nonmatching */
 }
 
 /* 00001C7C-00001C84       .text daObjTnTrap_IsDelete__FP13daObjTnTrap_c */
 static BOOL daObjTnTrap_IsDelete(daObjTnTrap_c*) {
-    return TRUE;
+    /* Nonmatching */
 }
 
 static actor_method_class l_daObjTnTrap_Method = {

--- a/src/d/actor/d_a_obj_tousekiki.cpp
+++ b/src/d/actor/d_a_obj_tousekiki.cpp
@@ -18,8 +18,8 @@ void daObj_Tousekiki_c::CreateHeap() {
 }
 
 /* 000002BC-000002DC       .text daObj_TousekikiCreate__FPv */
-static s32 daObj_TousekikiCreate(void*) {
-    /* Nonmatching */
+static s32 daObj_TousekikiCreate(void* i_this) {
+    return ((daObj_Tousekiki_c*)i_this)->_create();
 }
 
 /* 000002DC-000004F4       .text _create__17daObj_Tousekiki_cFv */
@@ -44,7 +44,7 @@ static BOOL daObj_TousekikiDraw(void*) {
 
 /* 00000934-0000093C       .text daObj_TousekikiIsDelete__FPv */
 static BOOL daObj_TousekikiIsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daObj_TousekikiMethodTable = {

--- a/src/d/actor/d_a_obj_trap.cpp
+++ b/src/d/actor/d_a_obj_trap.cpp
@@ -109,28 +109,28 @@ bool daObjTrap_c::_draw() {
 
 namespace {
 /* 00002D54-00002D74       .text Mthd_Create__26@unnamed@d_a_obj_trap_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjTrap_c*)i_this)->_create();
 }
 
 /* 00002D74-00002D98       .text Mthd_Delete__26@unnamed@d_a_obj_trap_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjTrap_c*)i_this)->_delete();
 }
 
 /* 00002D98-00002DBC       .text Mthd_Execute__26@unnamed@d_a_obj_trap_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjTrap_c*)i_this)->_execute();
 }
 
 /* 00002DBC-00002DE0       .text Mthd_Draw__26@unnamed@d_a_obj_trap_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daObjTrap_c*)i_this)->_draw();
 }
 
 /* 00002DE0-00002DE8       .text Mthd_IsDelete__26@unnamed@d_a_obj_trap_cpp@FPv */
 BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class Trap_Mthd_Table = {

--- a/src/d/actor/d_a_obj_tribox.cpp
+++ b/src/d/actor/d_a_obj_tribox.cpp
@@ -340,28 +340,28 @@ bool daObjTribox::Act_c::_draw() {
 namespace daObjTribox {
 namespace {
 /* 00003538-00003558       .text Mthd_Create__Q211daObjTribox28@unnamed@d_a_obj_tribox_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjTribox::Act_c*)i_this)->_create();
 }
 
 /* 00003558-0000357C       .text Mthd_Delete__Q211daObjTribox28@unnamed@d_a_obj_tribox_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjTribox::Act_c*)i_this)->_delete();
 }
 
 /* 0000357C-000035A0       .text Mthd_Execute__Q211daObjTribox28@unnamed@d_a_obj_tribox_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjTribox::Act_c*)i_this)->_execute();
 }
 
 /* 000035A0-000035C4       .text Mthd_Draw__Q211daObjTribox28@unnamed@d_a_obj_tribox_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daObjTribox::Act_c*)i_this)->_draw();
 }
 
 /* 000035C4-000035CC       .text Mthd_IsDelete__Q211daObjTribox28@unnamed@d_a_obj_tribox_cpp@FPv */
 BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class Mthd_Table = {

--- a/src/d/actor/d_a_obj_try.cpp
+++ b/src/d/actor/d_a_obj_try.cpp
@@ -225,28 +225,28 @@ bool daObjTry::Act_c::_draw() {
 namespace daObjTry {
 namespace {
 /* 00002EA4-00002EC4       .text Mthd_Create__Q28daObjTry25@unnamed@d_a_obj_try_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjTry::Act_c*)i_this)->_create();
 }
 
 /* 00002EC4-00002EE8       .text Mthd_Delete__Q28daObjTry25@unnamed@d_a_obj_try_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjTry::Act_c*)i_this)->_delete();
 }
 
 /* 00002EE8-00002F0C       .text Mthd_Execute__Q28daObjTry25@unnamed@d_a_obj_try_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjTry::Act_c*)i_this)->_execute();
 }
 
 /* 00002F0C-00002F30       .text Mthd_Draw__Q28daObjTry25@unnamed@d_a_obj_try_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daObjTry::Act_c*)i_this)->_draw();
 }
 
 /* 00002F30-00002F38       .text Mthd_IsDelete__Q28daObjTry25@unnamed@d_a_obj_try_cpp@FPv */
 BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class Mthd_Table = {

--- a/src/d/actor/d_a_obj_volcano.cpp
+++ b/src/d/actor/d_a_obj_volcano.cpp
@@ -142,28 +142,28 @@ BOOL daObjVolcano::Act_c::Draw() {
 namespace daObjVolcano {
 namespace {
 /* 00001B8C-00001BAC       .text Mthd_Create__Q212daObjVolcano29@unnamed@d_a_obj_volcano_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjVolcano::Act_c*)i_this)->Mthd_Create();
 }
 
 /* 00001BAC-00001BCC       .text Mthd_Delete__Q212daObjVolcano29@unnamed@d_a_obj_volcano_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjVolcano::Act_c*)i_this)->Mthd_Delete();
 }
 
 /* 00001BCC-00001BEC       .text Mthd_Execute__Q212daObjVolcano29@unnamed@d_a_obj_volcano_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjVolcano::Act_c*)i_this)->MoveBGExecute();
 }
 
 /* 00001BEC-00001C18       .text Mthd_Draw__Q212daObjVolcano29@unnamed@d_a_obj_volcano_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daObjVolcano::Act_c*)i_this)->Draw();
 }
 
 /* 00001C18-00001C44       .text Mthd_IsDelete__Q212daObjVolcano29@unnamed@d_a_obj_volcano_cpp@FPv */
-BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+BOOL Mthd_IsDelete(void* i_this) {
+    return ((daObjVolcano::Act_c*)i_this)->IsDelete();
 }
 
 static actor_method_class Mthd_Table = {

--- a/src/d/actor/d_a_obj_vtil.cpp
+++ b/src/d/actor/d_a_obj_vtil.cpp
@@ -174,28 +174,28 @@ bool daObjVtil_c::_draw() {
 
 namespace {
 /* 00001864-00001884       .text Mthd_Create__26@unnamed@d_a_obj_vtil_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjVtil_c*)i_this)->_create();
 }
 
 /* 00001884-000018A8       .text Mthd_Delete__26@unnamed@d_a_obj_vtil_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjVtil_c*)i_this)->_delete();
 }
 
 /* 000018A8-000018CC       .text Mthd_Execute__26@unnamed@d_a_obj_vtil_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjVtil_c*)i_this)->_execute();
 }
 
 /* 000018CC-000018F0       .text Mthd_Draw__26@unnamed@d_a_obj_vtil_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daObjVtil_c*)i_this)->_draw();
 }
 
 /* 000018F0-000018F8       .text Mthd_IsDelete__26@unnamed@d_a_obj_vtil_cpp@FPv */
 BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class Vtil_Mthd_Table = {

--- a/src/d/actor/d_a_obj_vyasi.cpp
+++ b/src/d/actor/d_a_obj_vyasi.cpp
@@ -145,28 +145,28 @@ bool daObjVyasi::Act_c::_draw() {
 namespace daObjVyasi {
 namespace {
 /* 00002A6C-00002A8C       .text Mthd_Create__Q210daObjVyasi27@unnamed@d_a_obj_vyasi_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daObjVyasi::Act_c*)i_this)->_create();
 }
 
 /* 00002A8C-00002AB0       .text Mthd_Delete__Q210daObjVyasi27@unnamed@d_a_obj_vyasi_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daObjVyasi::Act_c*)i_this)->_delete();
 }
 
 /* 00002AB0-00002AD4       .text Mthd_Execute__Q210daObjVyasi27@unnamed@d_a_obj_vyasi_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daObjVyasi::Act_c*)i_this)->_execute();
 }
 
 /* 00002AD4-00002AF8       .text Mthd_Draw__Q210daObjVyasi27@unnamed@d_a_obj_vyasi_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daObjVyasi::Act_c*)i_this)->_draw();
 }
 
 /* 00002AF8-00002B00       .text Mthd_IsDelete__Q210daObjVyasi27@unnamed@d_a_obj_vyasi_cpp@FPv */
 BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class Mthd_Table = {

--- a/src/d/actor/d_a_obj_warpt.cpp
+++ b/src/d/actor/d_a_obj_warpt.cpp
@@ -267,28 +267,28 @@ bool daObj_Warpt_c::_delete() {
 }
 
 /* 00002858-00002878       .text daObj_WarptCreate__FPv */
-static s32 daObj_WarptCreate(void*) {
-    /* Nonmatching */
+static s32 daObj_WarptCreate(void* i_this) {
+    return ((daObj_Warpt_c*)i_this)->_create();
 }
 
 /* 00002878-0000289C       .text daObj_WarptDelete__FPv */
-static BOOL daObj_WarptDelete(void*) {
-    /* Nonmatching */
+static BOOL daObj_WarptDelete(void* i_this) {
+    return ((daObj_Warpt_c*)i_this)->_delete();
 }
 
 /* 0000289C-000028C0       .text daObj_WarptExecute__FPv */
-static BOOL daObj_WarptExecute(void*) {
-    /* Nonmatching */
+static BOOL daObj_WarptExecute(void* i_this) {
+    return ((daObj_Warpt_c*)i_this)->_execute();
 }
 
 /* 000028C0-000028E4       .text daObj_WarptDraw__FPv */
-static BOOL daObj_WarptDraw(void*) {
-    /* Nonmatching */
+static BOOL daObj_WarptDraw(void* i_this) {
+    return ((daObj_Warpt_c*)i_this)->_draw();
 }
 
 /* 000028E4-000028EC       .text daObj_WarptIsDelete__FPv */
 static BOOL daObj_WarptIsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daObj_WarptMethodTable = {

--- a/src/d/actor/d_a_oq.cpp
+++ b/src/d/actor/d_a_oq.cpp
@@ -96,7 +96,7 @@ static BOOL daOQ_Execute(oq_class*) {
 
 /* 00004274-0000427C       .text daOQ_IsDelete__FP8oq_class */
 static BOOL daOQ_IsDelete(oq_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 0000427C-00004300       .text daOQ_Delete__FP8oq_class */

--- a/src/d/actor/d_a_oship.cpp
+++ b/src/d/actor/d_a_oship.cpp
@@ -245,13 +245,13 @@ bool daOship_c::_delete() {
 }
 
 /* 00003F20-00003F40       .text daOshipCreate__FPv */
-static cPhs_State daOshipCreate(void*) {
-    /* Nonmatching */
+static cPhs_State daOshipCreate(void* i_this) {
+    return ((daOship_c*)i_this)->_create();
 }
 
 /* 00003F40-00003F64       .text daOshipDelete__FPv */
-static BOOL daOshipDelete(void*) {
-    /* Nonmatching */
+static BOOL daOshipDelete(void* i_this) {
+    return ((daOship_c*)i_this)->_delete();
 }
 
 /* 00003F64-00003F88       .text daOshipExecute__FPv */
@@ -260,13 +260,13 @@ static BOOL daOshipExecute(void*) {
 }
 
 /* 00003F88-00003FAC       .text daOshipDraw__FPv */
-static BOOL daOshipDraw(void*) {
-    /* Nonmatching */
+static BOOL daOshipDraw(void* i_this) {
+    return ((daOship_c*)i_this)->_draw();
 }
 
 /* 00003FAC-00003FB4       .text daOshipIsDelete__FPv */
 static BOOL daOshipIsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daOshipMethodTable = {

--- a/src/d/actor/d_a_ph.cpp
+++ b/src/d/actor/d_a_ph.cpp
@@ -150,7 +150,7 @@ static BOOL daPH_Execute(ph_class*) {
 
 /* 000061A4-000061AC       .text daPH_IsDelete__FP8ph_class */
 static BOOL daPH_IsDelete(ph_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 000061AC-00006224       .text daPH_Delete__FP8ph_class */

--- a/src/d/actor/d_a_pt.cpp
+++ b/src/d/actor/d_a_pt.cpp
@@ -100,7 +100,7 @@ static BOOL daPt_Execute(pt_class*) {
 
 /* 000043C8-000043D0       .text daPt_IsDelete__FP8pt_class */
 static BOOL daPt_IsDelete(pt_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 000043D0-00004540       .text daPt_Delete__FP8pt_class */

--- a/src/d/actor/d_a_pz.cpp
+++ b/src/d/actor/d_a_pz.cpp
@@ -405,28 +405,28 @@ bool daPz_c::_delete() {
 }
 
 /* 00007E20-00007E40       .text daPzCreate__FPv */
-static cPhs_State daPzCreate(void*) {
-    /* Nonmatching */
+static cPhs_State daPzCreate(void* i_this) {
+    return ((daPz_c*)i_this)->_create();
 }
 
 /* 00007E40-00007E64       .text daPzDelete__FPv */
-static BOOL daPzDelete(void*) {
-    /* Nonmatching */
+static BOOL daPzDelete(void* i_this) {
+    return ((daPz_c*)i_this)->_delete();
 }
 
 /* 00007E64-00007E88       .text daPzExecute__FPv */
-static BOOL daPzExecute(void*) {
-    /* Nonmatching */
+static BOOL daPzExecute(void* i_this) {
+    return ((daPz_c*)i_this)->_execute();
 }
 
 /* 00007E88-00007EAC       .text daPzDraw__FPv */
-static BOOL daPzDraw(void*) {
-    /* Nonmatching */
+static BOOL daPzDraw(void* i_this) {
+    return ((daPz_c*)i_this)->_draw();
 }
 
 /* 00007EAC-00007EB4       .text daPzIsDelete__FPv */
 static BOOL daPzIsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daPzMethodTable = {

--- a/src/d/actor/d_a_saku.cpp
+++ b/src/d/actor/d_a_saku.cpp
@@ -158,8 +158,8 @@ void changeXluMaterialAlpha(J3DMaterial*, unsigned char, bool) {
 }
 
 /* 00001B98-00001BB8       .text daSaku_Create__FP10fopAc_ac_c */
-static cPhs_State daSaku_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daSaku_Create(fopAc_ac_c* i_this) {
+    return ((daSaku_c*)i_this)->_daSaku_create();
 }
 
 /* 00001BB8-00001F28       .text _daSaku_create__8daSaku_cFv */
@@ -174,7 +174,7 @@ static BOOL daSaku_Delete(daSaku_c*) {
 
 /* 000023D8-000023E0       .text daSaku_IsDelete__FP8daSaku_c */
 static BOOL daSaku_IsDelete(daSaku_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 000023E0-0000242C       .text daSaku_Draw__FP8daSaku_c */

--- a/src/d/actor/d_a_salvage.cpp
+++ b/src/d/actor/d_a_salvage.cpp
@@ -143,28 +143,28 @@ void daSalvage_c::debugDraw() {
 }
 
 /* 00002410-00002430       .text daSalvageCreate__FPv */
-static s32 daSalvageCreate(void*) {
-    /* Nonmatching */
+static s32 daSalvageCreate(void* i_this) {
+    return ((daSalvage_c*)i_this)->_create();
 }
 
 /* 00002430-00002454       .text daSalvageDelete__FPv */
-static BOOL daSalvageDelete(void*) {
-    /* Nonmatching */
+static BOOL daSalvageDelete(void* i_this) {
+    return ((daSalvage_c*)i_this)->_delete();
 }
 
 /* 00002454-00002478       .text daSalvageExecute__FPv */
-static BOOL daSalvageExecute(void*) {
-    /* Nonmatching */
+static BOOL daSalvageExecute(void* i_this) {
+    return ((daSalvage_c*)i_this)->_execute();
 }
 
 /* 00002478-0000249C       .text daSalvageDraw__FPv */
-static BOOL daSalvageDraw(void*) {
-    /* Nonmatching */
+static BOOL daSalvageDraw(void* i_this) {
+    return ((daSalvage_c*)i_this)->_draw();
 }
 
 /* 0000249C-000024A4       .text daSalvageIsDelete__FPv */
 static BOOL daSalvageIsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daSalvageMethodTable = {

--- a/src/d/actor/d_a_salvage_tbox.cpp
+++ b/src/d/actor/d_a_salvage_tbox.cpp
@@ -113,13 +113,13 @@ void daSTBox_c::actWaitDummy(int) {
 }
 
 /* 000013BC-000013DC       .text daSTBox_Create__FPv */
-static cPhs_State daSTBox_Create(void*) {
-    /* Nonmatching */
+static cPhs_State daSTBox_Create(void* i_this) {
+    return ((daSTBox_c*)i_this)->_create();
 }
 
 /* 000013DC-00001400       .text daSTBox_Delete__FPv */
-static BOOL daSTBox_Delete(void*) {
-    /* Nonmatching */
+static BOOL daSTBox_Delete(void* i_this) {
+    return ((daSTBox_c*)i_this)->_delete();
 }
 
 /* 00001400-0000146C       .text daSTBox_Draw__FPv */
@@ -128,13 +128,13 @@ static BOOL daSTBox_Draw(void*) {
 }
 
 /* 0000146C-00001490       .text daSTBox_Execute__FPv */
-static BOOL daSTBox_Execute(void*) {
-    /* Nonmatching */
+static BOOL daSTBox_Execute(void* i_this) {
+    return ((daSTBox_c*)i_this)->_execute();
 }
 
 /* 00001490-00001498       .text daSTBox_IsDelete__FPv */
 static BOOL daSTBox_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daSTBoxMethodTable = {

--- a/src/d/actor/d_a_sbox.cpp
+++ b/src/d/actor/d_a_sbox.cpp
@@ -124,7 +124,7 @@ static BOOL daSbox_Execute(daSbox_c*) {
 
 /* 00001534-0000153C       .text daSbox_IsDelete__FP8daSbox_c */
 static BOOL daSbox_IsDelete(daSbox_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 0000153C-00001640       .text daSbox_Delete__FP8daSbox_c */
@@ -133,8 +133,8 @@ static BOOL daSbox_Delete(daSbox_c*) {
 }
 
 /* 00001640-00001660       .text daSbox_Create__FP10fopAc_ac_c */
-static cPhs_State daSbox_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daSbox_Create(fopAc_ac_c* i_this) {
+    return ((daSbox_c*)i_this)->create();
 }
 
 static actor_method_class l_daSbox_Method = {

--- a/src/d/actor/d_a_sie_flag.cpp
+++ b/src/d/actor/d_a_sie_flag.cpp
@@ -85,28 +85,28 @@ bool daSie_Flag_c::_draw() {
 }
 
 /* 00000B94-00000BB4       .text daSie_FlagCreate__FPv */
-static s32 daSie_FlagCreate(void*) {
-    /* Nonmatching */
+static s32 daSie_FlagCreate(void* i_this) {
+    return ((daSie_Flag_c*)i_this)->_create();
 }
 
 /* 00000BB4-00000BD8       .text daSie_FlagDelete__FPv */
-static BOOL daSie_FlagDelete(void*) {
-    /* Nonmatching */
+static BOOL daSie_FlagDelete(void* i_this) {
+    return ((daSie_Flag_c*)i_this)->_delete();
 }
 
 /* 00000BD8-00000BFC       .text daSie_FlagExecute__FPv */
-static BOOL daSie_FlagExecute(void*) {
-    /* Nonmatching */
+static BOOL daSie_FlagExecute(void* i_this) {
+    return ((daSie_Flag_c*)i_this)->_execute();
 }
 
 /* 00000BFC-00000C20       .text daSie_FlagDraw__FPv */
-static BOOL daSie_FlagDraw(void*) {
-    /* Nonmatching */
+static BOOL daSie_FlagDraw(void* i_this) {
+    return ((daSie_Flag_c*)i_this)->_draw();
 }
 
 /* 00000C20-00000C28       .text daSie_FlagIsDelete__FPv */
 static BOOL daSie_FlagIsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daSie_FlagMethodTable = {

--- a/src/d/actor/d_a_sitem.cpp
+++ b/src/d/actor/d_a_sitem.cpp
@@ -65,7 +65,7 @@ static BOOL daSitem_Execute(sitem_class*) {
 
 /* 000026F4-000026FC       .text daSitem_IsDelete__FP11sitem_class */
 static BOOL daSitem_IsDelete(sitem_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 000026FC-00002760       .text daSitem_Delete__FP11sitem_class */

--- a/src/d/actor/d_a_sk.cpp
+++ b/src/d/actor/d_a_sk.cpp
@@ -36,7 +36,7 @@ static BOOL daSk_Execute(sk_class*) {
 
 /* 000008D4-000008DC       .text daSk_IsDelete__FP8sk_class */
 static BOOL daSk_IsDelete(sk_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 000008DC-0000090C       .text daSk_Delete__FP8sk_class */

--- a/src/d/actor/d_a_sk2.cpp
+++ b/src/d/actor/d_a_sk2.cpp
@@ -31,7 +31,7 @@ static BOOL daSk2_Execute(sk2_class*) {
 
 /* 00000660-00000668       .text daSk2_IsDelete__FP9sk2_class */
 static BOOL daSk2_IsDelete(sk2_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00000668-000006C4       .text daSk2_Delete__FP9sk2_class */

--- a/src/d/actor/d_a_ss.cpp
+++ b/src/d/actor/d_a_ss.cpp
@@ -66,7 +66,7 @@ static BOOL daSs_Execute(ss_class*) {
 
 /* 00002F1C-00002F24       .text daSs_IsDelete__FP8ss_class */
 static BOOL daSs_IsDelete(ss_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00002F24-00002F58       .text daSs_Delete__FP8ss_class */

--- a/src/d/actor/d_a_ssk.cpp
+++ b/src/d/actor/d_a_ssk.cpp
@@ -41,7 +41,7 @@ static BOOL daSsk_Execute(ssk_class*) {
 
 /* 00000C80-00000C88       .text daSsk_IsDelete__FP9ssk_class */
 static BOOL daSsk_IsDelete(ssk_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00000C88-00000CD8       .text daSsk_Delete__FP9ssk_class */

--- a/src/d/actor/d_a_sss.cpp
+++ b/src/d/actor/d_a_sss.cpp
@@ -75,7 +75,7 @@ static BOOL daSss_Execute(sss_class*) {
 
 /* 0000269C-000026A4       .text daSss_IsDelete__FP9sss_class */
 static BOOL daSss_IsDelete(sss_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 000026A4-00002720       .text daSss_Delete__FP9sss_class */

--- a/src/d/actor/d_a_st.cpp
+++ b/src/d/actor/d_a_st.cpp
@@ -185,7 +185,7 @@ static BOOL daSt_Execute(st_class*) {
 
 /* 000087C8-000087D0       .text daSt_IsDelete__FP8st_class */
 static BOOL daSt_IsDelete(st_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 000087D0-000088CC       .text daSt_Delete__FP8st_class */

--- a/src/d/actor/d_a_stone2.cpp
+++ b/src/d/actor/d_a_stone2.cpp
@@ -245,28 +245,28 @@ BOOL daStone2::Act_c::Draw() {
 namespace daStone2 {
 namespace {
 /* 0000273C-0000275C       .text Mthd_Create__Q28daStone224@unnamed@d_a_stone2_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daStone2::Act_c*)i_this)->Mthd_Create();
 }
 
 /* 0000275C-0000277C       .text Mthd_Delete__Q28daStone224@unnamed@d_a_stone2_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daStone2::Act_c*)i_this)->Mthd_Delete();
 }
 
 /* 0000277C-0000279C       .text Mthd_Execute__Q28daStone224@unnamed@d_a_stone2_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daStone2::Act_c*)i_this)->MoveBGExecute();
 }
 
 /* 0000279C-000027C8       .text Mthd_Draw__Q28daStone224@unnamed@d_a_stone2_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daStone2::Act_c*)i_this)->Draw();
 }
 
 /* 000027C8-000027F4       .text Mthd_IsDelete__Q28daStone224@unnamed@d_a_stone2_cpp@FPv */
-BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+BOOL Mthd_IsDelete(void* i_this) {
+    return ((daStone2::Act_c*)i_this)->IsDelete();
 }
 
 static actor_method_class Mthd_Table = {

--- a/src/d/actor/d_a_swpropeller.cpp
+++ b/src/d/actor/d_a_swpropeller.cpp
@@ -86,28 +86,28 @@ bool daSwProp_c::_draw() {
 }
 
 /* 00000C00-00000C20       .text daSwProp_Create__FPv */
-static cPhs_State daSwProp_Create(void*) {
-    /* Nonmatching */
+static cPhs_State daSwProp_Create(void* i_this) {
+    return ((daSwProp_c*)i_this)->_create();
 }
 
 /* 00000C20-00000C44       .text daSwProp_Delete__FPv */
-static BOOL daSwProp_Delete(void*) {
-    /* Nonmatching */
+static BOOL daSwProp_Delete(void* i_this) {
+    return ((daSwProp_c*)i_this)->_delete();
 }
 
 /* 00000C44-00000C68       .text daSwProp_Draw__FPv */
-static BOOL daSwProp_Draw(void*) {
-    /* Nonmatching */
+static BOOL daSwProp_Draw(void* i_this) {
+    return ((daSwProp_c*)i_this)->_draw();
 }
 
 /* 00000C68-00000C8C       .text daSwProp_Execute__FPv */
-static BOOL daSwProp_Execute(void*) {
-    /* Nonmatching */
+static BOOL daSwProp_Execute(void* i_this) {
+    return ((daSwProp_c*)i_this)->_execute();
 }
 
 /* 00000C8C-00000C94       .text daSwProp_IsDelete__FPv */
 static BOOL daSwProp_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daSwPropMethodTable = {

--- a/src/d/actor/d_a_tag_ba1.cpp
+++ b/src/d/actor/d_a_tag_ba1.cpp
@@ -38,17 +38,17 @@ void daTag_Ba1_c::createInit() {
 }
 
 /* 00000288-00000290       .text _draw__11daTag_Ba1_cFv */
-bool daTag_Ba1_c::_draw() {
+BOOL daTag_Ba1_c::_draw() {
     /* Nonmatching */
 }
 
 /* 00000290-00000340       .text _execute__11daTag_Ba1_cFv */
-bool daTag_Ba1_c::_execute() {
+BOOL daTag_Ba1_c::_execute() {
     /* Nonmatching */
 }
 
 /* 00000340-00000394       .text _delete__11daTag_Ba1_cFv */
-bool daTag_Ba1_c::_delete() {
+BOOL daTag_Ba1_c::_delete() {
     /* Nonmatching */
 }
 
@@ -58,28 +58,28 @@ cPhs_State daTag_Ba1_c::_create() {
 }
 
 /* 00000454-00000474       .text daTag_Ba1_Create__FP10fopAc_ac_c */
-static cPhs_State daTag_Ba1_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daTag_Ba1_Create(fopAc_ac_c* i_this) {
+    return ((daTag_Ba1_c*)i_this)->_create();
 }
 
 /* 00000474-00000494       .text daTag_Ba1_Delete__FP11daTag_Ba1_c */
-static BOOL daTag_Ba1_Delete(daTag_Ba1_c*) {
-    /* Nonmatching */
+static BOOL daTag_Ba1_Delete(daTag_Ba1_c* i_this) {
+    return ((daTag_Ba1_c*)i_this)->_delete();
 }
 
 /* 00000494-000004B4       .text daTag_Ba1_Execute__FP11daTag_Ba1_c */
-static BOOL daTag_Ba1_Execute(daTag_Ba1_c*) {
-    /* Nonmatching */
+static BOOL daTag_Ba1_Execute(daTag_Ba1_c* i_this) {
+    return ((daTag_Ba1_c*)i_this)->_execute();
 }
 
 /* 000004B4-000004D4       .text daTag_Ba1_Draw__FP11daTag_Ba1_c */
-static BOOL daTag_Ba1_Draw(daTag_Ba1_c*) {
-    /* Nonmatching */
+static BOOL daTag_Ba1_Draw(daTag_Ba1_c* i_this) {
+    return ((daTag_Ba1_c*)i_this)->_draw();
 }
 
 /* 000004D4-000004DC       .text daTag_Ba1_IsDelete__FP11daTag_Ba1_c */
 static BOOL daTag_Ba1_IsDelete(daTag_Ba1_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daTag_Ba1_Method = {

--- a/src/d/actor/d_a_tag_hint.cpp
+++ b/src/d/actor/d_a_tag_hint.cpp
@@ -169,7 +169,7 @@ void daTag_Hint_c::actionWait() {
 
 /* 00001F68-00001F70       .text daTag_Hint_Draw__FP12daTag_Hint_c */
 static BOOL daTag_Hint_Draw(daTag_Hint_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00001F70-00001FE4       .text daTag_Hint_Execute__FP12daTag_Hint_c */
@@ -179,7 +179,7 @@ static BOOL daTag_Hint_Execute(daTag_Hint_c*) {
 
 /* 00001FE4-00001FEC       .text daTag_Hint_IsDelete__FP12daTag_Hint_c */
 static BOOL daTag_Hint_IsDelete(daTag_Hint_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00001FEC-00002074       .text daTag_Hint_Delete__FP12daTag_Hint_c */

--- a/src/d/actor/d_a_tag_kf1.cpp
+++ b/src/d/actor/d_a_tag_kf1.cpp
@@ -123,17 +123,17 @@ void daTag_Kf1_c::wait_action1(void*) {
 }
 
 /* 00000BE8-00000BF0       .text _draw__11daTag_Kf1_cFv */
-bool daTag_Kf1_c::_draw() {
+BOOL daTag_Kf1_c::_draw() {
     /* Nonmatching */
 }
 
 /* 00000BF0-00000C68       .text _execute__11daTag_Kf1_cFv */
-bool daTag_Kf1_c::_execute() {
+BOOL daTag_Kf1_c::_execute() {
     /* Nonmatching */
 }
 
 /* 00000C68-00000CBC       .text _delete__11daTag_Kf1_cFv */
-bool daTag_Kf1_c::_delete() {
+BOOL daTag_Kf1_c::_delete() {
     /* Nonmatching */
 }
 
@@ -143,28 +143,28 @@ cPhs_State daTag_Kf1_c::_create() {
 }
 
 /* 000010C0-000010E0       .text daTag_Kf1_Create__FP10fopAc_ac_c */
-static cPhs_State daTag_Kf1_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daTag_Kf1_Create(fopAc_ac_c* i_this) {
+    return ((daTag_Kf1_c*)i_this)->_create();
 }
 
 /* 000010E0-00001100       .text daTag_Kf1_Delete__FP11daTag_Kf1_c */
-static BOOL daTag_Kf1_Delete(daTag_Kf1_c*) {
-    /* Nonmatching */
+static BOOL daTag_Kf1_Delete(daTag_Kf1_c* i_this) {
+    return ((daTag_Kf1_c*)i_this)->_delete();
 }
 
 /* 00001100-00001120       .text daTag_Kf1_Execute__FP11daTag_Kf1_c */
-static BOOL daTag_Kf1_Execute(daTag_Kf1_c*) {
-    /* Nonmatching */
+static BOOL daTag_Kf1_Execute(daTag_Kf1_c* i_this) {
+    return ((daTag_Kf1_c*)i_this)->_execute();
 }
 
 /* 00001120-00001140       .text daTag_Kf1_Draw__FP11daTag_Kf1_c */
-static BOOL daTag_Kf1_Draw(daTag_Kf1_c*) {
-    /* Nonmatching */
+static BOOL daTag_Kf1_Draw(daTag_Kf1_c* i_this) {
+    return ((daTag_Kf1_c*)i_this)->_draw();
 }
 
 /* 00001140-00001148       .text daTag_Kf1_IsDelete__FP11daTag_Kf1_c */
 static BOOL daTag_Kf1_IsDelete(daTag_Kf1_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class l_daTag_Kf1_Method = {

--- a/src/d/actor/d_a_tag_kf1.cpp
+++ b/src/d/actor/d_a_tag_kf1.cpp
@@ -123,17 +123,17 @@ void daTag_Kf1_c::wait_action1(void*) {
 }
 
 /* 00000BE8-00000BF0       .text _draw__11daTag_Kf1_cFv */
-BOOL daTag_Kf1_c::_draw() {
+bool daTag_Kf1_c::_draw() {
     /* Nonmatching */
 }
 
 /* 00000BF0-00000C68       .text _execute__11daTag_Kf1_cFv */
-BOOL daTag_Kf1_c::_execute() {
+bool daTag_Kf1_c::_execute() {
     /* Nonmatching */
 }
 
 /* 00000C68-00000CBC       .text _delete__11daTag_Kf1_cFv */
-BOOL daTag_Kf1_c::_delete() {
+bool daTag_Kf1_c::_delete() {
     /* Nonmatching */
 }
 
@@ -143,28 +143,28 @@ cPhs_State daTag_Kf1_c::_create() {
 }
 
 /* 000010C0-000010E0       .text daTag_Kf1_Create__FP10fopAc_ac_c */
-static cPhs_State daTag_Kf1_Create(fopAc_ac_c* i_this) {
-    return ((daTag_Kf1_c*)i_this)->_create();
+static cPhs_State daTag_Kf1_Create(fopAc_ac_c*) {
+    /* Nonmatching */
 }
 
 /* 000010E0-00001100       .text daTag_Kf1_Delete__FP11daTag_Kf1_c */
-static BOOL daTag_Kf1_Delete(daTag_Kf1_c* i_this) {
-    return ((daTag_Kf1_c*)i_this)->_delete();
+static BOOL daTag_Kf1_Delete(daTag_Kf1_c*) {
+    /* Nonmatching */
 }
 
 /* 00001100-00001120       .text daTag_Kf1_Execute__FP11daTag_Kf1_c */
-static BOOL daTag_Kf1_Execute(daTag_Kf1_c* i_this) {
-    return ((daTag_Kf1_c*)i_this)->_execute();
+static BOOL daTag_Kf1_Execute(daTag_Kf1_c*) {
+    /* Nonmatching */
 }
 
 /* 00001120-00001140       .text daTag_Kf1_Draw__FP11daTag_Kf1_c */
-static BOOL daTag_Kf1_Draw(daTag_Kf1_c* i_this) {
-    return ((daTag_Kf1_c*)i_this)->_draw();
+static BOOL daTag_Kf1_Draw(daTag_Kf1_c*) {
+    /* Nonmatching */
 }
 
 /* 00001140-00001148       .text daTag_Kf1_IsDelete__FP11daTag_Kf1_c */
 static BOOL daTag_Kf1_IsDelete(daTag_Kf1_c*) {
-    return TRUE;
+    /* Nonmatching */
 }
 
 static actor_method_class l_daTag_Kf1_Method = {

--- a/src/d/actor/d_a_tag_light.cpp
+++ b/src/d/actor/d_a_tag_light.cpp
@@ -100,28 +100,28 @@ bool daTagLight::Act_c::_draw() {
 namespace daTagLight {
 namespace {
 /* 00001EAC-00001ECC       .text Mthd_Create__Q210daTagLight27@unnamed@d_a_tag_light_cpp@FPv */
-cPhs_State Mthd_Create(void*) {
-    /* Nonmatching */
+cPhs_State Mthd_Create(void* i_this) {
+    return ((daTagLight::Act_c*)i_this)->_create();
 }
 
 /* 00001ECC-00001EF0       .text Mthd_Delete__Q210daTagLight27@unnamed@d_a_tag_light_cpp@FPv */
-BOOL Mthd_Delete(void*) {
-    /* Nonmatching */
+BOOL Mthd_Delete(void* i_this) {
+    return ((daTagLight::Act_c*)i_this)->_delete();
 }
 
 /* 00001EF0-00001F14       .text Mthd_Execute__Q210daTagLight27@unnamed@d_a_tag_light_cpp@FPv */
-BOOL Mthd_Execute(void*) {
-    /* Nonmatching */
+BOOL Mthd_Execute(void* i_this) {
+    return ((daTagLight::Act_c*)i_this)->_execute();
 }
 
 /* 00001F14-00001F38       .text Mthd_Draw__Q210daTagLight27@unnamed@d_a_tag_light_cpp@FPv */
-BOOL Mthd_Draw(void*) {
-    /* Nonmatching */
+BOOL Mthd_Draw(void* i_this) {
+    return ((daTagLight::Act_c*)i_this)->_draw();
 }
 
 /* 00001F38-00001F40       .text Mthd_IsDelete__Q210daTagLight27@unnamed@d_a_tag_light_cpp@FPv */
 BOOL Mthd_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class Mthd_Table = {

--- a/src/d/actor/d_a_tag_md_cb.cpp
+++ b/src/d/actor/d_a_tag_md_cb.cpp
@@ -158,28 +158,30 @@ daTag_MdCb_c::~daTag_MdCb_c() {
 }
 
 /* 0000191C-0000193C       .text daTag_MdCb_Draw__FP12daTag_MdCb_c */
-static BOOL daTag_MdCb_Draw(daTag_MdCb_c*) {
-    /* Nonmatching */
+static BOOL daTag_MdCb_Draw(daTag_MdCb_c* i_this) {
+    return ((daTag_MdCb_c*)i_this)->draw();
 }
 
 /* 0000193C-00001960       .text daTag_MdCb_Execute__FP12daTag_MdCb_c */
-static BOOL daTag_MdCb_Execute(daTag_MdCb_c*) {
-    /* Nonmatching */
+static BOOL daTag_MdCb_Execute(daTag_MdCb_c* i_this) {
+    ((daTag_MdCb_c*)i_this)->execute();
+    return TRUE;
 }
 
 /* 00001960-00001968       .text daTag_MdCb_IsDelete__FP12daTag_MdCb_c */
 static BOOL daTag_MdCb_IsDelete(daTag_MdCb_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00001968-00001990       .text daTag_MdCb_Delete__FP12daTag_MdCb_c */
-static BOOL daTag_MdCb_Delete(daTag_MdCb_c*) {
-    /* Nonmatching */
+static BOOL daTag_MdCb_Delete(daTag_MdCb_c* i_this) {
+    ((daTag_MdCb_c*)i_this)->~daTag_MdCb_c();
+    return TRUE;
 }
 
 /* 00001990-000019B0       .text daTag_MdCb_Create__FP10fopAc_ac_c */
-static cPhs_State daTag_MdCb_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daTag_MdCb_Create(fopAc_ac_c* i_this) {
+    return ((daTag_MdCb_c*)i_this)->create();
 }
 
 static actor_method_class l_daTag_MdCb_Method = {

--- a/src/d/actor/d_a_tag_mk.cpp
+++ b/src/d/actor/d_a_tag_mk.cpp
@@ -159,17 +159,18 @@ BOOL daTag_Mk_c::execute() {
 
 /* 00000E9C-00000EA4       .text daTag_Mk_Draw__FP10daTag_Mk_c */
 static BOOL daTag_Mk_Draw(daTag_Mk_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00000EA4-00000EC8       .text daTag_Mk_Execute__FP10daTag_Mk_c */
-static BOOL daTag_Mk_Execute(daTag_Mk_c*) {
-    /* Nonmatching */
+static BOOL daTag_Mk_Execute(daTag_Mk_c* i_this) {
+    ((daTag_Mk_c*)i_this)->execute();
+    return TRUE;
 }
 
 /* 00000EC8-00000ED0       .text daTag_Mk_IsDelete__FP10daTag_Mk_c */
 static BOOL daTag_Mk_IsDelete(daTag_Mk_c*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00000ED0-00000F00       .text daTag_Mk_Delete__FP10daTag_Mk_c */
@@ -178,8 +179,8 @@ static BOOL daTag_Mk_Delete(daTag_Mk_c*) {
 }
 
 /* 00000F00-00000F20       .text daTag_Mk_Create__FP10fopAc_ac_c */
-static cPhs_State daTag_Mk_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daTag_Mk_Create(fopAc_ac_c* i_this) {
+    return ((daTag_Mk_c*)i_this)->create();
 }
 
 /* 00000F20-000011E4       .text create__10daTag_Mk_cFv */

--- a/src/d/actor/d_a_tag_photo.cpp
+++ b/src/d/actor/d_a_tag_photo.cpp
@@ -43,12 +43,12 @@ void daTagPhoto_c::createInit() {
 }
 
 /* 00000298-000002A0       .text _delete__12daTagPhoto_cFv */
-bool daTagPhoto_c::_delete() {
+BOOL daTagPhoto_c::_delete() {
     /* Nonmatching */
 }
 
 /* 000002A0-000002A8       .text _draw__12daTagPhoto_cFv */
-bool daTagPhoto_c::_draw() {
+BOOL daTagPhoto_c::_draw() {
     /* Nonmatching */
 }
 
@@ -58,7 +58,7 @@ void daTagPhoto_c::setMode(unsigned char) {
 }
 
 /* 000002CC-00000368       .text _execute__12daTagPhoto_cFv */
-bool daTagPhoto_c::_execute() {
+BOOL daTagPhoto_c::_execute() {
     /* Nonmatching */
 }
 
@@ -128,28 +128,28 @@ void daTagPhoto_c::getPrmTagNo() {
 }
 
 /* 00000928-00000948       .text daTagPhotoCreate__FPv */
-static s32 daTagPhotoCreate(void*) {
-    /* Nonmatching */
+static s32 daTagPhotoCreate(void* i_this) {
+    return ((daTagPhoto_c*)i_this)->_create();
 }
 
 /* 00000948-00000968       .text daTagPhotoDelete__FPv */
-static BOOL daTagPhotoDelete(void*) {
-    /* Nonmatching */
+static BOOL daTagPhotoDelete(void* i_this) {
+    return ((daTagPhoto_c*)i_this)->_delete();
 }
 
 /* 00000968-00000988       .text daTagPhotoExecute__FPv */
-static BOOL daTagPhotoExecute(void*) {
-    /* Nonmatching */
+static BOOL daTagPhotoExecute(void* i_this) {
+    return ((daTagPhoto_c*)i_this)->_execute();
 }
 
 /* 00000988-000009A8       .text daTagPhotoDraw__FPv */
-static BOOL daTagPhotoDraw(void*) {
-    /* Nonmatching */
+static BOOL daTagPhotoDraw(void* i_this) {
+    return ((daTagPhoto_c*)i_this)->_draw();
 }
 
 /* 000009A8-000009B0       .text daTagPhotoIsDelete__FPv */
 static BOOL daTagPhotoIsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daTagPhotoMethodTable = {

--- a/src/d/actor/d_a_tn.cpp
+++ b/src/d/actor/d_a_tn.cpp
@@ -286,7 +286,7 @@ static BOOL daTn_Execute(tn_class*) {
 
 /* 0000BCE4-0000BCEC       .text daTn_IsDelete__FP8tn_class */
 static BOOL daTn_IsDelete(tn_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 0000BCEC-0000BE58       .text daTn_Delete__FP8tn_class */

--- a/src/d/actor/d_a_warpdm20.cpp
+++ b/src/d/actor/d_a_warpdm20.cpp
@@ -168,28 +168,28 @@ bool daWarpdm20_c::_draw() {
 }
 
 /* 000017C0-000017E0       .text daWarpdm20_Create__FPv */
-static cPhs_State daWarpdm20_Create(void*) {
-    /* Nonmatching */
+static cPhs_State daWarpdm20_Create(void* i_this) {
+    return ((daWarpdm20_c*)i_this)->_create();
 }
 
 /* 000017E0-00001804       .text daWarpdm20_Delete__FPv */
-static BOOL daWarpdm20_Delete(void*) {
-    /* Nonmatching */
+static BOOL daWarpdm20_Delete(void* i_this) {
+    return ((daWarpdm20_c*)i_this)->_delete();
 }
 
 /* 00001804-00001828       .text daWarpdm20_Draw__FPv */
-static BOOL daWarpdm20_Draw(void*) {
-    /* Nonmatching */
+static BOOL daWarpdm20_Draw(void* i_this) {
+    return ((daWarpdm20_c*)i_this)->_draw();
 }
 
 /* 00001828-0000184C       .text daWarpdm20_Execute__FPv */
-static BOOL daWarpdm20_Execute(void*) {
-    /* Nonmatching */
+static BOOL daWarpdm20_Execute(void* i_this) {
+    return ((daWarpdm20_c*)i_this)->_execute();
 }
 
 /* 0000184C-00001854       .text daWarpdm20_IsDelete__FPv */
 static BOOL daWarpdm20_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daWarpdm20MethodTable = {

--- a/src/d/actor/d_a_warpf.cpp
+++ b/src/d/actor/d_a_warpf.cpp
@@ -178,28 +178,28 @@ bool daWarpf_c::_draw() {
 }
 
 /* 00002340-00002360       .text daWarpf_Create__FPv */
-static cPhs_State daWarpf_Create(void*) {
-    /* Nonmatching */
+static cPhs_State daWarpf_Create(void* i_this) {
+    return ((daWarpf_c*)i_this)->_create();
 }
 
 /* 00002360-00002384       .text daWarpf_Delete__FPv */
-static BOOL daWarpf_Delete(void*) {
-    /* Nonmatching */
+static BOOL daWarpf_Delete(void* i_this) {
+    return ((daWarpf_c*)i_this)->_delete();
 }
 
 /* 00002384-000023A8       .text daWarpf_Draw__FPv */
-static BOOL daWarpf_Draw(void*) {
-    /* Nonmatching */
+static BOOL daWarpf_Draw(void* i_this) {
+    return ((daWarpf_c*)i_this)->_draw();
 }
 
 /* 000023A8-000023CC       .text daWarpf_Execute__FPv */
-static BOOL daWarpf_Execute(void*) {
-    /* Nonmatching */
+static BOOL daWarpf_Execute(void* i_this) {
+    return ((daWarpf_c*)i_this)->_execute();
 }
 
 /* 000023CC-000023D4       .text daWarpf_IsDelete__FPv */
 static BOOL daWarpf_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daWarpfMethodTable = {

--- a/src/d/actor/d_a_warpgn.cpp
+++ b/src/d/actor/d_a_warpgn.cpp
@@ -153,28 +153,28 @@ bool daWarpgn_c::_draw() {
 }
 
 /* 000018D4-000018F4       .text daWarpgn_Create__FPv */
-static cPhs_State daWarpgn_Create(void*) {
-    /* Nonmatching */
+static cPhs_State daWarpgn_Create(void* i_this) {
+    return ((daWarpgn_c*)i_this)->_create();
 }
 
 /* 000018F4-00001918       .text daWarpgn_Delete__FPv */
-static BOOL daWarpgn_Delete(void*) {
-    /* Nonmatching */
+static BOOL daWarpgn_Delete(void* i_this) {
+    return ((daWarpgn_c*)i_this)->_delete();
 }
 
 /* 00001918-0000193C       .text daWarpgn_Draw__FPv */
-static BOOL daWarpgn_Draw(void*) {
-    /* Nonmatching */
+static BOOL daWarpgn_Draw(void* i_this) {
+    return ((daWarpgn_c*)i_this)->_draw();
 }
 
 /* 0000193C-00001960       .text daWarpgn_Execute__FPv */
-static BOOL daWarpgn_Execute(void*) {
-    /* Nonmatching */
+static BOOL daWarpgn_Execute(void* i_this) {
+    return ((daWarpgn_c*)i_this)->_execute();
 }
 
 /* 00001960-00001968       .text daWarpgn_IsDelete__FPv */
 static BOOL daWarpgn_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daWarpgnMethodTable = {

--- a/src/d/actor/d_a_warphr.cpp
+++ b/src/d/actor/d_a_warphr.cpp
@@ -143,28 +143,28 @@ bool daWarphr_c::_draw() {
 }
 
 /* 000016E0-00001700       .text daWarphr_Create__FPv */
-static cPhs_State daWarphr_Create(void*) {
-    /* Nonmatching */
+static cPhs_State daWarphr_Create(void* i_this) {
+    return ((daWarphr_c*)i_this)->_create();
 }
 
 /* 00001700-00001724       .text daWarphr_Delete__FPv */
-static BOOL daWarphr_Delete(void*) {
-    /* Nonmatching */
+static BOOL daWarphr_Delete(void* i_this) {
+    return ((daWarphr_c*)i_this)->_delete();
 }
 
 /* 00001724-00001748       .text daWarphr_Draw__FPv */
-static BOOL daWarphr_Draw(void*) {
-    /* Nonmatching */
+static BOOL daWarphr_Draw(void* i_this) {
+    return ((daWarphr_c*)i_this)->_draw();
 }
 
 /* 00001748-0000176C       .text daWarphr_Execute__FPv */
-static BOOL daWarphr_Execute(void*) {
-    /* Nonmatching */
+static BOOL daWarphr_Execute(void* i_this) {
+    return ((daWarphr_c*)i_this)->_execute();
 }
 
 /* 0000176C-00001774       .text daWarphr_IsDelete__FPv */
 static BOOL daWarphr_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daWarphrMethodTable = {

--- a/src/d/actor/d_a_warpls.cpp
+++ b/src/d/actor/d_a_warpls.cpp
@@ -78,13 +78,13 @@ void daWarpls_c::warp_eff_start() {
 }
 
 /* 000010C8-000010E8       .text daWarpls_Create__FPv */
-static cPhs_State daWarpls_Create(void*) {
-    /* Nonmatching */
+static cPhs_State daWarpls_Create(void* i_this) {
+    return ((daWarpls_c*)i_this)->_create();
 }
 
 /* 000010E8-0000110C       .text daWarpls_Delete__FPv */
-static BOOL daWarpls_Delete(void*) {
-    /* Nonmatching */
+static BOOL daWarpls_Delete(void* i_this) {
+    return ((daWarpls_c*)i_this)->_delete();
 }
 
 /* 0000110C-000011D0       .text daWarpls_Draw__FPv */
@@ -93,13 +93,13 @@ static BOOL daWarpls_Draw(void*) {
 }
 
 /* 000011D0-000011F4       .text daWarpls_Execute__FPv */
-static BOOL daWarpls_Execute(void*) {
-    /* Nonmatching */
+static BOOL daWarpls_Execute(void* i_this) {
+    return ((daWarpls_c*)i_this)->_execute();
 }
 
 /* 000011F4-000011FC       .text daWarpls_IsDelete__FPv */
 static BOOL daWarpls_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daWarplsMethodTable = {

--- a/src/d/actor/d_a_warpmj.cpp
+++ b/src/d/actor/d_a_warpmj.cpp
@@ -123,28 +123,28 @@ bool daWarpmj_c::_draw() {
 }
 
 /* 0000114C-0000116C       .text daWarpmj_Create__FPv */
-static cPhs_State daWarpmj_Create(void*) {
-    /* Nonmatching */
+static cPhs_State daWarpmj_Create(void* i_this) {
+    return ((daWarpmj_c*)i_this)->_create();
 }
 
 /* 0000116C-00001190       .text daWarpmj_Delete__FPv */
-static BOOL daWarpmj_Delete(void*) {
-    /* Nonmatching */
+static BOOL daWarpmj_Delete(void* i_this) {
+    return ((daWarpmj_c*)i_this)->_delete();
 }
 
 /* 00001190-000011B4       .text daWarpmj_Draw__FPv */
-static BOOL daWarpmj_Draw(void*) {
-    /* Nonmatching */
+static BOOL daWarpmj_Draw(void* i_this) {
+    return ((daWarpmj_c*)i_this)->_draw();
 }
 
 /* 000011B4-000011D8       .text daWarpmj_Execute__FPv */
-static BOOL daWarpmj_Execute(void*) {
-    /* Nonmatching */
+static BOOL daWarpmj_Execute(void* i_this) {
+    return ((daWarpmj_c*)i_this)->_execute();
 }
 
 /* 000011D8-000011E0       .text daWarpmj_IsDelete__FPv */
 static BOOL daWarpmj_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daWarpmjMethodTable = {

--- a/src/d/actor/d_a_waterfall.cpp
+++ b/src/d/actor/d_a_waterfall.cpp
@@ -103,13 +103,13 @@ void daWfall_c::set_se() {
 }
 
 /* 000013E0-00001400       .text daWfall_Create__FPv */
-static cPhs_State daWfall_Create(void*) {
-    /* Nonmatching */
+static cPhs_State daWfall_Create(void* i_this) {
+    return ((daWfall_c*)i_this)->_create();
 }
 
 /* 00001400-00001424       .text daWfall_Delete__FPv */
-static BOOL daWfall_Delete(void*) {
-    /* Nonmatching */
+static BOOL daWfall_Delete(void* i_this) {
+    return ((daWfall_c*)i_this)->_delete();
 }
 
 /* 00001424-00001550       .text daWfall_Draw__FPv */
@@ -118,13 +118,13 @@ static BOOL daWfall_Draw(void*) {
 }
 
 /* 00001550-00001574       .text daWfall_Execute__FPv */
-static BOOL daWfall_Execute(void*) {
-    /* Nonmatching */
+static BOOL daWfall_Execute(void* i_this) {
+    return ((daWfall_c*)i_this)->_execute();
 }
 
 /* 00001574-0000157C       .text daWfall_IsDelete__FPv */
 static BOOL daWfall_IsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daWfallMethodTable = {

--- a/src/d/actor/d_a_wz.cpp
+++ b/src/d/actor/d_a_wz.cpp
@@ -121,7 +121,7 @@ static BOOL daWZ_Execute(wz_class*) {
 
 /* 00006108-00006110       .text daWZ_IsDelete__FP8wz_class */
 static BOOL daWZ_IsDelete(wz_class*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00006110-0000627C       .text daWZ_Delete__FP8wz_class */

--- a/src/d/actor/d_a_ykgr.cpp
+++ b/src/d/actor/d_a_ykgr.cpp
@@ -23,8 +23,8 @@ void daYkgr_c::getPosRate() {
 }
 
 /* 00000408-00000428       .text daYkgrCreate__FPv */
-static s32 daYkgrCreate(void*) {
-    /* Nonmatching */
+static s32 daYkgrCreate(void* i_this) {
+    return ((daYkgr_c*)i_this)->_create();
 }
 
 /* 00000428-00000680       .text _create__8daYkgr_cFv */
@@ -34,7 +34,7 @@ cPhs_State daYkgr_c::_create() {
 
 /* 00000680-00000688       .text daYkgrDelete__FPv */
 static BOOL daYkgrDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00000688-000007F4       .text daYkgrExecute__FPv */
@@ -49,7 +49,7 @@ static BOOL daYkgrDraw(void*) {
 
 /* 000008F4-000008FC       .text daYkgrIsDelete__FPv */
 static BOOL daYkgrIsDelete(void*) {
-    /* Nonmatching */
+    return TRUE;
 }
 
 static actor_method_class daYkgrMethodTable = {

--- a/src/d/actor/d_a_yougan.cpp
+++ b/src/d/actor/d_a_yougan.cpp
@@ -13,8 +13,8 @@ daYOUGAN_HIO_c::daYOUGAN_HIO_c() {
 }
 
 /* 00000158-00000178       .text daYougan_Draw__FP10daYougan_c */
-static BOOL daYougan_Draw(daYougan_c*) {
-    /* Nonmatching */
+static BOOL daYougan_Draw(daYougan_c* i_this) {
+    return ((daYougan_c*)i_this)->_daYougan_draw();
 }
 
 /* 00000178-000002A8       .text _daYougan_draw__10daYougan_cFv */
@@ -23,8 +23,8 @@ BOOL daYougan_c::_daYougan_draw() {
 }
 
 /* 000002A8-000002C8       .text daYougan_Execute__FP10daYougan_c */
-static BOOL daYougan_Execute(daYougan_c*) {
-    /* Nonmatching */
+static BOOL daYougan_Execute(daYougan_c* i_this) {
+    return ((daYougan_c*)i_this)->_daYougan_execute();
 }
 
 /* 000002C8-00000554       .text _daYougan_execute__10daYougan_cFv */
@@ -33,8 +33,8 @@ BOOL daYougan_c::_daYougan_execute() {
 }
 
 /* 00000554-00000574       .text daYougan_IsDelete__FP10daYougan_c */
-static BOOL daYougan_IsDelete(daYougan_c*) {
-    /* Nonmatching */
+static BOOL daYougan_IsDelete(daYougan_c* i_this) {
+    return ((daYougan_c*)i_this)->_daYougan_isdelete();
 }
 
 /* 00000574-0000057C       .text _daYougan_isdelete__10daYougan_cFv */
@@ -43,8 +43,8 @@ BOOL daYougan_c::_daYougan_isdelete() {
 }
 
 /* 0000057C-0000059C       .text daYougan_Delete__FP10daYougan_c */
-static BOOL daYougan_Delete(daYougan_c*) {
-    /* Nonmatching */
+static BOOL daYougan_Delete(daYougan_c* i_this) {
+    return ((daYougan_c*)i_this)->_daYougan_delete();
 }
 
 /* 0000059C-00000600       .text _daYougan_delete__10daYougan_cFv */
@@ -63,8 +63,8 @@ static BOOL daYougan_solidHeapCB(fopAc_ac_c*) {
 }
 
 /* 000008A4-000008C4       .text daYougan_Create__FP10fopAc_ac_c */
-static cPhs_State daYougan_Create(fopAc_ac_c*) {
-    /* Nonmatching */
+static cPhs_State daYougan_Create(fopAc_ac_c* i_this) {
+    return ((daYougan_c*)i_this)->_daYougan_create();
 }
 
 /* 000008C4-000009C8       .text _daYougan_create__10daYougan_cFv */


### PR DESCRIPTION
Some of these methods are pretty mechanical so I figured automatically generating them might be good to avoid a bunch of manual busy-work.

Generated by going over all the `process_method_func` tables and then generating the functions based on their bodies in the `.s` files. Functions where is just does a `return TRUE` or delegates to a C++ method were automatically inserted.

There's a second commit in the PR that reverts all the files with pull requests to not create unnecessary merge conflicts for contributors.


## Verification

Verified correctness by running `ninja changes_all` on `GZLE01` and demo (you may want to check the other versions):

```
                                                                 Total | fuzzy_match  |  42.95% ->  43.19%
                                                                 Total | matched_code |  28.31% ->  28.59%
                                       framework/d/actor/d_a_boomerang | fuzzy_match  |   1.04% ->   1.89%
                                       framework/d/actor/d_a_boomerang | matched_code |   0.00% ->   1.04%
                                   daBoomerang_Draw__FP13daBoomerang_c | fuzzy_match  |  12.50% -> 100.00%
...
```

Made sure all the new matches were 100% with:

```python
x = [l for l in lines.splitlines() if '/' not in l and '-> 100.00%' not in l]
```

This removes the `fuzzy match` lines for the full TUs and only shows symbols.

The result is:
```
                                        _create__17daObj_Tousekiki_cFv | fuzzy_match  |   0.00% ->   0.75%
                                                  _create__8daYkgr_cFv | fuzzy_match  |   0.00% ->   0.67%
                                                  _create__8daBeam_cFv | fuzzy_match  |   0.00% ->   2.78%
                                                 _create__9daCanon_cFv | fuzzy_match  |   0.00% ->   0.49%
...
```

Not sure why but objdiff increases the fuzzy match for lines that haven't been touched, but all the new method matches are 100%