### PR TITLE
fix: JAInter::SoundTable::init

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -876,7 +876,7 @@ config.libs = [
             Object(Matching,    "JSystem/JAudio/JAISequenceHeap.cpp"),
             Object(NonMatching, "JSystem/JAudio/JAISequenceMgr.cpp"),
             Object(NonMatching, "JSystem/JAudio/JAISound.cpp"),
-            Object(NonMatching, "JSystem/JAudio/JAISoundTable.cpp"),
+            Object(Matching,    "JSystem/JAudio/JAISoundTable.cpp"),
             Object(NonMatching, "JSystem/JAudio/JAIStreamMgr.cpp"),
             Object(Matching,    "JSystem/JAudio/JAISystemInterface.cpp"),
         ],

--- a/src/JSystem/JAudio/JAISoundTable.cpp
+++ b/src/JSystem/JAudio/JAISoundTable.cpp
@@ -19,15 +19,14 @@ u8* JAInter::SoundTable::mAddress;
 
 /* 8029B570-8029B6FC       .text init__Q27JAInter10SoundTableFPUcUl */
 void JAInter::SoundTable::init(u8* param_1, u32 param_2) {
-    /* Nonmatching - operand swap */
     mAddress = param_1;
     mDatasize = param_2;
     mVersion = param_1[3];
     mSoundMax = new (JAIBasic::getCurrentJAIHeap(), 4) u16[18];
     mPointerCategory = new (JAIBasic::getCurrentJAIHeap(), 4) SoundInfo*[18];
     for (u8 i = 0; i < 18; i++) {
-        mSoundMax[i] = reinterpret_cast<u16*>(&mAddress[6])[i*2];
-        u32 temp = reinterpret_cast<u16*>(&mAddress[8])[i*2];
+        mSoundMax[i] = *reinterpret_cast<u16*>(&mAddress[i*4 + 6]);
+        u32 temp = *reinterpret_cast<u16*>(&mAddress[i*4 + 8]);
         mPointerCategory[i] = &(reinterpret_cast<SoundInfo*>(&mAddress[0x50])[temp]);
         
         if (i < 16 && mSoundMax[i] != 0) {


### PR DESCRIPTION
My first stab at one of these - hope this is ok!

`JAInter::SoundTable::init` had an operand swap mismatch due to the order of operations in this instance of pointer arithmetic; the target's pointer arithmetic was done prior to the cast to `u16*`.