### PR TITLE
Rename fopAcM_SetupActor to fopAcM_ct and simplify version differences related to this macro.

### DIFF
--- a/docs/decompiling.md
+++ b/docs/decompiling.md
@@ -142,10 +142,10 @@ For example, if you were to look at the actor's create function, you should see 
 
 ![Create function in Ghidra](images/ghidra_setup_actor_macro.png)
 
-This code is constructing the actor when it's first created. You shouldn't write it out by hand - instead, use the `fopAcM_SetupActor` macro, like so:
+This code is constructing the actor when it's first created. You shouldn't write it out by hand - instead, use the `fopAcM_ct` macro, like so:
 
 ```cpp
-    fopAcM_SetupActor(this, daWall_c);
+    fopAcM_ct(this, daWall_c);
 ```
 
 That should expand out into the proper code when compiled. If something in there is missing even after using the macro, then you might not have set up all of the actor's member variables properly in the previous step, so add any missing fields now.

--- a/include/d/actor/d_a_npc_nz.h
+++ b/include/d/actor/d_a_npc_nz.h
@@ -19,7 +19,7 @@ public:
     };
 
     // objdiff says this is a weak function
-    // but defining it here with {} causes it to be inlined with fopAcM_SetupActor which breaks things
+    // but defining it here with {} causes it to be inlined with fopAcM_ct which breaks things
     daNpc_Nz_c();
 
     void modeProcInit(int newMode) { modeProc(PROC_INIT_e, newMode); }

--- a/include/f_op/f_op_actor_mng.h
+++ b/include/f_op/f_op_actor_mng.h
@@ -12,14 +12,22 @@
 #include "d/d_event.h"
 
 // The name of this macro is official and comes from a TP debug assert: "fopAcM_ct No Call !!"
-#define fopAcM_ct(ptr,ClassName) \
-    if (!fopAcM_CheckCondition(ptr, fopAcCnd_INIT_e)) { \
-        new (ptr) ClassName(); \
-        fopAcM_OnCondition(ptr, fopAcCnd_INIT_e); \
+#define fopAcM_ct(ptr, ClassName)                                                                  \
+    if (!fopAcM_CheckCondition(ptr, fopAcCnd_INIT_e)) {                                            \
+        new (ptr) ClassName();                                                                     \
+        fopAcM_OnCondition(ptr, fopAcCnd_INIT_e);                                                  \
     }
 
 // Unofficial name, kept to avoid conflicts with open PRs. TODO: Remove later.
 #define fopAcM_SetupActor fopAcM_ct
+
+#if VERSION == VERSION_DEMO
+#define fopAcM_ct_Demo fopAcM_ct
+#define fopAcM_ct_Retail(ptr, ClassName)
+#else
+#define fopAcM_ct_Demo(ptr, ClassName)
+#define fopAcM_ct_Retail fopAcM_ct
+#endif
 
 class J3DModelData;
 class daItem_c;

--- a/include/f_op/f_op_actor_mng.h
+++ b/include/f_op/f_op_actor_mng.h
@@ -1,7 +1,7 @@
 #ifndef F_OP_ACTOR_MNG_H_
 #define F_OP_ACTOR_MNG_H_
 
-#include "new.h" // IWYU pragma: export // Used by the fopAcM_SetupActor macro.
+#include "new.h" // IWYU pragma: export // Used by the fopAcM_ct macro.
 #include "f_op/f_op_actor.h"
 #include "f_op/f_op_actor_iter.h"
 #include "f_pc/f_pc_manager.h"
@@ -11,11 +11,15 @@
 #include "d/d_save.h"
 #include "d/d_event.h"
 
-#define fopAcM_SetupActor(ptr,ClassName) \
+// The name of this macro is official and comes from a TP debug assert: "fopAcM_ct No Call !!"
+#define fopAcM_ct(ptr,ClassName) \
     if (!fopAcM_CheckCondition(ptr, fopAcCnd_INIT_e)) { \
         new (ptr) ClassName(); \
         fopAcM_OnCondition(ptr, fopAcCnd_INIT_e); \
     }
+
+// Unofficial name, kept to avoid conflicts with open PRs. TODO: Remove later.
+#define fopAcM_SetupActor fopAcM_ct
 
 class J3DModelData;
 class daItem_c;

--- a/src/d/actor/d_a_acorn_leaf.cpp
+++ b/src/d/actor/d_a_acorn_leaf.cpp
@@ -129,7 +129,7 @@ fpc_ProcID daAleaf_c::create_acorn_sub(bool arg1) {
 
 /* 0000049C-000005EC       .text _create__9daAleaf_cFv */
 cPhs_State daAleaf_c::_create() {
-    fopAcM_SetupActor(this, daAleaf_c);
+    fopAcM_ct(this, daAleaf_c);
 
     cPhs_State ret = dComIfG_resLoad(&unk_290, daAleaf_c::m_arcname);
     if (ret == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_agb.cpp
+++ b/src/d/actor/d_a_agb.cpp
@@ -1774,7 +1774,7 @@ BOOL daAgb_c::createHeap() {
 /* 800D3B58-800D3D2C       .text daAgb_Create__FP10fopAc_ac_c */
 static cPhs_State daAgb_Create(fopAc_ac_c* i_this) {
     daAgb_c* a_this = (daAgb_c*)i_this;
-    fopAcM_SetupActor(i_this, daAgb_c);
+    fopAcM_ct(i_this, daAgb_c);
 
     cPhs_State phase = dComIfG_resLoad(&a_this->mPhase, "Agb");
     if (phase == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_agbsw0.cpp
+++ b/src/d/actor/d_a_agbsw0.cpp
@@ -2572,7 +2572,7 @@ static BOOL daAgbsw0_Delete(daAgbsw0_c* i_this) {
 
 /* 00004E98-00004F80       .text daAgbsw0_Create__FP10fopAc_ac_c */
 static cPhs_State daAgbsw0_Create(fopAc_ac_c* i_this) {
-    fopAcM_SetupActor(i_this, daAgbsw0_c);
+    fopAcM_ct(i_this, daAgbsw0_c);
 
     return static_cast<daAgbsw0_c*>(i_this)->create();
 }

--- a/src/d/actor/d_a_alldie.cpp
+++ b/src/d/actor/d_a_alldie.cpp
@@ -67,7 +67,7 @@ BOOL daAlldie_c::execute() {
 }
 
 cPhs_State daAlldie_c::create() {
-    fopAcM_SetupActor(this, daAlldie_c);
+    fopAcM_ct(this, daAlldie_c);
 
     if (!dComIfGs_isSwitch(getSwbit(), fopAcM_GetRoomNo(this))) {
         setActio(ACT_CHECK);

--- a/src/d/actor/d_a_am.cpp
+++ b/src/d/actor/d_a_am.cpp
@@ -1164,7 +1164,7 @@ static BOOL useHeapInit(fopAc_ac_c* i_this) {
 
 /* 00003C00-00003F5C       .text daAM_Create__FP10fopAc_ac_c */
 static cPhs_State daAM_Create(fopAc_ac_c* i_this) {
-    fopAcM_SetupActor(i_this, am_class);
+    fopAcM_ct(i_this, am_class);
 
     am_class* a_this = (am_class*)i_this;
 

--- a/src/d/actor/d_a_am2.cpp
+++ b/src/d/actor/d_a_am2.cpp
@@ -1271,7 +1271,7 @@ static BOOL useHeapInit(fopAc_ac_c* i_this) {
 
 /* 00003E70-00004250       .text daAM2_Create__FP10fopAc_ac_c */
 static cPhs_State daAM2_Create(fopAc_ac_c* i_this) {
-    fopAcM_SetupActor(i_this, am2_class);
+    fopAcM_ct(i_this, am2_class);
 
     am2_class* a_this = (am2_class*)i_this;
 

--- a/src/d/actor/d_a_amiprop.cpp
+++ b/src/d/actor/d_a_amiprop.cpp
@@ -118,7 +118,7 @@ void daAmiProp_c::CreateInit() {
 
 /* 00000318-00000444       .text _create__11daAmiProp_cFv */
 cPhs_State daAmiProp_c::_create() {
-    fopAcM_SetupActor(this, daAmiProp_c);
+    fopAcM_ct(this, daAmiProp_c);
     cPhs_State ret = dComIfG_resLoad(&mPhase, daAmiProp_c::m_arcname);
 
     if (ret == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_andsw0.cpp
+++ b/src/d/actor/d_a_andsw0.cpp
@@ -318,7 +318,7 @@ static BOOL daAndsw0_Delete(andsw0_class*) {
 
 /* 00000974-00000A64       .text daAndsw0_Create__FP10fopAc_ac_c */
 static cPhs_State daAndsw0_Create(fopAc_ac_c* ac) {
-    fopAcM_SetupActor(ac, andsw0_class);
+    fopAcM_ct(ac, andsw0_class);
 
     andsw0_class * i_this = (andsw0_class *)ac;
     i_this->mNumSwitchesToCheck = (fopAcM_GetParam(ac) >> 0) & 0xFF;

--- a/src/d/actor/d_a_andsw2.cpp
+++ b/src/d/actor/d_a_andsw2.cpp
@@ -180,7 +180,7 @@ BOOL daAndsw2_c::execute() {
 cPhs_State daAndsw2_c::create() {
     int sw = getSwbit();
     
-    fopAcM_SetupActor(this, daAndsw2_c);
+    fopAcM_ct(this, daAndsw2_c);
     
     switch (getType()) {
     case TYPE_ONE_OFF:

--- a/src/d/actor/d_a_arrow.cpp
+++ b/src/d/actor/d_a_arrow.cpp
@@ -1216,7 +1216,7 @@ BOOL daArrow_c::_draw() {
 
 /* 800D7960-800D7A38       .text _create__9daArrow_cFv */
 cPhs_State daArrow_c::_create() {
-    fopAcM_SetupActor(this, daArrow_c);
+    fopAcM_ct(this, daArrow_c);
     
     checkCreater();
     

--- a/src/d/actor/d_a_arrow_iceeff.cpp
+++ b/src/d/actor/d_a_arrow_iceeff.cpp
@@ -110,7 +110,7 @@ void daArrow_Iceeff_c::set_mtx() {
 }
 
 cPhs_State daArrow_Iceeff_c::_create() {
-    fopAcM_SetupActor(this, daArrow_Iceeff_c);
+    fopAcM_ct(this, daArrow_Iceeff_c);
 
     void* arrow = fopAcM_SearchByID(parentActorID);
     if(arrow == 0) {

--- a/src/d/actor/d_a_arrow_lighteff.cpp
+++ b/src/d/actor/d_a_arrow_lighteff.cpp
@@ -190,7 +190,7 @@ void daArrow_Lighteff_c::set_mtx() {
 }
 
 cPhs_State daArrow_Lighteff_c::_create() {
-    fopAcM_SetupActor(this, daArrow_Lighteff_c);
+    fopAcM_ct(this, daArrow_Lighteff_c);
 
     field_0x2EA = 0;
     if(!fopAcM_entrySolidHeap(this, &CheckCreateHeap, 0x2660)) {

--- a/src/d/actor/d_a_atdoor.cpp
+++ b/src/d/actor/d_a_atdoor.cpp
@@ -97,9 +97,9 @@ cPhs_State daAtdoor_c::create() {
     if (ret != cPhs_COMPLEATE_e) {
         return ret;
     }
-    fopAcM_SetupActor(this, daAtdoor_c);
+    fopAcM_ct(this, daAtdoor_c);
 #else
-    fopAcM_SetupActor(this, daAtdoor_c);
+    fopAcM_ct(this, daAtdoor_c);
     if (ret != cPhs_COMPLEATE_e) {
         return ret;
     }

--- a/src/d/actor/d_a_atdoor.cpp
+++ b/src/d/actor/d_a_atdoor.cpp
@@ -93,17 +93,11 @@ bool daAtdoor_c::CreateInit() {
 /* 0000036C-00000418       .text create__10daAtdoor_cFv */
 cPhs_State daAtdoor_c::create() {
     cPhs_State ret = dComIfG_resLoad(&mPhase, daAtdoor_c::M_arcname);
-#if VERSION == VERSION_DEMO
+    fopAcM_ct_Retail(this, daAtdoor_c);
     if (ret != cPhs_COMPLEATE_e) {
         return ret;
     }
-    fopAcM_ct(this, daAtdoor_c);
-#else
-    fopAcM_ct(this, daAtdoor_c);
-    if (ret != cPhs_COMPLEATE_e) {
-        return ret;
-    }
-#endif
+    fopAcM_ct_Demo(this, daAtdoor_c);
 
     if (!fopAcM_entrySolidHeap(this, CheckCreateHeap, 0x1580)) {
         return cPhs_ERROR_e;

--- a/src/d/actor/d_a_att.cpp
+++ b/src/d/actor/d_a_att.cpp
@@ -200,7 +200,7 @@ static cPhs_State daAtt_Create(fopAc_ac_c* i_this) {
     };
     
     att_class* a_this = (att_class*)i_this;
-    fopAcM_SetupActor(i_this, att_class);
+    fopAcM_ct(i_this, att_class);
     
     a_this->m2B5 = fopAcM_GetParam(a_this) & 0xFF;
     a_this->attention_info.distances[fopAc_Attn_TYPE_BATTLE_e] = 4;

--- a/src/d/actor/d_a_auction.cpp
+++ b/src/d/actor/d_a_auction.cpp
@@ -229,7 +229,7 @@ static BOOL CheckCreateHeap(fopAc_ac_c* i_this) {
 
 /* 00000664-000006F4       .text _create__11daAuction_cFv */
 cPhs_State daAuction_c::_create() {
-    fopAcM_SetupActor(this, daAuction_c);
+    fopAcM_ct(this, daAuction_c);
 
     cPhs_State phase_state = dComIfG_resLoad(&mPhs, "Pspl");
 

--- a/src/d/actor/d_a_bb.cpp
+++ b/src/d/actor/d_a_bb.cpp
@@ -2700,7 +2700,7 @@ static cPhs_State daBb_Create(fopAc_ac_c* a_this) {
 
     cPhs_State ret = dComIfG_resLoad(&i_this->mPhase, "Bb");
 
-    fopAcM_SetupActor(a_this, bb_class);
+    fopAcM_ct(a_this, bb_class);
 
     if (ret == cPhs_COMPLEATE_e) {
         i_this->unk_2D8 = (fopAcM_GetParam(i_this) >> 0) & 0xFF;

--- a/src/d/actor/d_a_bdk.cpp
+++ b/src/d/actor/d_a_bdk.cpp
@@ -4004,7 +4004,7 @@ static cPhs_State daBdk_Create(fopAc_ac_c* a_this) {
         }},
     };
 
-    fopAcM_SetupActor(a_this, bdk_class);
+    fopAcM_ct(a_this, bdk_class);
     bdk_class* i_this = (bdk_class*)a_this;
     fopAc_ac_c* actor = &i_this->actor;
 

--- a/src/d/actor/d_a_bdkobj.cpp
+++ b/src/d/actor/d_a_bdkobj.cpp
@@ -561,7 +561,7 @@ static cPhs_State daBdkobj_Create(fopAc_ac_c* a_this) {
     };
 
     bdkobj_class* i_this = (bdkobj_class*)a_this;
-    fopAcM_SetupActor(a_this, bdkobj_class);
+    fopAcM_ct(a_this, bdkobj_class);
 
     cPhs_State res = dComIfG_resLoad(&i_this->mPhase, "Bdkobj");
     if (res == cPhs_ERROR_e) {

--- a/src/d/actor/d_a_beam.cpp
+++ b/src/d/actor/d_a_beam.cpp
@@ -597,9 +597,9 @@ cPhs_State daBeam_c::_create() {
 #if VERSION == VERSION_DEMO
     cPhs_State PVar1 = dComIfG_resLoad(&mPhase, M_arcname);
     if (PVar1 == cPhs_COMPLEATE_e) {
-        fopAcM_SetupActor(this, daBeam_c);
+        fopAcM_ct(this, daBeam_c);
 #else
-    fopAcM_SetupActor(this, daBeam_c);
+    fopAcM_ct(this, daBeam_c);
     cPhs_State PVar1 = dComIfG_resLoad(&mPhase, M_arcname);
     if (PVar1 == cPhs_COMPLEATE_e) {
 #endif

--- a/src/d/actor/d_a_beam.cpp
+++ b/src/d/actor/d_a_beam.cpp
@@ -594,15 +594,10 @@ static cPhs_State daBeamCreate(void* i_this) {
 
 /* 00001CA4-00001D34       .text _create__8daBeam_cFv */
 cPhs_State daBeam_c::_create() {
-#if VERSION == VERSION_DEMO
+    fopAcM_ct_Retail(this, daBeam_c);
     cPhs_State PVar1 = dComIfG_resLoad(&mPhase, M_arcname);
     if (PVar1 == cPhs_COMPLEATE_e) {
-        fopAcM_ct(this, daBeam_c);
-#else
-    fopAcM_ct(this, daBeam_c);
-    cPhs_State PVar1 = dComIfG_resLoad(&mPhase, M_arcname);
-    if (PVar1 == cPhs_COMPLEATE_e) {
-#endif
+        fopAcM_ct_Demo(this, daBeam_c);
         if (fopAcM_entrySolidHeap(this, CheckCreateHeap, 0x22A0)) {
             return CreateInit();
         }

--- a/src/d/actor/d_a_bflower.cpp
+++ b/src/d/actor/d_a_bflower.cpp
@@ -235,7 +235,7 @@ int daBFlower_c::init_bck_anm(s16 param) {
 
 /* 0000080C-000008AC       .text _create__11daBFlower_cFv */
 cPhs_State daBFlower_c::_create() {
-    fopAcM_SetupActor(this, daBFlower_c);
+    fopAcM_ct(this, daBFlower_c);
 
     cPhs_State phase_state = dComIfG_resLoad(&mPhs, m_arcname);
 

--- a/src/d/actor/d_a_bg.cpp
+++ b/src/d/actor/d_a_bg.cpp
@@ -341,7 +341,7 @@ static cPhs_State daBg_Create(fopAc_ac_c* i_ac) {
 
 /* 800D9094-800D9318       .text create__6daBg_cFv */
 cPhs_State daBg_c::create() {
-    fopAcM_SetupActor(this, daBg_c);
+    fopAcM_ct(this, daBg_c);
 
     s32 roomNo = fopAcM_GetParam(this);
     JKRExpHeap * roomHeap = dStage_roomControl_c::getMemoryBlock(roomNo);

--- a/src/d/actor/d_a_bgn.cpp
+++ b/src/d/actor/d_a_bgn.cpp
@@ -331,7 +331,7 @@ static cPhs_State daBgn_Create(fopAc_ac_c* i_this) {
             /* Radius */ 70.0f,
         }},
     };
-    fopAcM_SetupActor(i_this, bgn_class);
+    fopAcM_ct(i_this, bgn_class);
 }
 
 static actor_method_class l_daBgn_Method = {

--- a/src/d/actor/d_a_bita.cpp
+++ b/src/d/actor/d_a_bita.cpp
@@ -234,7 +234,7 @@ static cPhs_State daBita_Create(fopAc_ac_c* i_ac) {
         }},
     };
 
-    fopAcM_SetupActor(i_ac, bita_class);
+    fopAcM_ct(i_ac, bita_class);
     bita_class* i_this = (bita_class*)i_ac;
 
     cPhs_State rt = dComIfG_resLoad(&i_this->mPhs, "Bita");

--- a/src/d/actor/d_a_bk.cpp
+++ b/src/d/actor/d_a_bk.cpp
@@ -4743,7 +4743,7 @@ static BOOL useHeapInit(fopAc_ac_c* i_actor) {
 
 /* 0000E310-0000EA2C       .text daBk_Create__FP10fopAc_ac_c */
 static cPhs_State daBk_Create(fopAc_ac_c* i_actor) {
-    fopAcM_SetupActor(i_actor, bk_class);
+    fopAcM_ct(i_actor, bk_class);
     bk_class* i_this = (bk_class*)i_actor;
     
     cPhs_State phase_state = dComIfG_resLoad(&i_this->mPhase, "Bk");

--- a/src/d/actor/d_a_bmd.cpp
+++ b/src/d/actor/d_a_bmd.cpp
@@ -1941,7 +1941,7 @@ static cPhs_State daBmd_Create(fopAc_ac_c* a_this) {
     cXyz local_30;
 
     bmd_class* i_this = (bmd_class*)a_this;
-    fopAcM_SetupActor(a_this, bmd_class);
+    fopAcM_ct(a_this, bmd_class);
     res = dComIfG_resLoad(&i_this->mPhs, "Bmd");
 #if VERSION == VERSION_DEMO
     if (res == cPhs_ERROR_e) {

--- a/src/d/actor/d_a_bmdfoot.cpp
+++ b/src/d/actor/d_a_bmdfoot.cpp
@@ -811,7 +811,7 @@ static cPhs_State daBmdfoot_Create(fopAc_ac_c* a_this) {
     };
     cPhs_State res;
 
-    fopAcM_SetupActor(a_this, bmdfoot_class);
+    fopAcM_ct(a_this, bmdfoot_class);
     bmdfoot_class* i_this = (bmdfoot_class*)a_this;
     res = dComIfG_resLoad(&i_this->m2AC, "Bmdfoot");
     if (res == cPhs_ERROR_e) {

--- a/src/d/actor/d_a_bmdhand.cpp
+++ b/src/d/actor/d_a_bmdhand.cpp
@@ -770,7 +770,7 @@ static cPhs_State daBmdhand_Create(fopAc_ac_c* a_this) {
     cPhs_State res;
 
     fopAc_ac_c* actor = a_this;
-    fopAcM_SetupActor(actor, bmdhand_class);
+    fopAcM_ct(actor, bmdhand_class);
     bmdhand_class* i_this = (bmdhand_class*)a_this;
     res = dComIfG_resLoad(&i_this->m2AC, "Bmdhand");
     if (res == cPhs_ERROR_e) {

--- a/src/d/actor/d_a_boko.cpp
+++ b/src/d/actor/d_a_boko.cpp
@@ -946,7 +946,7 @@ cPhs_State daBoko_c::create() {
         }},
     };
 
-    fopAcM_SetupActor(this, daBoko_c);
+    fopAcM_ct(this, daBoko_c);
 
     u32 type = fopAcM_GetParam(this);
     if (type == Type_UNK_7_e) {

--- a/src/d/actor/d_a_bomb2.cpp
+++ b/src/d/actor/d_a_bomb2.cpp
@@ -404,7 +404,7 @@ namespace daBomb2 {
     }
 
     cPhs_State Act_c::_create() {
-        fopAcM_SetupActor(this, Act_c);
+        fopAcM_ct(this, Act_c);
 
         cPhs_State status = dComIfG_resLoad(&mPhase, attr().resName);
 

--- a/src/d/actor/d_a_bomb3.inc
+++ b/src/d/actor/d_a_bomb3.inc
@@ -1375,7 +1375,7 @@ cPhs_State daBomb_c::create() {
         mType = 0;
     }
 
-    fopAcM_SetupActor(this, daBomb_c);
+    fopAcM_ct(this, daBomb_c);
 
     cPhs_State status = mType == 1 ? dComIfG_resLoad(&mPhase, attrType().resName) : cPhs_COMPLEATE_e;
 

--- a/src/d/actor/d_a_boomerang.cpp
+++ b/src/d/actor/d_a_boomerang.cpp
@@ -797,7 +797,7 @@ static dCcD_SrcCps l_at_cps_src = {
 
 /* 800E2CE8-800E2EF0       .text create__13daBoomerang_cFv */
 cPhs_State daBoomerang_c::create() {
-    fopAcM_SetupActor(this, daBoomerang_c);
+    fopAcM_ct(this, daBoomerang_c);
 
     if (!fopAcM_entrySolidHeap(this, daBoomerang_createHeap, 0xD40)) {
         return cPhs_ERROR_e;

--- a/src/d/actor/d_a_boss_item.cpp
+++ b/src/d/actor/d_a_boss_item.cpp
@@ -24,7 +24,7 @@ static BOOL daBossItem_Delete(bossitem_class* i_this) {
 /* 00000088-00000128       .text daBossItem_Create__FP10fopAc_ac_c */
 static cPhs_State daBossItem_Create(fopAc_ac_c* i_this) {
     bossitem_class* a_this = (bossitem_class*)i_this;
-    fopAcM_SetupActor(i_this, bossitem_class);
+    fopAcM_ct(i_this, bossitem_class);
 
     int stageNo = daBossItem_prm::getStage(a_this);
     BOOL isStageBossDead = dComIfGs_isStageBossEnemy(stageNo);

--- a/src/d/actor/d_a_bpw.cpp
+++ b/src/d/actor/d_a_bpw.cpp
@@ -4369,14 +4369,10 @@ static cPhs_State daBPW_Create(fopAc_ac_c* a_this) {
     bpw_class* i_this = (bpw_class*)a_this;
     fopAc_ac_c* actor = a_this;
     csXyz sp18 = actor->shape_angle;
-#if VERSION > VERSION_DEMO
-    fopAcM_ct(actor, bpw_class);
-#endif
+    fopAcM_ct_Retail(actor, bpw_class);
     res = dComIfG_resLoad(&i_this->m2AC, "BPW");
     if (res == cPhs_COMPLEATE_e) {
-#if VERSION == VERSION_DEMO
-        fopAcM_ct(actor, bpw_class);
-#endif
+        fopAcM_ct_Demo(actor, bpw_class);
         i_this->mType = (bpw_class::Actor_Type_e)fopAcM_GetParam(actor);
         i_this->mUnknownParam2 = (bpw_class::Damage_Action_e)((uint)fopAcM_GetParam(actor) >> 8);
         i_this->mLightState = (u8)((uint)fopAcM_GetParam(actor) >> 0x10);

--- a/src/d/actor/d_a_bpw.cpp
+++ b/src/d/actor/d_a_bpw.cpp
@@ -4370,12 +4370,12 @@ static cPhs_State daBPW_Create(fopAc_ac_c* a_this) {
     fopAc_ac_c* actor = a_this;
     csXyz sp18 = actor->shape_angle;
 #if VERSION > VERSION_DEMO
-    fopAcM_SetupActor(actor, bpw_class);
+    fopAcM_ct(actor, bpw_class);
 #endif
     res = dComIfG_resLoad(&i_this->m2AC, "BPW");
     if (res == cPhs_COMPLEATE_e) {
 #if VERSION == VERSION_DEMO
-        fopAcM_SetupActor(actor, bpw_class);
+        fopAcM_ct(actor, bpw_class);
 #endif
         i_this->mType = (bpw_class::Actor_Type_e)fopAcM_GetParam(actor);
         i_this->mUnknownParam2 = (bpw_class::Damage_Action_e)((uint)fopAcM_GetParam(actor) >> 8);

--- a/src/d/actor/d_a_branch.cpp
+++ b/src/d/actor/d_a_branch.cpp
@@ -192,13 +192,13 @@ static BOOL daBranch_Delete(daBranch_c* i_this) {
 
 inline cPhs_State daBranch_c::create() {
 #if VERSION > VERSION_DEMO
-    fopAcM_SetupActor(this, daBranch_c);
+    fopAcM_ct(this, daBranch_c);
 #endif
 
     cPhs_State phase_state = dComIfG_resLoad(&mPhase, daBranch_c::m_arcname);
     if (phase_state == cPhs_COMPLEATE_e) {
 #if VERSION == VERSION_DEMO
-        fopAcM_SetupActor(this, daBranch_c);
+        fopAcM_ct(this, daBranch_c);
 #endif
 
         if (!fopAcM_entrySolidHeap(this, daBranch_c::solidHeapCB, 0x4000)) {

--- a/src/d/actor/d_a_branch.cpp
+++ b/src/d/actor/d_a_branch.cpp
@@ -191,15 +191,11 @@ static BOOL daBranch_Delete(daBranch_c* i_this) {
 }
 
 inline cPhs_State daBranch_c::create() {
-#if VERSION > VERSION_DEMO
-    fopAcM_ct(this, daBranch_c);
-#endif
+    fopAcM_ct_Retail(this, daBranch_c);
 
     cPhs_State phase_state = dComIfG_resLoad(&mPhase, daBranch_c::m_arcname);
     if (phase_state == cPhs_COMPLEATE_e) {
-#if VERSION == VERSION_DEMO
-        fopAcM_ct(this, daBranch_c);
-#endif
+        fopAcM_ct_Demo(this, daBranch_c);
 
         if (!fopAcM_entrySolidHeap(this, daBranch_c::solidHeapCB, 0x4000)) {
             for (int i = 0; i < (s32)ARRAY_SIZE(mAnims); i++) {

--- a/src/d/actor/d_a_bridge.cpp
+++ b/src/d/actor/d_a_bridge.cpp
@@ -1452,9 +1452,9 @@ static cPhs_State daBridge_Create(fopAc_ac_c* a_this) {
 #if VERSION == VERSION_DEMO
     cPhs_State ret = dComIfG_resLoad(&i_this->mPhase, "Bridge");
     if (ret == cPhs_COMPLEATE_e) {
-        fopAcM_SetupActor(&i_this->actor, bridge_class);
+        fopAcM_ct(&i_this->actor, bridge_class);
 #else
-    fopAcM_SetupActor(&i_this->actor, bridge_class);
+    fopAcM_ct(&i_this->actor, bridge_class);
     cPhs_State ret = dComIfG_resLoad(&i_this->mPhase, "Bridge");
     if (ret == cPhs_COMPLEATE_e) {
 #endif

--- a/src/d/actor/d_a_bridge.cpp
+++ b/src/d/actor/d_a_bridge.cpp
@@ -1449,15 +1449,10 @@ static BOOL CallbackCreateHeap(fopAc_ac_c* a_this) {
 static cPhs_State daBridge_Create(fopAc_ac_c* a_this) {
     bridge_class* i_this = (bridge_class*)a_this;
 
-#if VERSION == VERSION_DEMO
+    fopAcM_ct_Retail(&i_this->actor, bridge_class);
     cPhs_State ret = dComIfG_resLoad(&i_this->mPhase, "Bridge");
     if (ret == cPhs_COMPLEATE_e) {
-        fopAcM_ct(&i_this->actor, bridge_class);
-#else
-    fopAcM_ct(&i_this->actor, bridge_class);
-    cPhs_State ret = dComIfG_resLoad(&i_this->mPhase, "Bridge");
-    if (ret == cPhs_COMPLEATE_e) {
-#endif
+        fopAcM_ct_Demo(&i_this->actor, bridge_class);
         i_this->mTypeBits = fopAcM_GetParam(a_this);
         if (i_this->mTypeBits == 0xFF) {
             i_this->mTypeBits = 0;

--- a/src/d/actor/d_a_bst.cpp
+++ b/src/d/actor/d_a_bst.cpp
@@ -3053,7 +3053,7 @@ static cPhs_State daBst_Create(fopAc_ac_c* a_this) {
         }},
     };
 
-    fopAcM_SetupActor(a_this, bst_class);
+    fopAcM_ct(a_this, bst_class);
     cPhs_State res;
     bst_class* i_this = (bst_class*)a_this;
     fopAc_ac_c* actor = &i_this->actor;

--- a/src/d/actor/d_a_btd.cpp
+++ b/src/d/actor/d_a_btd.cpp
@@ -2866,7 +2866,7 @@ static cPhs_State daBtd_Create(fopAc_ac_c* a_this) {
     cPhs_State res;
 
     fopAc_ac_c* actor = a_this;
-    fopAcM_SetupActor(actor, btd_class);
+    fopAcM_ct(actor, btd_class);
     btd_class* i_this = (btd_class*)a_this;
     res = dComIfG_resLoad(&i_this->m02AC, "Btd");
     if (res != cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_bwd.cpp
+++ b/src/d/actor/d_a_bwd.cpp
@@ -2530,7 +2530,7 @@ static cPhs_State daBwd_Create(fopAc_ac_c* a_this) {
     f32 fVar1;
     cPhs_State res;
 
-    fopAcM_SetupActor(a_this, bwd_class);
+    fopAcM_ct(a_this, bwd_class);
     bwd_class* i_this = (bwd_class*)a_this;
     fopAc_ac_c* actor = &i_this->actor;
     res = dComIfG_resLoad(&i_this->mPhaseBwd, "Bwd");

--- a/src/d/actor/d_a_bwdg.cpp
+++ b/src/d/actor/d_a_bwdg.cpp
@@ -220,7 +220,7 @@ static BOOL useHeapInit(fopAc_ac_c* i_actor) {
 /* 000009A0-00000B5C       .text daBwdg_Create__FP10fopAc_ac_c */
 static cPhs_State daBwdg_Create(fopAc_ac_c* i_actor) {
     bwdg_class* i_this = (bwdg_class*)i_actor;
-    fopAcM_SetupActor(i_this, bwdg_class);
+    fopAcM_ct(i_this, bwdg_class);
     
     cPhs_State phase_state = dComIfG_resLoad(&i_this->mPhase, "Bwdg");
     if (phase_state == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_bwds.cpp
+++ b/src/d/actor/d_a_bwds.cpp
@@ -1033,7 +1033,7 @@ static cPhs_State daBwds_Create(fopAc_ac_c* a_this) {
     };
 
     bwds_class* i_this = (bwds_class*)a_this;
-    fopAcM_SetupActor(&i_this->actor, bwds_class);
+    fopAcM_ct(&i_this->actor, bwds_class);
 
     cPhs_State res = dComIfG_resLoad(&i_this->m02AC, "Bwds");
     if (res == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_canon.cpp
+++ b/src/d/actor/d_a_canon.cpp
@@ -589,7 +589,7 @@ static cPhs_State daCanonCreate(void* i_this) {
 
 /* 00002094-000023C0       .text _create__9daCanon_cFv */
 cPhs_State daCanon_c::_create() {
-    fopAcM_SetupActor(this, daCanon_c);
+    fopAcM_ct(this, daCanon_c);
 
     cPhs_State PVar1 = dComIfG_resLoad(&mPhase, M_arcname);
     if (PVar1 == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_cc.cpp
+++ b/src/d/actor/d_a_cc.cpp
@@ -2580,7 +2580,7 @@ static cPhs_State daCC_Create(fopAc_ac_c* a_this) {
 
     cc_class* i_this = (cc_class*)a_this;
 
-    fopAcM_SetupActor(a_this, cc_class);
+    fopAcM_ct(a_this, cc_class);
 
     cPhs_State PVar3 = dComIfG_resLoad(&i_this->mPhase, "CC");
     if (PVar3 == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_coming2.cpp
+++ b/src/d/actor/d_a_coming2.cpp
@@ -589,7 +589,7 @@ void daComing2::Act_c::coming_process_main() {
 
 /* 00002154-00002264       .text _create__Q29daComing25Act_cFv */
 cPhs_State daComing2::Act_c::_create() {
-    fopAcM_SetupActor(this, daComing2::Act_c);
+    fopAcM_ct(this, daComing2::Act_c);
     unk_299 = -1;
     init_barrel_info();
     init_coming_info();

--- a/src/d/actor/d_a_coming3.cpp
+++ b/src/d/actor/d_a_coming3.cpp
@@ -433,7 +433,7 @@ bool daComing3::Act_c::create_heap() {
 
 /* 000018CC-00001A24       .text _create__Q29daComing35Act_cFv */
 cPhs_State daComing3::Act_c::_create() {
-    fopAcM_SetupActor(this, daComing3::Act_c);
+    fopAcM_ct(this, daComing3::Act_c);
 
     cPhs_State ret = dComIfG_resLoad(&mPhase, M_arcname);
     if (ret == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_dai.cpp
+++ b/src/d/actor/d_a_dai.cpp
@@ -114,7 +114,7 @@ void daDai_c::CreateInit() {
 
 /* 000003A8-00000494       .text _create__7daDai_cFv */
 cPhs_State daDai_c::_create() {
-    fopAcM_SetupActor(this, daDai_c);
+    fopAcM_ct(this, daDai_c);
 
     if (!checkItemGet(dItem_DELIVERY_BAG_e, TRUE)) {
         return cPhs_ERROR_e;

--- a/src/d/actor/d_a_dai_item.cpp
+++ b/src/d/actor/d_a_dai_item.cpp
@@ -373,7 +373,7 @@ void daStandItem_c::CreateInit() {
 
 /* 800E3E94-800E4048       .text _create__13daStandItem_cFv */
 cPhs_State daStandItem_c::_create() {
-    fopAcM_SetupActor(this, daStandItem_c);
+    fopAcM_ct(this, daStandItem_c);
 
     mItemNo = fopAcM_GetParam(this);
     mItemType = convItemNo(mItemNo);

--- a/src/d/actor/d_a_daiocta.cpp
+++ b/src/d/actor/d_a_daiocta.cpp
@@ -1687,7 +1687,7 @@ void daDaiocta_c::createInit() {
 
 /* 00004660-00004918       .text _create__11daDaiocta_cFv */
 cPhs_State daDaiocta_c::_create() {
-    fopAcM_SetupActor(this, daDaiocta_c);
+    fopAcM_ct(this, daDaiocta_c);
     cPhs_State state = dComIfG_resLoad(&mPhs, m_arc_name);
 
     if (state == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_daiocta_eye.cpp
+++ b/src/d/actor/d_a_daiocta_eye.cpp
@@ -469,7 +469,7 @@ void daDaiocta_Eye_c::createInit() {
 
 /* 000012D4-00001450       .text _create__15daDaiocta_Eye_cFv */
 cPhs_State daDaiocta_Eye_c::_create() {
-    fopAcM_SetupActor(this, daDaiocta_Eye_c);
+    fopAcM_ct(this, daDaiocta_Eye_c);
     cPhs_State result = dComIfG_resLoad(&mPhs, m_arc_name);
     if (result == cPhs_COMPLEATE_e) {
         if (!fopAcM_entrySolidHeap(this, createHeap_CB, m_heapsize)) {

--- a/src/d/actor/d_a_deku_item.cpp
+++ b/src/d/actor/d_a_deku_item.cpp
@@ -107,7 +107,7 @@ void daDekuItem_c::CreateInit() {
 
 /* 000003A8-00000598       .text _create__12daDekuItem_cFv */
 cPhs_State daDekuItem_c::_create() {
-    fopAcM_SetupActor(this, daDekuItem_c);
+    fopAcM_ct(this, daDekuItem_c);
 
     mItemBitNo = daDekuItem_prm::getItemBitNo(this);
 

--- a/src/d/actor/d_a_demo00.cpp
+++ b/src/d/actor/d_a_demo00.cpp
@@ -428,7 +428,7 @@ static BOOL daDemo00_Delete(daDemo00_c* i_this) {
 /* 800E78D0-800E7964       .text daDemo00_Create__FP10fopAc_ac_c */
 static cPhs_State daDemo00_Create(fopAc_ac_c* i_ac) {
     daDemo00_c* i_this = (daDemo00_c*)i_ac;
-    fopAcM_SetupActor(i_this, daDemo00_c);
+    fopAcM_ct(i_this, daDemo00_c);
     dKy_tevstr_init(&i_this->tevStr, dComIfGp_roomControl_getStayNo(), 0xFF);
     i_this->setAction(&daDemo00_c::actStandby);
     i_this->nextRes.reset();

--- a/src/d/actor/d_a_demo_dk.cpp
+++ b/src/d/actor/d_a_demo_dk.cpp
@@ -126,7 +126,7 @@ static BOOL useHeapInit(fopAc_ac_c* a_this) {
 static cPhs_State daDEMO_DK_Create(fopAc_ac_c* a_this) {
     demo_dk_class* i_this = (demo_dk_class*)a_this;
     
-    fopAcM_SetupActor(&i_this->actor, demo_dk_class);
+    fopAcM_ct(&i_this->actor, demo_dk_class);
 
     cPhs_State ret = dComIfG_resLoad(&i_this->mPhase, "DEMO_DK");
     if (ret == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_demo_item.cpp
+++ b/src/d/actor/d_a_demo_item.cpp
@@ -454,7 +454,7 @@ BOOL daDitem_c::Delete() {
 }
 
 cPhs_State daDitem_c::create() {
-    fopAcM_SetupActor(this, daDitem_c);
+    fopAcM_ct(this, daDitem_c);
     
     m_itemNo = daDitem_prm::getNo(this);
     

--- a/src/d/actor/d_a_demo_kmm.cpp
+++ b/src/d/actor/d_a_demo_kmm.cpp
@@ -59,9 +59,9 @@ cPhs_State daDemo_Kmm_c::create() {
     if (ret != cPhs_COMPLEATE_e) {
         return ret;
     }
-    fopAcM_SetupActor(this, daDemo_Kmm_c);
+    fopAcM_ct(this, daDemo_Kmm_c);
 #else
-    fopAcM_SetupActor(this, daDemo_Kmm_c);
+    fopAcM_ct(this, daDemo_Kmm_c);
     cPhs_State ret = dComIfG_resLoad(&this->mPhase, M_arcname);
     if (ret != cPhs_COMPLEATE_e) {
         return ret;

--- a/src/d/actor/d_a_demo_kmm.cpp
+++ b/src/d/actor/d_a_demo_kmm.cpp
@@ -54,19 +54,12 @@ BOOL daDemo_Kmm_c::CreateInit() {
 
 /* 00000308-000003A0       .text create__12daDemo_Kmm_cFv */
 cPhs_State daDemo_Kmm_c::create() {
-#if VERSION == DEMO
+    fopAcM_ct_Retail(this, daDemo_Kmm_c);
     cPhs_State ret = dComIfG_resLoad(&this->mPhase, M_arcname);
     if (ret != cPhs_COMPLEATE_e) {
         return ret;
     }
-    fopAcM_ct(this, daDemo_Kmm_c);
-#else
-    fopAcM_ct(this, daDemo_Kmm_c);
-    cPhs_State ret = dComIfG_resLoad(&this->mPhase, M_arcname);
-    if (ret != cPhs_COMPLEATE_e) {
-        return ret;
-    }
-#endif
+    fopAcM_ct_Demo(this, daDemo_Kmm_c);
 
     if (!fopAcM_entrySolidHeap(this, CheckCreateHeap, 0x5700)) {
         return cPhs_ERROR_e;

--- a/src/d/actor/d_a_disappear.cpp
+++ b/src/d/actor/d_a_disappear.cpp
@@ -101,7 +101,7 @@ void set_disappear(disappear_class* i_this, float scale) {
 static cPhs_State daDisappear_Create(fopAc_ac_c* i_this) {
     disappear_class* dis = static_cast<disappear_class*>(i_this);
 
-    fopAcM_SetupActor(dis, disappear_class);
+    fopAcM_ct(dis, disappear_class);
 
     dis->health = fopAcM_GetParam(dis) & 0xFF; // Drop type param is stored in health
     f32 scaleMag = ((fopAcM_GetParam(dis) >> 8) & 0xFF) * 0.1f;

--- a/src/d/actor/d_a_dk.cpp
+++ b/src/d/actor/d_a_dk.cpp
@@ -370,7 +370,7 @@ static BOOL useHeapInit(fopAc_ac_c* i_this) {
 /* 00000FFC-000011EC       .text daDk_Create__FP10fopAc_ac_c */
 static cPhs_State daDk_Create(fopAc_ac_c* i_this) {
     dk_class* a_this = (dk_class*)i_this;
-    fopAcM_SetupActor(i_this, dk_class);
+    fopAcM_ct(i_this, dk_class);
 
     cPhs_State res = dComIfG_resLoad(&a_this->mPhs, "Dk");
     if (res == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_door10.cpp
+++ b/src/d/actor/d_a_door10.cpp
@@ -867,7 +867,7 @@ static BOOL daDoor10_Delete(daDoor10_c* i_this) {
 
 /* 00001E18-00001EA8       .text daDoor10_Create__FP10fopAc_ac_c */
 static cPhs_State daDoor10_Create(fopAc_ac_c* a_this) {
-    fopAcM_SetupActor(a_this, daDoor10_c);
+    fopAcM_ct(a_this, daDoor10_c);
     return ((daDoor10_c*)a_this)->create();
 }
 

--- a/src/d/actor/d_a_door12.cpp
+++ b/src/d/actor/d_a_door12.cpp
@@ -893,7 +893,7 @@ static BOOL daDoor12_Delete(daDoor12_c* i_this) {
 
 /* 00001CC4-00001D3C       .text daDoor12_Create__FP10fopAc_ac_c */
 static cPhs_State daDoor12_Create(fopAc_ac_c* a_this) {
-    fopAcM_SetupActor(a_this, daDoor12_c);
+    fopAcM_ct(a_this, daDoor12_c);
 
     return ((daDoor12_c*)a_this)->create();
 }

--- a/src/d/actor/d_a_dr.cpp
+++ b/src/d/actor/d_a_dr.cpp
@@ -248,13 +248,13 @@ static cPhs_State daDr_Create(fopAc_ac_c* i_this) {
     dr_class* a_this = (dr_class*)i_this;
 
 #if VERSION > VERSION_DEMO
-    fopAcM_SetupActor(a_this, dr_class);
+    fopAcM_ct(a_this, dr_class);
 #endif
 
     cPhs_State phase_state = dComIfG_resLoad(&a_this->mPhs, "Dr");
     if (phase_state == cPhs_COMPLEATE_e) {
 #if VERSION == VERSION_DEMO
-        fopAcM_SetupActor(a_this, dr_class);
+        fopAcM_ct(a_this, dr_class);
 #endif
 
         if (!fopAcM_entrySolidHeap(a_this, createHeap, 0xF000)) {

--- a/src/d/actor/d_a_dr.cpp
+++ b/src/d/actor/d_a_dr.cpp
@@ -247,15 +247,11 @@ static BOOL createHeap(fopAc_ac_c* i_actor) {
 static cPhs_State daDr_Create(fopAc_ac_c* i_this) {
     dr_class* a_this = (dr_class*)i_this;
 
-#if VERSION > VERSION_DEMO
-    fopAcM_ct(a_this, dr_class);
-#endif
+    fopAcM_ct_Retail(a_this, dr_class);
 
     cPhs_State phase_state = dComIfG_resLoad(&a_this->mPhs, "Dr");
     if (phase_state == cPhs_COMPLEATE_e) {
-#if VERSION == VERSION_DEMO
-        fopAcM_ct(a_this, dr_class);
-#endif
+        fopAcM_ct_Demo(a_this, dr_class);
 
         if (!fopAcM_entrySolidHeap(a_this, createHeap, 0xF000)) {
             return cPhs_ERROR_e;

--- a/src/d/actor/d_a_dr2.cpp
+++ b/src/d/actor/d_a_dr2.cpp
@@ -782,7 +782,7 @@ static BOOL useHeapInit(fopAc_ac_c* a_this) {
 static cPhs_State daDr2_Create(fopAc_ac_c* a_this) {
     dr2_class* i_this = (dr2_class*)a_this;
 
-    fopAcM_SetupActor(&i_this->actor, dr2_class);
+    fopAcM_ct(&i_this->actor, dr2_class);
 
     cPhs_State ret = dComIfG_resLoad(&i_this->mPhase, "Dr2");
     if (ret == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_dummy.cpp
+++ b/src/d/actor/d_a_dummy.cpp
@@ -22,7 +22,7 @@ bool daDummy::Act_c::create_heap() {
 
 /* 000000A4-0000015C       .text _create__Q27daDummy5Act_cFv */
 cPhs_State daDummy::Act_c::_create() {  
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
 
     if (fopAcM_entrySolidHeap(this, solidHeapCB, 0)) {
         set_mtx();

--- a/src/d/actor/d_a_ep.cpp
+++ b/src/d/actor/d_a_ep.cpp
@@ -641,9 +641,9 @@ static cPhs_State daEp_Create(fopAc_ac_c* a_this) {
 #if VERSION == VERSION_DEMO
     cPhs_State ret = dComIfG_resLoad(&i_this->mPhase, "Ep");
     if (ret == cPhs_COMPLEATE_e) {
-        fopAcM_SetupActor(a_this, ep_class);
+        fopAcM_ct(a_this, ep_class);
 #else
-    fopAcM_SetupActor(a_this, ep_class);
+    fopAcM_ct(a_this, ep_class);
     cPhs_State ret = dComIfG_resLoad(&i_this->mPhase, "Ep");
     if (ret == cPhs_COMPLEATE_e) {
 #endif

--- a/src/d/actor/d_a_ep.cpp
+++ b/src/d/actor/d_a_ep.cpp
@@ -637,16 +637,11 @@ static cPhs_State daEp_Create(fopAc_ac_c* a_this) {
     };
 
     ep_class* i_this = (ep_class*)a_this;
+    fopAcM_ct_Retail(a_this, ep_class);
 
-#if VERSION == VERSION_DEMO
     cPhs_State ret = dComIfG_resLoad(&i_this->mPhase, "Ep");
     if (ret == cPhs_COMPLEATE_e) {
-        fopAcM_ct(a_this, ep_class);
-#else
-    fopAcM_ct(a_this, ep_class);
-    cPhs_State ret = dComIfG_resLoad(&i_this->mPhase, "Ep");
-    if (ret == cPhs_COMPLEATE_e) {
-#endif
+        fopAcM_ct_Demo(a_this, ep_class);
         i_this->mType = fopAcM_GetParam(a_this) & 0x3F;
         if (i_this->mType == 0x3F) {
             i_this->mType = 0;

--- a/src/d/actor/d_a_esa.cpp
+++ b/src/d/actor/d_a_esa.cpp
@@ -243,7 +243,7 @@ static BOOL daEsa_CreateHeap(fopAc_ac_c* i_actor) {
 static cPhs_State daEsa_Create(fopAc_ac_c* i_actor) {
     daPy_py_c* player = daPy_getPlayerActorClass();
 
-    fopAcM_SetupActor(i_actor, esa_class);
+    fopAcM_ct(i_actor, esa_class);
 
     esa_class* i_this = static_cast<esa_class*>(i_actor);
 

--- a/src/d/actor/d_a_fallrock.cpp
+++ b/src/d/actor/d_a_fallrock.cpp
@@ -189,13 +189,13 @@ static cPhs_State daFallRock_Create(fopAc_ac_c* i_this) {
 /* 00001050-0000127C       .text create__12daFallRock_cFv */
 cPhs_State daFallRock_c::create() {
 #if VERSION > VERSION_DEMO
-    fopAcM_SetupActor(this, daFallRock_c);
+    fopAcM_ct(this, daFallRock_c);
 #endif
 
     cPhs_State res = dComIfG_resLoad(&mPhs, m_arcname);
     if (res == cPhs_COMPLEATE_e) {
 #if VERSION == VERSION_DEMO
-        fopAcM_SetupActor(this, daFallRock_c);
+        fopAcM_ct(this, daFallRock_c);
 #endif
 
         if (!fopAcM_entrySolidHeap(this, CheckCreateHeap, 0xB80)) {

--- a/src/d/actor/d_a_fallrock.cpp
+++ b/src/d/actor/d_a_fallrock.cpp
@@ -188,15 +188,11 @@ static cPhs_State daFallRock_Create(fopAc_ac_c* i_this) {
 
 /* 00001050-0000127C       .text create__12daFallRock_cFv */
 cPhs_State daFallRock_c::create() {
-#if VERSION > VERSION_DEMO
-    fopAcM_ct(this, daFallRock_c);
-#endif
+    fopAcM_ct_Retail(this, daFallRock_c);
 
     cPhs_State res = dComIfG_resLoad(&mPhs, m_arcname);
     if (res == cPhs_COMPLEATE_e) {
-#if VERSION == VERSION_DEMO
-        fopAcM_ct(this, daFallRock_c);
-#endif
+        fopAcM_ct_Demo(this, daFallRock_c);
 
         if (!fopAcM_entrySolidHeap(this, CheckCreateHeap, 0xB80)) {
             return cPhs_ERROR_e;

--- a/src/d/actor/d_a_fan.cpp
+++ b/src/d/actor/d_a_fan.cpp
@@ -156,7 +156,7 @@ static BOOL nodeCallBack(J3DNode* node, int calcTiming) {
 
 /* 000006F4-00000900       .text _create__7daFan_cFv */
 cPhs_State daFan_c::_create() {
-    fopAcM_SetupActor(this, daFan_c);
+    fopAcM_ct(this, daFan_c);
 
     mType = daFan_prm::getType(this);
     cPhs_State rt1 = dComIfG_resLoad(&mPhs, m_arcname[mType]);

--- a/src/d/actor/d_a_ff.cpp
+++ b/src/d/actor/d_a_ff.cpp
@@ -288,7 +288,7 @@ static BOOL useHeapInit(fopAc_ac_c* i_this) {
 
 /* 000013D4-0000164C       .text daFf_Create__FP10fopAc_ac_c */
 static cPhs_State daFf_Create(fopAc_ac_c* i_this) {
-    fopAcM_SetupActor(i_this, ff_class);
+    fopAcM_ct(i_this, ff_class);
     ff_class* a_this = (ff_class*)i_this;
     cPhs_State phase_state = dComIfG_resLoad(&a_this->mPhs, "Ff");
 

--- a/src/d/actor/d_a_fganon.cpp
+++ b/src/d/actor/d_a_fganon.cpp
@@ -2735,7 +2735,7 @@ static BOOL useHeapInit(fopAc_ac_c* i_act) {
 static cPhs_State daFganon_Create(fopAc_ac_c* a_this) {
     fganon_class* i_this = (fganon_class*)a_this;
     fopEn_enemy_c* e_this = (fopEn_enemy_c*)a_this;
-    fopAcM_SetupActor(a_this, fganon_class);
+    fopAcM_ct(a_this, fganon_class);
     s32 res;
     s32 res2;
     

--- a/src/d/actor/d_a_fgmahou.cpp
+++ b/src/d/actor/d_a_fgmahou.cpp
@@ -400,15 +400,11 @@ static cPhs_State daFgmahou_Create(fopAc_ac_c* a_this) {
 
     fgmahou_class* i_this = static_cast<fgmahou_class*>(a_this);
 
-#if VERSION > VERSION_DEMO
-    fopAcM_ct(i_this, fgmahou_class);
-#endif
+    fopAcM_ct_Retail(i_this, fgmahou_class);
 
     cPhs_State phase_state = dComIfG_resLoad(&i_this->mPhs, "Fganon");
     if(phase_state == cPhs_COMPLEATE_e) {
-    #if VERSION == VERSION_DEMO
-        fopAcM_ct(i_this, fgmahou_class);
-    #endif
+        fopAcM_ct_Demo(i_this, fgmahou_class);
 
         i_this->mOrbNumber = fopAcM_GetParam(i_this) & 0xF;
 

--- a/src/d/actor/d_a_fgmahou.cpp
+++ b/src/d/actor/d_a_fgmahou.cpp
@@ -401,13 +401,13 @@ static cPhs_State daFgmahou_Create(fopAc_ac_c* a_this) {
     fgmahou_class* i_this = static_cast<fgmahou_class*>(a_this);
 
 #if VERSION > VERSION_DEMO
-    fopAcM_SetupActor(i_this, fgmahou_class);
+    fopAcM_ct(i_this, fgmahou_class);
 #endif
 
     cPhs_State phase_state = dComIfG_resLoad(&i_this->mPhs, "Fganon");
     if(phase_state == cPhs_COMPLEATE_e) {
     #if VERSION == VERSION_DEMO
-        fopAcM_SetupActor(i_this, fgmahou_class);
+        fopAcM_ct(i_this, fgmahou_class);
     #endif
 
         i_this->mOrbNumber = fopAcM_GetParam(i_this) & 0xF;

--- a/src/d/actor/d_a_fire.cpp
+++ b/src/d/actor/d_a_fire.cpp
@@ -219,7 +219,7 @@ BOOL daFire_c::CreateInit() {
 
 /* 00000518-00000758       .text _create__8daFire_cFv */
 cPhs_State daFire_c::_create() {
-    fopAcM_SetupActor(this, daFire_c);
+    fopAcM_ct(this, daFire_c);
 
     field_0x8BC = dComIfGp_particle_set(dPa_name::ID_IT_JN_KAKOMI_FIRE_A00, &current.pos);
     field_0x8C0 = dComIfGp_particle_set(dPa_name::ID_IT_JN_KAKOMI_FIRE_B00, &current.pos);

--- a/src/d/actor/d_a_floor.cpp
+++ b/src/d/actor/d_a_floor.cpp
@@ -56,7 +56,7 @@ BOOL daFloor_c::Create() {
 
 /* 0000025C-00000354       .text _create__9daFloor_cFv */
 cPhs_State daFloor_c::_create() {
-    fopAcM_SetupActor(this, daFloor_c);
+    fopAcM_ct(this, daFloor_c);
 
     mSwitchNo = daFloor_prm::getSwitchNo(this);
     if (mSwitchNo != 0xFF && dComIfGs_isSwitch(mSwitchNo, fopAcM_GetHomeRoomNo(this)))

--- a/src/d/actor/d_a_fm.cpp
+++ b/src/d/actor/d_a_fm.cpp
@@ -3441,7 +3441,7 @@ void daFm_c::createInit() {
 
 /* 000090DC-00009258       .text _create__6daFm_cFv */
 cPhs_State daFm_c::_create() {
-    fopAcM_SetupActor(this, daFm_c);
+    fopAcM_ct(this, daFm_c);
     cPhs_State phase_state = dComIfG_resLoad(&mPhs, m_arc_name);
     if(phase_state == cPhs_COMPLEATE_e) {
         if(parentActorID != -1) {

--- a/src/d/actor/d_a_ghostship.cpp
+++ b/src/d/actor/d_a_ghostship.cpp
@@ -236,7 +236,7 @@ void daGhostship_c::getArg() {
 }
 
 cPhs_State daGhostship_c::_create() {
-    fopAcM_SetupActor(this, daGhostship_c);
+    fopAcM_ct(this, daGhostship_c);
 
     cPhs_State result = dComIfG_resLoad(&mPhs, m_arc_name);
     if(result != cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_goal_flag.cpp
+++ b/src/d/actor/d_a_goal_flag.cpp
@@ -574,7 +574,7 @@ cPhs_State daGoal_Flag_c::_create() {
     u8 arc_index;
     dPath* path_p;
 
-    fopAcM_SetupActor(this, daGoal_Flag_c);
+    fopAcM_ct(this, daGoal_Flag_c);
 
     u8 prm = fopAcM_GetParam(this) & 0xFF;
     cloth_resload_state = dComIfG_resLoad(&mClothPhs, "Cloth");

--- a/src/d/actor/d_a_grass.cpp
+++ b/src/d/actor/d_a_grass.cpp
@@ -131,7 +131,7 @@ static cPhs_State daGrass_Create(fopAc_ac_c* i_ac) {
 
     grass_class * i_this = (grass_class*)i_ac;
 
-    fopAcM_SetupActor(i_this, grass_class);
+    fopAcM_ct(i_this, grass_class);
 
     u32 grp = daGrass_prm::getType(i_this);
     OffsetData * offset = &l_offsetData[grp];

--- a/src/d/actor/d_a_gy_ctrl.cpp
+++ b/src/d/actor/d_a_gy_ctrl.cpp
@@ -531,7 +531,7 @@ bool daGy_Ctrl_c::checkGyCtrlExist() {
 
 /* 00001458-000016AC       .text _create__11daGy_Ctrl_cFv */
 cPhs_State daGy_Ctrl_c::_create() {
-    fopAcM_SetupActor(this, daGy_Ctrl_c);
+    fopAcM_ct(this, daGy_Ctrl_c);
 
     getArg();
 

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -1798,7 +1798,7 @@ static cPhs_State daHimo2_Create(fopAc_ac_c* i_this) {
     himo2_class* a_this = (himo2_class*)i_this;
     daPy_py_c* player = (daPy_py_c*)dComIfGp_getPlayer(0);
 
-    fopAcM_SetupActor(i_this, himo2_class);
+    fopAcM_ct(i_this, himo2_class);
 
     cPhs_State phase_state;
     if (!fopAcM_entrySolidHeap(&a_this->actor, CallbackCreateHeap, REG0_S(9) + 0x9050)) {

--- a/src/d/actor/d_a_himo3.cpp
+++ b/src/d/actor/d_a_himo3.cpp
@@ -760,7 +760,7 @@ static cPhs_State daHimo3_Create(fopAc_ac_c* a_this) {
 
     himo3_class* i_this = (himo3_class*)a_this;
 
-    fopAcM_SetupActor(a_this, himo3_class);
+    fopAcM_ct(a_this, himo3_class);
 
     cPhs_State PVar1 = dComIfG_resLoad(&i_this->mPhase, "Himo3");
     if (PVar1 == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_hitobj.cpp
+++ b/src/d/actor/d_a_hitobj.cpp
@@ -46,7 +46,7 @@ static BOOL daHitobj_Delete(hitobj_class* i_this) {
 /* 00000120-0000025C       .text daHitobj_Create__FP10fopAc_ac_c */
 static cPhs_State daHitobj_Create(fopAc_ac_c* pActor) {
     hitobj_class* i_this = (hitobj_class*)pActor;
-    fopAcM_SetupActor(i_this, hitobj_class);
+    fopAcM_ct(i_this, hitobj_class);
 
     cPhs_State res = dComIfG_resLoad(&(i_this->mPhs), "Hitobj");
     if (res == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_hmlif.cpp
+++ b/src/d/actor/d_a_hmlif.cpp
@@ -249,7 +249,7 @@ BOOL daHmlif_c::Create() {
 
 /* 000007C8-00000930       .text daHmlifCreate__9daHmlif_cFv */
 cPhs_State daHmlif_c::daHmlifCreate() {
-    fopAcM_SetupActor(this, daHmlif_c);
+    fopAcM_ct(this, daHmlif_c);
     m489 = daHmlif_prm::getType(this);
     cPhs_State PVar2 = dComIfG_resLoad(&mPhase, m_arcname[m489]);
     if (PVar2 == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_hookshot.cpp
+++ b/src/d/actor/d_a_hookshot.cpp
@@ -543,7 +543,7 @@ static dCcD_SrcCps l_at_cps_src = {
 
 /* 800F2C14-800F2CC8       .text create__12daHookshot_cFv */
 cPhs_State daHookshot_c::create() {
-    fopAcM_SetupActor(this, daHookshot_c);
+    fopAcM_ct(this, daHookshot_c);
     
     mShape.setUserArea(reinterpret_cast<u32>(this));
     mLinChk.ClrSttsRoofOff();

--- a/src/d/actor/d_a_hot_floor.cpp
+++ b/src/d/actor/d_a_hot_floor.cpp
@@ -55,7 +55,7 @@ cPhs_State daHot_Floor_c::CreateInit() {
 cPhs_State daHot_Floor_c::_create() {
 #if VERSION > VERSION_DEMO
     // Bug: This actor is never initialized in the demo.
-    fopAcM_SetupActor(this, daHot_Floor_c);
+    fopAcM_ct(this, daHot_Floor_c);
 #endif
     return CreateInit();
 }

--- a/src/d/actor/d_a_hys.cpp
+++ b/src/d/actor/d_a_hys.cpp
@@ -78,7 +78,7 @@ BOOL daHys_c::CreateHeap() {
 }
 
 cPhs_State daHys_c::_create() {
-    fopAcM_SetupActor(this, daHys_c);
+    fopAcM_ct(this, daHys_c);
 
     mType = fopAcM_GetParam(this) >> 8;
     cPhs_State res = dComIfG_resLoad(&mPhs, m_arcname[mType]);

--- a/src/d/actor/d_a_ib.cpp
+++ b/src/d/actor/d_a_ib.cpp
@@ -408,7 +408,7 @@ static BOOL CheckCreateHeap(fopAc_ac_c* i_this) {
 
 /* 800F4698-800F4870       .text _daIball_create__9daIball_cFv */
 cPhs_State daIball_c::_daIball_create() {
-    fopAcM_SetupActor(this, daIball_c);
+    fopAcM_ct(this, daIball_c);
     
     if (!fopAcM_entrySolidHeap(this, CheckCreateHeap, 0x3500)) {
         return cPhs_ERROR_e;

--- a/src/d/actor/d_a_ikari.cpp
+++ b/src/d/actor/d_a_ikari.cpp
@@ -128,7 +128,7 @@ bool daIkari_c::_draw() {
 cPhs_State daIkari_c::_create() {
     cPhs_State phase = dComIfG_resLoad(&mPhs, M_arcname);
 
-    fopAcM_SetupActor(this, daIkari_c);
+    fopAcM_ct(this, daIkari_c);
 
     if (phase == cPhs_COMPLEATE_e) {
         getArg();

--- a/src/d/actor/d_a_item.cpp
+++ b/src/d/actor/d_a_item.cpp
@@ -216,7 +216,7 @@ void daItem_c::CreateInit() {
 
 /* 800F53EC-800F5668       .text _daItem_create__8daItem_cFv */
 cPhs_State daItem_c::_daItem_create() {
-    fopAcM_SetupActor(this, daItem_c);
+    fopAcM_ct(this, daItem_c);
     
     m_itemNo = daItem_prm::getItemNo(this);
     

--- a/src/d/actor/d_a_jbo.cpp
+++ b/src/d/actor/d_a_jbo.cpp
@@ -190,13 +190,13 @@ static BOOL useHeapInit(fopAc_ac_c* i_this) {
 /* 0000081C-00000A90       .text daJBO_Create__FP10fopAc_ac_c */
 static cPhs_State daJBO_Create(fopAc_ac_c* i_this) {
     #if VERSION > VERSION_DEMO
-    fopAcM_SetupActor(i_this, jbo_class);
+    fopAcM_ct(i_this, jbo_class);
     #endif
     jbo_class* a_this = (jbo_class*)i_this;
     cPhs_State state = dComIfG_resLoad(&a_this->mPhs, "JBO");
     if (state == cPhs_COMPLEATE_e) {
         #if VERSION == VERSION_DEMO
-        fopAcM_SetupActor(i_this, jbo_class);
+        fopAcM_ct(i_this, jbo_class);
         #endif
         if (!fopAcM_entrySolidHeap(i_this, &useHeapInit, 0x1c20)) {
             return cPhs_ERROR_e;

--- a/src/d/actor/d_a_jbo.cpp
+++ b/src/d/actor/d_a_jbo.cpp
@@ -189,15 +189,11 @@ static BOOL useHeapInit(fopAc_ac_c* i_this) {
 
 /* 0000081C-00000A90       .text daJBO_Create__FP10fopAc_ac_c */
 static cPhs_State daJBO_Create(fopAc_ac_c* i_this) {
-    #if VERSION > VERSION_DEMO
-    fopAcM_ct(i_this, jbo_class);
-    #endif
+    fopAcM_ct_Retail(i_this, jbo_class);
     jbo_class* a_this = (jbo_class*)i_this;
     cPhs_State state = dComIfG_resLoad(&a_this->mPhs, "JBO");
     if (state == cPhs_COMPLEATE_e) {
-        #if VERSION == VERSION_DEMO
-        fopAcM_ct(i_this, jbo_class);
-        #endif
+        fopAcM_ct_Demo(i_this, jbo_class);
         if (!fopAcM_entrySolidHeap(i_this, &useHeapInit, 0x1c20)) {
             return cPhs_ERROR_e;
         } else {

--- a/src/d/actor/d_a_kaji.cpp
+++ b/src/d/actor/d_a_kaji.cpp
@@ -43,7 +43,7 @@ BOOL daKaji_c::CreateHeap() {
 }
 
 cPhs_State daKaji_c::_create() {
-    fopAcM_SetupActor(this, daKaji_c);
+    fopAcM_ct(this, daKaji_c);
     
     cPhs_State phase_state = dComIfG_resLoad(&mPhs, M_arcname);
     if (phase_state == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_kamome.cpp
+++ b/src/d/actor/d_a_kamome.cpp
@@ -1485,9 +1485,9 @@ static cPhs_State daKamome_Create(fopAc_ac_c* a_this) {
 #if VERSION == VERSION_DEMO
     cPhs_State PVar1 = dComIfG_resLoad(&i_this->mPhase, "Kamome");
     if (PVar1 == cPhs_COMPLEATE_e) {
-        fopAcM_SetupActor(a_this, kamome_class);
+        fopAcM_ct(a_this, kamome_class);
 #else
-    fopAcM_SetupActor(a_this, kamome_class);
+    fopAcM_ct(a_this, kamome_class);
 
     cPhs_State PVar1 = dComIfG_resLoad(&i_this->mPhase, "Kamome");
     if (PVar1 == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_kamome.cpp
+++ b/src/d/actor/d_a_kamome.cpp
@@ -1481,17 +1481,11 @@ static cPhs_State daKamome_Create(fopAc_ac_c* a_this) {
     };
 
     kamome_class* i_this = (kamome_class*)a_this;
-
-#if VERSION == VERSION_DEMO
-    cPhs_State PVar1 = dComIfG_resLoad(&i_this->mPhase, "Kamome");
-    if (PVar1 == cPhs_COMPLEATE_e) {
-        fopAcM_ct(a_this, kamome_class);
-#else
-    fopAcM_ct(a_this, kamome_class);
+    fopAcM_ct_Retail(a_this, kamome_class);
 
     cPhs_State PVar1 = dComIfG_resLoad(&i_this->mPhase, "Kamome");
     if (PVar1 == cPhs_COMPLEATE_e) {
-#endif
+        fopAcM_ct_Demo(a_this, kamome_class);
 
         i_this->mType = fopAcM_GetParam(a_this);
         if (i_this->mType == 0xff) {

--- a/src/d/actor/d_a_kamome2.cpp
+++ b/src/d/actor/d_a_kamome2.cpp
@@ -324,7 +324,7 @@ static cPhs_State daKamome2_Create(fopAc_ac_c* a_this) {
 
     cPhs_State iVar1 = dComIfG_resLoad(&i_this->mPhase, "Kamome");
     if (iVar1 == cPhs_COMPLEATE_e) {
-        fopAcM_SetupActor(a_this, kamome2_class);
+        fopAcM_ct(a_this, kamome2_class);
 
         i_this->m2A4 = fopAcM_GetParam(a_this);
         if (!fopAcM_entrySolidHeap(a_this, useHeapInit, 0x59A0)) {

--- a/src/d/actor/d_a_kanban.cpp
+++ b/src/d/actor/d_a_kanban.cpp
@@ -1082,7 +1082,7 @@ static cPhs_State daKanban_Create(fopAc_ac_c* a_this) {
     u32 maxHeapSize = 0;
     kanban_class* i_this = (kanban_class*)a_this;
 
-    fopAcM_SetupActor(&i_this->actor, kanban_class);
+    fopAcM_ct(&i_this->actor, kanban_class);
     cPhs_State ret = dComIfG_resLoad(&i_this->mPhase, "Kanban");
 
     if (ret == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_kantera.cpp
+++ b/src/d/actor/d_a_kantera.cpp
@@ -379,7 +379,7 @@ static cPhs_State daKantera_Create(fopAc_ac_c* a_this) {
 
     kantera_class* i_this = (kantera_class*)a_this;
 
-    fopAcM_SetupActor(a_this, kantera_class);
+    fopAcM_ct(a_this, kantera_class);
 
     i_this->mParam0 = fopAcM_GetParam(a_this);
     i_this->mParam1 = fopAcM_GetParam(a_this) >> 8;

--- a/src/d/actor/d_a_ki.cpp
+++ b/src/d/actor/d_a_ki.cpp
@@ -1369,7 +1369,7 @@ static cPhs_State daKi_Create(fopAc_ac_c* a_this) {
 
     ki_class* i_this = (ki_class*)a_this;
 
-    fopAcM_SetupActor(a_this, ki_class);
+    fopAcM_ct(a_this, ki_class);
 
     cPhs_State ret = dComIfG_resLoad(&i_this->mPhase, "Ki");
     if (ret == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_kita.cpp
+++ b/src/d/actor/d_a_kita.cpp
@@ -420,7 +420,7 @@ static cPhs_State daKita_Create(fopAc_ac_c* a_this) {
     };
     
     kita_class* i_this = static_cast<kita_class*>(a_this);
-    fopAcM_SetupActor(a_this, kita_class);
+    fopAcM_ct(a_this, kita_class);
     cPhs_State ret;
 
     ret = dComIfG_resLoad(&i_this->mPhs, "Kita");

--- a/src/d/actor/d_a_kmon.cpp
+++ b/src/d/actor/d_a_kmon.cpp
@@ -95,7 +95,7 @@ void daKmon_c::checkTalk() {
 }
 
 cPhs_State daKmon_c::_create() {
-    fopAcM_SetupActor(this, daKmon_c);
+    fopAcM_ct(this, daKmon_c);
 
     cPhs_State state = dComIfG_resLoad(&mPhase, daKmon_c::m_arcname);
     if(state == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_kn.cpp
+++ b/src/d/actor/d_a_kn.cpp
@@ -518,9 +518,9 @@ static cPhs_State daKN_Create(fopAc_ac_c* a_this) {
 #if VERSION == VERSION_DEMO
     cPhs_State PVar1 = dComIfG_resLoad(&i_this->mPhase, "KN");
     if (PVar1 == cPhs_COMPLEATE_e) {
-        fopAcM_SetupActor(&i_this->actor, kn_class);
+        fopAcM_ct(&i_this->actor, kn_class);
 #else
-    fopAcM_SetupActor(a_this, kn_class);
+    fopAcM_ct(a_this, kn_class);
     cPhs_State PVar1 = dComIfG_resLoad(&i_this->mPhase, "KN");
     if (PVar1 == cPhs_COMPLEATE_e) {
 #endif

--- a/src/d/actor/d_a_kn.cpp
+++ b/src/d/actor/d_a_kn.cpp
@@ -515,15 +515,10 @@ static BOOL useHeapInit(fopAc_ac_c* a_this) {
 static cPhs_State daKN_Create(fopAc_ac_c* a_this) {
     kn_class* i_this = (kn_class*)a_this;
 
-#if VERSION == VERSION_DEMO
+    fopAcM_ct_Retail(a_this, kn_class);
     cPhs_State PVar1 = dComIfG_resLoad(&i_this->mPhase, "KN");
     if (PVar1 == cPhs_COMPLEATE_e) {
-        fopAcM_ct(&i_this->actor, kn_class);
-#else
-    fopAcM_ct(a_this, kn_class);
-    cPhs_State PVar1 = dComIfG_resLoad(&i_this->mPhase, "KN");
-    if (PVar1 == cPhs_COMPLEATE_e) {
-#endif
+        fopAcM_ct_Demo(&i_this->actor, kn_class);
         i_this->m2B4 = fopAcM_GetParam(a_this);
         i_this->m2B5 = fopAcM_GetParam(a_this) >> 8;
         i_this->m2EC = a_this->current.pos;

--- a/src/d/actor/d_a_knob00.cpp
+++ b/src/d/actor/d_a_knob00.cpp
@@ -375,9 +375,9 @@ cPhs_State daKnob00_c::create() {
     if (ret != cPhs_COMPLEATE_e) {
         return ret;
     }
-    fopAcM_SetupActor(this, daKnob00_c);
+    fopAcM_ct(this, daKnob00_c);
 #else
-    fopAcM_SetupActor(this, daKnob00_c);
+    fopAcM_ct(this, daKnob00_c);
     if (ret != cPhs_COMPLEATE_e) {
         return ret;
     }

--- a/src/d/actor/d_a_knob00.cpp
+++ b/src/d/actor/d_a_knob00.cpp
@@ -371,17 +371,11 @@ BOOL daKnob00_c::CreateInit() {
 /* 00000D84-00000E70       .text create__10daKnob00_cFv */
 cPhs_State daKnob00_c::create() {
     cPhs_State ret = dComIfG_resLoad(&mPhase, M_arcname);
-#if VERSION == VERSION_DEMO
+    fopAcM_ct_Retail(this, daKnob00_c);
     if (ret != cPhs_COMPLEATE_e) {
         return ret;
     }
-    fopAcM_ct(this, daKnob00_c);
-#else
-    fopAcM_ct(this, daKnob00_c);
-    if (ret != cPhs_COMPLEATE_e) {
-        return ret;
-    }
-#endif
+    fopAcM_ct_Demo(this, daKnob00_c);
 
     if (fopAcM_GetRoomNo(this) == -1) {
         fopAcM_SetRoomNo(this, getFRoomNo());

--- a/src/d/actor/d_a_kokiie.cpp
+++ b/src/d/actor/d_a_kokiie.cpp
@@ -376,7 +376,7 @@ static BOOL CallbackCreateHeap(fopAc_ac_c* a_this) {
 static cPhs_State daKokiie_Create(fopAc_ac_c* a_this) {
     kokiie_class* i_this = (kokiie_class*)a_this;
 
-    fopAcM_SetupActor(a_this, kokiie_class);
+    fopAcM_ct(a_this, kokiie_class);
 
     cPhs_State PVar3 = dComIfG_resLoad(&i_this->mPhase, "Kokiie");
 #if VERSION == VERSION_DEMO

--- a/src/d/actor/d_a_komore.cpp
+++ b/src/d/actor/d_a_komore.cpp
@@ -46,7 +46,7 @@ bool daKomore::Act_c::create_heap() {
 
 /* 000001F8-000002F8       .text _create__Q28daKomore5Act_cFv */
 cPhs_State daKomore::Act_c::_create() {
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
     cPhs_State phase_state = dComIfG_resLoad(&mPhs, M_arcname);
     if (phase_state == cPhs_COMPLEATE_e) {
         if (fopAcM_entrySolidHeap(this, solidHeapCB, 0x0)) {

--- a/src/d/actor/d_a_ks.cpp
+++ b/src/d/actor/d_a_ks.cpp
@@ -1552,16 +1552,12 @@ static BOOL useHeapInit(fopAc_ac_c* i_act) {
 
 /* 000034F8-00003A94       .text daKS_Create__FP10fopAc_ac_c */
 static cPhs_State daKS_Create(fopAc_ac_c* i_this) {
-#if VERSION > VERSION_DEMO
-    fopAcM_ct(i_this, ks_class);
-#endif
+    fopAcM_ct_Retail(i_this, ks_class);
     ks_class* a_this = (ks_class*)i_this;
     
     cPhs_State res = dComIfG_resLoad(&a_this->mPhs, "KS");
     if (res == cPhs_COMPLEATE_e) {
-#if VERSION == VERSION_DEMO
-        fopAcM_ct(i_this, ks_class);
-#endif
+        fopAcM_ct_Demo(i_this, ks_class);
         if (!fopAcM_entrySolidHeap(i_this, useHeapInit, 0x1060)) {
             return cPhs_ERROR_e;
         }

--- a/src/d/actor/d_a_ks.cpp
+++ b/src/d/actor/d_a_ks.cpp
@@ -1553,14 +1553,14 @@ static BOOL useHeapInit(fopAc_ac_c* i_act) {
 /* 000034F8-00003A94       .text daKS_Create__FP10fopAc_ac_c */
 static cPhs_State daKS_Create(fopAc_ac_c* i_this) {
 #if VERSION > VERSION_DEMO
-    fopAcM_SetupActor(i_this, ks_class);
+    fopAcM_ct(i_this, ks_class);
 #endif
     ks_class* a_this = (ks_class*)i_this;
     
     cPhs_State res = dComIfG_resLoad(&a_this->mPhs, "KS");
     if (res == cPhs_COMPLEATE_e) {
 #if VERSION == VERSION_DEMO
-        fopAcM_SetupActor(i_this, ks_class);
+        fopAcM_ct(i_this, ks_class);
 #endif
         if (!fopAcM_entrySolidHeap(i_this, useHeapInit, 0x1060)) {
             return cPhs_ERROR_e;

--- a/src/d/actor/d_a_kt.cpp
+++ b/src/d/actor/d_a_kt.cpp
@@ -328,7 +328,7 @@ static BOOL daKt_solidHeapCB(fopAc_ac_c* i_ac) {
 
 /* 0000134C-00001530       .text daKt_Create__FP10fopAc_ac_c */
 static cPhs_State daKt_Create(fopAc_ac_c* i_ac) {
-    fopAcM_SetupActor(i_ac, kt_class);
+    fopAcM_ct(i_ac, kt_class);
     kt_class* i_this = (kt_class*)i_ac;
 
     cPhs_State rt = dComIfG_resLoad(&i_this->mPhs, "Kt");

--- a/src/d/actor/d_a_kui.cpp
+++ b/src/d/actor/d_a_kui.cpp
@@ -470,7 +470,7 @@ static cPhs_State daKui_Create(fopAc_ac_c* a_this) {
     kui_class* i_this;
     cPhs_State result;
 
-    fopAcM_SetupActor(a_this, kui_class);
+    fopAcM_ct(a_this, kui_class);
     i_this = (kui_class*) a_this;
 
     result = dComIfG_resLoad(&i_this->mPhs, "Kui");

--- a/src/d/actor/d_a_kytag00.cpp
+++ b/src/d/actor/d_a_kytag00.cpp
@@ -355,7 +355,7 @@ static BOOL daKytag00_Delete(kytag00_class* i_this) {
 static cPhs_State daKytag00_Create(fopAc_ac_c* i_ac) {
     kytag00_class * i_this = (kytag00_class *)i_ac;
 
-    fopAcM_SetupActor(i_ac, kytag00_class);
+    fopAcM_ct(i_ac, kytag00_class);
 
     i_this->field_0x296 = 0;
     i_this->mPselIdx = (fopAcM_GetParam(i_ac) >> 0) & 0xFF;

--- a/src/d/actor/d_a_kytag01.cpp
+++ b/src/d/actor/d_a_kytag01.cpp
@@ -84,7 +84,7 @@ void wave_make() {
 static cPhs_State daKytag01_Create(fopAc_ac_c* i_ac) {
     dScnKy_env_light_c& env_light = dKy_getEnvlight();
     kytag01_class* i_this = (kytag01_class*)i_ac;
-    fopAcM_SetupActor(i_ac, kytag01_class);
+    fopAcM_ct(i_ac, kytag01_class);
 
     i_this->mWaveInfo.mPos = i_ac->current.pos;
     i_this->mWaveInfo.mInnerRadius = i_ac->scale.x * 5000.0f;

--- a/src/d/actor/d_a_kytag02.cpp
+++ b/src/d/actor/d_a_kytag02.cpp
@@ -114,7 +114,7 @@ static BOOL daKytag02_Delete(kytag02_class* i_this) {
 /* 00000420-0000047C       .text daKytag02_Create__FP10fopAc_ac_c */
 static cPhs_State daKytag02_Create(fopAc_ac_c* i_this) {
     kytag02_class* a_this = (kytag02_class*)i_this;
-    fopAcM_SetupActor(i_this, kytag02_class);
+    fopAcM_ct(i_this, kytag02_class);
     a_this->mpPath = set_path_info(i_this);
     return cPhs_COMPLEATE_e;
 }

--- a/src/d/actor/d_a_kytag03.cpp
+++ b/src/d/actor/d_a_kytag03.cpp
@@ -128,15 +128,11 @@ static BOOL daKytag03_Delete(kytag03_class* i_this) {
 static cPhs_State daKytag03_Create(fopAc_ac_c* i_ac) {
     kytag03_class* i_this = (kytag03_class*)i_ac;
 
-#if VERSION > VERSION_DEMO
-    fopAcM_ct(i_ac, kytag03_class);
-#endif
+    fopAcM_ct_Retail(i_ac, kytag03_class);
 
     cPhs_State ret = dComIfG_resLoad(&i_this->mPhs, "M_DOOR");
     if (ret == cPhs_COMPLEATE_e) {
-#if VERSION == VERSION_DEMO
-        fopAcM_ct(i_ac, kytag03_class);
-#endif
+        fopAcM_ct_Demo(i_ac, kytag03_class);
 
         if (!fopAcM_entrySolidHeap(&i_this->actor, useHeapInit, 0x4c30)) {
             return cPhs_ERROR_e;

--- a/src/d/actor/d_a_kytag03.cpp
+++ b/src/d/actor/d_a_kytag03.cpp
@@ -129,13 +129,13 @@ static cPhs_State daKytag03_Create(fopAc_ac_c* i_ac) {
     kytag03_class* i_this = (kytag03_class*)i_ac;
 
 #if VERSION > VERSION_DEMO
-    fopAcM_SetupActor(i_ac, kytag03_class);
+    fopAcM_ct(i_ac, kytag03_class);
 #endif
 
     cPhs_State ret = dComIfG_resLoad(&i_this->mPhs, "M_DOOR");
     if (ret == cPhs_COMPLEATE_e) {
 #if VERSION == VERSION_DEMO
-        fopAcM_SetupActor(i_ac, kytag03_class);
+        fopAcM_ct(i_ac, kytag03_class);
 #endif
 
         if (!fopAcM_entrySolidHeap(&i_this->actor, useHeapInit, 0x4c30)) {

--- a/src/d/actor/d_a_kytag04.cpp
+++ b/src/d/actor/d_a_kytag04.cpp
@@ -48,7 +48,7 @@ static BOOL daKytag04_Delete(kytag04_class*) {
 
 /* 00000168-00000208       .text daKytag04_Create__FP10fopAc_ac_c */
 static cPhs_State daKytag04_Create(fopAc_ac_c* i_this)  {
-    fopAcM_SetupActor(i_this, kytag04_class);
+    fopAcM_ct(i_this, kytag04_class);
     kytag04_class* a_this = (kytag04_class*)i_this;
     a_this->mState = 0;
     a_this->mOffColPat = fopAcM_GetParam(a_this) & 0xFF;

--- a/src/d/actor/d_a_kytag05.cpp
+++ b/src/d/actor/d_a_kytag05.cpp
@@ -123,7 +123,7 @@ static BOOL daKytag05_Delete(kytag05_class*) {
 /* 00000404-000004C0       .text daKytag05_Create__FP10fopAc_ac_c */
 static cPhs_State daKytag05_Create(fopAc_ac_c* i_this) {
 #if VERSION > VERSION_DEMO
-    fopAcM_SetupActor(i_this, kytag05_class);
+    fopAcM_ct(i_this, kytag05_class);
 #endif
     kytag05_class *a_this = (kytag05_class*)i_this;
     if (dComIfGs_isSymbol(1) != 0) {
@@ -131,7 +131,7 @@ static cPhs_State daKytag05_Create(fopAc_ac_c* i_this) {
     }
 
 #if VERSION == VERSION_DEMO
-    fopAcM_SetupActor(i_this, kytag05_class);
+    fopAcM_ct(i_this, kytag05_class);
 #endif
 
     a_this->mIndex = 0;

--- a/src/d/actor/d_a_kytag05.cpp
+++ b/src/d/actor/d_a_kytag05.cpp
@@ -122,17 +122,13 @@ static BOOL daKytag05_Delete(kytag05_class*) {
 
 /* 00000404-000004C0       .text daKytag05_Create__FP10fopAc_ac_c */
 static cPhs_State daKytag05_Create(fopAc_ac_c* i_this) {
-#if VERSION > VERSION_DEMO
-    fopAcM_ct(i_this, kytag05_class);
-#endif
+    fopAcM_ct_Retail(i_this, kytag05_class);
     kytag05_class *a_this = (kytag05_class*)i_this;
     if (dComIfGs_isSymbol(1) != 0) {
         return cPhs_STOP_e;
     }
 
-#if VERSION == VERSION_DEMO
-    fopAcM_ct(i_this, kytag05_class);
-#endif
+    fopAcM_ct_Demo(i_this, kytag05_class);
 
     a_this->mIndex = 0;
     a_this->mTimer = 0;

--- a/src/d/actor/d_a_kytag06.cpp
+++ b/src/d/actor/d_a_kytag06.cpp
@@ -61,7 +61,7 @@ static BOOL daKytag06_Delete(kytag06_class*) {
 /* 000001A4-00000224       .text daKytag06_Create__FP10fopAc_ac_c */
 static cPhs_State daKytag06_Create(fopAc_ac_c* i_this) {
 #if VERSION > VERSION_DEMO
-    fopAcM_SetupActor(i_this, kytag06_class);
+    fopAcM_ct(i_this, kytag06_class);
 #endif
     kytag06_class* a_this = (kytag06_class*)i_this;
 
@@ -70,7 +70,7 @@ static cPhs_State daKytag06_Create(fopAc_ac_c* i_this) {
         phase_state = cPhs_ERROR_e;
     } else {
 #if VERSION == VERSION_DEMO
-        fopAcM_SetupActor(i_this, kytag06_class);
+        fopAcM_ct(i_this, kytag06_class);
 #endif
         a_this->field_0x294 = 0;
         phase_state = cPhs_COMPLEATE_e;

--- a/src/d/actor/d_a_kytag06.cpp
+++ b/src/d/actor/d_a_kytag06.cpp
@@ -60,18 +60,14 @@ static BOOL daKytag06_Delete(kytag06_class*) {
 
 /* 000001A4-00000224       .text daKytag06_Create__FP10fopAc_ac_c */
 static cPhs_State daKytag06_Create(fopAc_ac_c* i_this) {
-#if VERSION > VERSION_DEMO
-    fopAcM_ct(i_this, kytag06_class);
-#endif
+    fopAcM_ct_Retail(i_this, kytag06_class);
     kytag06_class* a_this = (kytag06_class*)i_this;
 
     cPhs_State phase_state;
     if(dComIfGs_isSymbol(0)) {
         phase_state = cPhs_ERROR_e;
     } else {
-#if VERSION == VERSION_DEMO
-        fopAcM_ct(i_this, kytag06_class);
-#endif
+        fopAcM_ct_Demo(i_this, kytag06_class);
         a_this->field_0x294 = 0;
         phase_state = cPhs_COMPLEATE_e;
     }

--- a/src/d/actor/d_a_kytag07.cpp
+++ b/src/d/actor/d_a_kytag07.cpp
@@ -86,16 +86,12 @@ static cPhs_State daKytag07_Create(fopAc_ac_c* i_this) {
     kytag07_class* a_this = (kytag07_class*)i_this;
     dScnKy_env_light_c& env_light = dKy_getEnvlight();
 
-#if VERSION > VERSION_DEMO
-    fopAcM_ct(i_this, kytag07_class);
-#endif
+    fopAcM_ct_Retail(i_this, kytag07_class);
 
     if (strcmp(dComIfGp_getStartStageName(), "GTower") != 0)
         env_light.mbDayNightTactStop = true;
 
-#if VERSION == VERSION_DEMO
-    fopAcM_ct(i_this, kytag07_class);
-#endif
+    fopAcM_ct_Demo(i_this, kytag07_class);
 
     return cPhs_COMPLEATE_e;
 }

--- a/src/d/actor/d_a_kytag07.cpp
+++ b/src/d/actor/d_a_kytag07.cpp
@@ -87,14 +87,14 @@ static cPhs_State daKytag07_Create(fopAc_ac_c* i_this) {
     dScnKy_env_light_c& env_light = dKy_getEnvlight();
 
 #if VERSION > VERSION_DEMO
-    fopAcM_SetupActor(i_this, kytag07_class);
+    fopAcM_ct(i_this, kytag07_class);
 #endif
 
     if (strcmp(dComIfGp_getStartStageName(), "GTower") != 0)
         env_light.mbDayNightTactStop = true;
 
 #if VERSION == VERSION_DEMO
-    fopAcM_SetupActor(i_this, kytag07_class);
+    fopAcM_ct(i_this, kytag07_class);
 #endif
 
     return cPhs_COMPLEATE_e;

--- a/src/d/actor/d_a_lamp.cpp
+++ b/src/d/actor/d_a_lamp.cpp
@@ -143,7 +143,7 @@ static BOOL daLamp_solidHeapCB(fopAc_ac_c* i_ac) {
 
 /* 0000075C-00000914       .text daLamp_Create__FP10fopAc_ac_c */
 static cPhs_State daLamp_Create(fopAc_ac_c* i_ac) {
-    fopAcM_SetupActor(i_ac, lamp_class);
+    fopAcM_ct(i_ac, lamp_class);
     lamp_class* i_this = (lamp_class*)i_ac;
 
     cPhs_State phase_state = dComIfG_resLoad(&i_this->mPhs, "Lamp");

--- a/src/d/actor/d_a_lbridge.cpp
+++ b/src/d/actor/d_a_lbridge.cpp
@@ -103,7 +103,7 @@ void daLbridge_c::CreateInit() {
 
 /* 00000544-0000063C       .text _create__11daLbridge_cFv */
 cPhs_State daLbridge_c::_create() {
-    fopAcM_SetupActor(this, daLbridge_c);
+    fopAcM_ct(this, daLbridge_c);
 
     cPhs_State ret = dComIfG_resLoad(&mPhs, m_arcname);
 

--- a/src/d/actor/d_a_leaflift.cpp
+++ b/src/d/actor/d_a_leaflift.cpp
@@ -156,7 +156,7 @@ void daLlift_c::CreateInit() {
 /* 00000634-00000760       .text _create__9daLlift_cFv */
 cPhs_State daLlift_c::_create() {
     int res;
-    fopAcM_SetupActor(this, daLlift_c);
+    fopAcM_ct(this, daLlift_c);
     res = dComIfG_resLoad(&mPhs, m_arcname);
     if (res == cPhs_COMPLEATE_e) {
         if (!fopAcM_entrySolidHeap(this, CheckCreateHeap, 0xf40)) {

--- a/src/d/actor/d_a_lod_bg.cpp
+++ b/src/d/actor/d_a_lod_bg.cpp
@@ -400,7 +400,7 @@ static BOOL daLodbg_Delete(daLodbg_c* i_this) {
 /* 000012EC-0000133C       .text daLodbg_Create__FP10fopAc_ac_c */
 static cPhs_State daLodbg_Create(fopAc_ac_c* i_ac) {
     daLodbg_c* i_this = (daLodbg_c*)i_ac;
-    fopAcM_SetupActor(i_this, daLodbg_c);
+    fopAcM_ct(i_this, daLodbg_c);
     return cPhs_COMPLEATE_e;
 }
 

--- a/src/d/actor/d_a_lwood.cpp
+++ b/src/d/actor/d_a_lwood.cpp
@@ -113,7 +113,7 @@ void daLwood_c::setMoveBGMtx() {
 }
 
 cPhs_State daLwood_c::_create() {
-    fopAcM_SetupActor(this, daLwood_c);
+    fopAcM_ct(this, daLwood_c);
 
     cPhs_State ret = dComIfG_resLoad(&mPhs, m_arcname);
 

--- a/src/d/actor/d_a_machine.cpp
+++ b/src/d/actor/d_a_machine.cpp
@@ -253,7 +253,7 @@ void daMachine_c::set_speed() {
 
 /* 000007F8-00000898       .text _create__11daMachine_cFv */
 cPhs_State daMachine_c::_create() {
-    fopAcM_SetupActor(this, daMachine_c);
+    fopAcM_ct(this, daMachine_c);
 
     cPhs_State ret = dComIfG_resLoad(&mPhs, m_arcname);
     if (ret == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_magma.cpp
+++ b/src/d/actor/d_a_magma.cpp
@@ -16,7 +16,7 @@ daMagma_c::~daMagma_c() {
 }
 
 cPhs_State daMagma_c::create() {
-    fopAcM_SetupActor(this, daMagma_c);
+    fopAcM_ct(this, daMagma_c);
 
     cPhs_State result = dComIfG_resLoad(&mPhs, "Magma");
     if (result != cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_majuu_flag.cpp
+++ b/src/d/actor/d_a_majuu_flag.cpp
@@ -902,7 +902,7 @@ static BOOL daMajuu_Flag_Delete(daMajuu_Flag_c* i_this) {
 static cPhs_State daMajuu_Flag_Create(fopAc_ac_c* a_this) {
     daMajuu_Flag_c* i_this = (daMajuu_Flag_c*)a_this;
 
-    fopAcM_SetupActor(a_this, daMajuu_Flag_c);
+    fopAcM_ct(a_this, daMajuu_Flag_c);
 
     u32 uVar3 = fopAcM_GetParam(a_this);
     u32 uVar2 = uVar3 & 0xFF;

--- a/src/d/actor/d_a_mbdoor.cpp
+++ b/src/d/actor/d_a_mbdoor.cpp
@@ -257,17 +257,13 @@ BOOL daMbdoor_c::CreateInit() {
 /* 00000A44-00000AF4       .text create__10daMbdoor_cFv */
 cPhs_State daMbdoor_c::create() {
     cPhs_State phase_state = dComIfG_resLoad(&mPhs, getArcName());
-#if VERSION > VERSION_DEMO
-    fopAcM_ct(this, daMbdoor_c);
-#endif
+    fopAcM_ct_Retail(this, daMbdoor_c);
     
     if (phase_state != cPhs_COMPLEATE_e) {
         return phase_state;
     }
 
-#if VERSION == VERSION_DEMO
-    fopAcM_ct(this, daMbdoor_c);
-#endif
+    fopAcM_ct_Demo(this, daMbdoor_c);
 
     if (!fopAcM_entrySolidHeap(this, CheckCreateHeap, 0x8200)) {
         return cPhs_ERROR_e;

--- a/src/d/actor/d_a_mbdoor.cpp
+++ b/src/d/actor/d_a_mbdoor.cpp
@@ -258,7 +258,7 @@ BOOL daMbdoor_c::CreateInit() {
 cPhs_State daMbdoor_c::create() {
     cPhs_State phase_state = dComIfG_resLoad(&mPhs, getArcName());
 #if VERSION > VERSION_DEMO
-    fopAcM_SetupActor(this, daMbdoor_c);
+    fopAcM_ct(this, daMbdoor_c);
 #endif
     
     if (phase_state != cPhs_COMPLEATE_e) {
@@ -266,7 +266,7 @@ cPhs_State daMbdoor_c::create() {
     }
 
 #if VERSION == VERSION_DEMO
-    fopAcM_SetupActor(this, daMbdoor_c);
+    fopAcM_ct(this, daMbdoor_c);
 #endif
 
     if (!fopAcM_entrySolidHeap(this, CheckCreateHeap, 0x8200)) {

--- a/src/d/actor/d_a_mdoor.cpp
+++ b/src/d/actor/d_a_mdoor.cpp
@@ -181,9 +181,9 @@ cPhs_State daMdoor_c::create() {
     if (ret != cPhs_COMPLEATE_e) {
         return ret;
     }
-    fopAcM_SetupActor(this, daMdoor_c);
+    fopAcM_ct(this, daMdoor_c);
 #else
-    fopAcM_SetupActor(this, daMdoor_c);
+    fopAcM_ct(this, daMdoor_c);
     if (ret != cPhs_COMPLEATE_e) {
         return ret;
     }

--- a/src/d/actor/d_a_mdoor.cpp
+++ b/src/d/actor/d_a_mdoor.cpp
@@ -177,17 +177,11 @@ BOOL daMdoor_c::CreateInit() {
 /* 000005E0-00000698       .text create__9daMdoor_cFv */
 cPhs_State daMdoor_c::create() {
     cPhs_State ret = dComIfG_resLoad(&mPhase, M_arcname);
-#if VERSION == VERSION_DEMO
+    fopAcM_ct_Retail(this, daMdoor_c);
     if (ret != cPhs_COMPLEATE_e) {
         return ret;
     }
-    fopAcM_ct(this, daMdoor_c);
-#else
-    fopAcM_ct(this, daMdoor_c);
-    if (ret != cPhs_COMPLEATE_e) {
-        return ret;
-    }
-#endif
+    fopAcM_ct_Demo(this, daMdoor_c);
 
     if (!fopAcM_entrySolidHeap(this, CheckCreateHeap, 0x1640)) {
         return cPhs_ERROR_e;

--- a/src/d/actor/d_a_mflft.cpp
+++ b/src/d/actor/d_a_mflft.cpp
@@ -599,7 +599,7 @@ static cPhs_State daMflft_Create(fopAc_ac_c* a_this) {
 
     mflft_class* i_this = (mflft_class*)a_this;
 
-    fopAcM_SetupActor(&i_this->actor, mflft_class);
+    fopAcM_ct(&i_this->actor, mflft_class);
 
     cPhs_State PVar2 = dComIfG_resLoad(&i_this->mPhase, "Mflft");
     if (PVar2 == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_mmusic.cpp
+++ b/src/d/actor/d_a_mmusic.cpp
@@ -58,7 +58,7 @@ void daMmusic::Act_c::set_mtx() {
 
 /* 000001A4-00000268       .text _create__Q28daMmusic5Act_cFv */
 cPhs_State daMmusic::Act_c::_create() {
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
 
     cPhs_State ret = cPhs_COMPLEATE_e;
     if (ret == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_movie_player.cpp
+++ b/src/d/actor/d_a_movie_player.cpp
@@ -3072,7 +3072,7 @@ BOOL daMP_c::daMP_c_Draw() {
 
 /* 000066C4-00006728       .text daMP_c_Callback_Init__6daMP_cFP10fopAc_ac_c */
 int daMP_c::daMP_c_Callback_Init(fopAc_ac_c* i_this) {
-    fopAcM_SetupActor(i_this, daMP_c);
+    fopAcM_ct(i_this, daMP_c);
     daMP_c* a_this = (daMP_c*)i_this;
     return a_this->daMP_c_Init();
 }

--- a/src/d/actor/d_a_mozo.cpp
+++ b/src/d/actor/d_a_mozo.cpp
@@ -241,7 +241,7 @@ cPhs_State daMozo_c::CreateInit() {
 
 /* 00002228-000023B0       .text _create__8daMozo_cFv */
 cPhs_State daMozo_c::_create() {
-    fopAcM_SetupActor(this, daMozo_c);
+    fopAcM_ct(this, daMozo_c);
 
     cPhs_State result = dComIfG_resLoad(&mPhs, "Mozo");
 

--- a/src/d/actor/d_a_msw.cpp
+++ b/src/d/actor/d_a_msw.cpp
@@ -280,7 +280,7 @@ static cPhs_State daMsw_Create(fopAc_ac_c* i_this) {
         }},
     };
 
-    fopAcM_SetupActor(i_this, msw_class);
+    fopAcM_ct(i_this, msw_class);
     msw_class* a_this = static_cast<msw_class*>(i_this);
 
     cPhs_State phase_state = dComIfG_resLoad(&a_this->mPhs, "Msw");

--- a/src/d/actor/d_a_mtoge.cpp
+++ b/src/d/actor/d_a_mtoge.cpp
@@ -99,7 +99,7 @@ BOOL daMtoge_c::CreateInit() {
 
 /* 00000384-0000041C       .text create__9daMtoge_cFv */
 cPhs_State daMtoge_c::create() {
-    fopAcM_SetupActor(this, daMtoge_c);
+    fopAcM_ct(this, daMtoge_c);
 
     cPhs_State phase_state = dComIfG_resLoad(&mPhaseProcReq, M_arcname);
     if (phase_state != cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_nh.cpp
+++ b/src/d/actor/d_a_nh.cpp
@@ -136,7 +136,7 @@ cPhs_State daNh_c::create() {
     
     cPhs_State phase_state = cPhs_COMPLEATE_e;
     
-    fopAcM_SetupActor(this, daNh_c);
+    fopAcM_ct(this, daNh_c);
     
     if (!fopAcM_entrySolidHeap(this, checkCreateHeap, a_heap_size_tbl)) {
         return cPhs_ERROR_e;

--- a/src/d/actor/d_a_npc_bmsw.cpp
+++ b/src/d/actor/d_a_npc_bmsw.cpp
@@ -1131,7 +1131,7 @@ static BOOL CallbackCreateHeap(fopAc_ac_c* i_this) {
 
 /* 00002D60-00002ECC       .text _create__12daNpc_Bmsw_cFv */
 cPhs_State daNpc_Bmsw_c::_create() {
-    fopAcM_SetupActor(this, daNpc_Bmsw_c);
+    fopAcM_ct(this, daNpc_Bmsw_c);
 
     u8 reg_val = dComIfGs_getEventReg(dSv_event_flag_c::UNK_C203);
     if (reg_val >= 3 && !dComIfGs_isEventBit(dSv_event_flag_c::UNK_2701)) {

--- a/src/d/actor/d_a_npc_bs1.cpp
+++ b/src/d/actor/d_a_npc_bs1.cpp
@@ -2160,15 +2160,11 @@ static BOOL CheckCreateHeap(fopAc_ac_c* i_this) {
 
 /* 00004980-00004AD8       .text _create__11daNpc_Bs1_cFv */
 cPhs_State daNpc_Bs1_c::_create() {
-#if VERSION > VERSION_DEMO
-    fopAcM_ct(this, daNpc_Bs1_c);
-#endif
+    fopAcM_ct_Retail(this, daNpc_Bs1_c);
     
     cPhs_State phase_state = dComIfG_resLoad(&mPhase, "Bs");
     if (phase_state == cPhs_COMPLEATE_e) {
-#if VERSION == VERSION_DEMO
-        fopAcM_ct(this, daNpc_Bs1_c);
-#endif
+        fopAcM_ct_Demo(this, daNpc_Bs1_c);
         mType = fopAcM_GetParamBit(fopAcM_GetParam(this), 0x14, 0x4);
         switch (mType) {
         case 0:

--- a/src/d/actor/d_a_npc_bs1.cpp
+++ b/src/d/actor/d_a_npc_bs1.cpp
@@ -2161,13 +2161,13 @@ static BOOL CheckCreateHeap(fopAc_ac_c* i_this) {
 /* 00004980-00004AD8       .text _create__11daNpc_Bs1_cFv */
 cPhs_State daNpc_Bs1_c::_create() {
 #if VERSION > VERSION_DEMO
-    fopAcM_SetupActor(this, daNpc_Bs1_c);
+    fopAcM_ct(this, daNpc_Bs1_c);
 #endif
     
     cPhs_State phase_state = dComIfG_resLoad(&mPhase, "Bs");
     if (phase_state == cPhs_COMPLEATE_e) {
 #if VERSION == VERSION_DEMO
-        fopAcM_SetupActor(this, daNpc_Bs1_c);
+        fopAcM_ct(this, daNpc_Bs1_c);
 #endif
         mType = fopAcM_GetParamBit(fopAcM_GetParam(this), 0x14, 0x4);
         switch (mType) {

--- a/src/d/actor/d_a_npc_btsw.cpp
+++ b/src/d/actor/d_a_npc_btsw.cpp
@@ -976,7 +976,7 @@ static BOOL CallbackCreateHeap(fopAc_ac_c* i_this) {
 
 /* 00002BB0-00002CAC       .text _create__12daNpc_Btsw_cFv */
 cPhs_State daNpc_Btsw_c::_create() {
-    fopAcM_SetupActor(this, daNpc_Btsw_c);
+    fopAcM_ct(this, daNpc_Btsw_c);
 
     cPhs_State res = dComIfG_resLoad(&mPhs, "Btsw");
     if (res == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_npc_btsw2.cpp
+++ b/src/d/actor/d_a_npc_btsw2.cpp
@@ -542,7 +542,7 @@ BOOL daNpc_Btsw2_c::wait_action(void*) {
 
 /* 00001660-00001884       .text _create__13daNpc_Btsw2_cFv */
 cPhs_State daNpc_Btsw2_c::_create() {
-    fopAcM_SetupActor(this, daNpc_Btsw2_c);
+    fopAcM_ct(this, daNpc_Btsw2_c);
     
     if (dComIfGs_getEventReg(dSv_event_flag_c::UNK_C203) == 3 || !checkItemGet(dItem_PEARL_DIN_e, TRUE)) {
         return cPhs_ERROR_e;

--- a/src/d/actor/d_a_npc_cb1.cpp
+++ b/src/d/actor/d_a_npc_cb1.cpp
@@ -192,7 +192,7 @@ static BOOL CheckCreateHeap(fopAc_ac_c* i_this) {
 
 /* 000004F8-00000814       .text create__11daNpc_Cb1_cFv */
 cPhs_State daNpc_Cb1_c::create() {
-    fopAcM_SetupActor(this, daNpc_Cb1_c);
+    fopAcM_ct(this, daNpc_Cb1_c);
 
     if(!isTypeBossDie()) {
 #if VERSION == VERSION_DEMO

--- a/src/d/actor/d_a_npc_fa1.cpp
+++ b/src/d/actor/d_a_npc_fa1.cpp
@@ -930,7 +930,7 @@ cPhs_State daNpc_Fa1_c::_create() {
     static u32 a_heap_size_tbl = 0x1100;
     cPhs_State phase_state = cPhs_COMPLEATE_e;
 
-    fopAcM_SetupActor(this, daNpc_Fa1_c);
+    fopAcM_ct(this, daNpc_Fa1_c);
     if (fopAcM_entrySolidHeap(this, CheckCreateHeap, a_heap_size_tbl)) {
         fopAcM_SetMtx(this, mpMorf->getModel()->getBaseTRMtx());
     } else {

--- a/src/d/actor/d_a_npc_hi1.cpp
+++ b/src/d/actor/d_a_npc_hi1.cpp
@@ -893,7 +893,7 @@ cPhs_State daNpc_Hi1_c::_create() {
     };
 
     cPhs_State state;
-    fopAcM_SetupActor(this, daNpc_Hi1_c);
+    fopAcM_ct(this, daNpc_Hi1_c);
     if(!decideType(fopAcM_GetParam(this) & 0xFF)) {
         return cPhs_ERROR_e;
     }

--- a/src/d/actor/d_a_npc_hr.cpp
+++ b/src/d/actor/d_a_npc_hr.cpp
@@ -2081,14 +2081,10 @@ static BOOL CheckCreateHeap(fopAc_ac_c* i_this) {
 /* 000051A8-000052C4       .text _create__10daNpc_Hr_cFv */
 cPhs_State daNpc_Hr_c::_create() {
 
-#if VERSION > VERSION_DEMO
-    fopAcM_ct(this, daNpc_Hr_c);
-#endif
+    fopAcM_ct_Retail(this, daNpc_Hr_c);
     cPhs_State state = dComIfG_resLoad(&mPhs, "Hr");
     if (state == cPhs_COMPLEATE_e) {
-#if VERSION == VERSION_DEMO
-    fopAcM_ct(this, daNpc_Hr_c);
-#endif
+    fopAcM_ct_Demo(this, daNpc_Hr_c);
         switch(fopAcM_GetName(this)) {
             case PROC_NPC_HR:
                 switch (getShapeType()) {

--- a/src/d/actor/d_a_npc_hr.cpp
+++ b/src/d/actor/d_a_npc_hr.cpp
@@ -2082,12 +2082,12 @@ static BOOL CheckCreateHeap(fopAc_ac_c* i_this) {
 cPhs_State daNpc_Hr_c::_create() {
 
 #if VERSION > VERSION_DEMO
-    fopAcM_SetupActor(this, daNpc_Hr_c);
+    fopAcM_ct(this, daNpc_Hr_c);
 #endif
     cPhs_State state = dComIfG_resLoad(&mPhs, "Hr");
     if (state == cPhs_COMPLEATE_e) {
 #if VERSION == VERSION_DEMO
-    fopAcM_SetupActor(this, daNpc_Hr_c);
+    fopAcM_ct(this, daNpc_Hr_c);
 #endif
         switch(fopAcM_GetName(this)) {
             case PROC_NPC_HR:

--- a/src/d/actor/d_a_npc_ji1.cpp
+++ b/src/d/actor/d_a_npc_ji1.cpp
@@ -4537,7 +4537,7 @@ static BOOL CheckCreateHeap(fopAc_ac_c* i_this) {
 
 /* 0000DED0-0000DF78       .text _create__11daNpc_Ji1_cFv */
 cPhs_State daNpc_Ji1_c::_create() {
-    fopAcM_SetupActor(this, daNpc_Ji1_c);
+    fopAcM_ct(this, daNpc_Ji1_c);
 
     cPhs_State state = dComIfG_resLoad(&mPhs, "Ji");
     if(state == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_npc_kamome.cpp
+++ b/src/d/actor/d_a_npc_kamome.cpp
@@ -312,9 +312,7 @@ static BOOL checkCreateHeap(fopAc_ac_c* i_this) {
 
 /* 00000ED8-0000101C       .text create__11daNpc_kam_cFv */
 cPhs_State daNpc_kam_c::create() {
-#if VERSION > VERSION_DEMO
-    fopAcM_ct(this, daNpc_kam_c);
-#endif
+    fopAcM_ct_Retail(this, daNpc_kam_c);
     
     if (l_act != NULL && l_act != this) {
         return cPhs_ERROR_e;
@@ -326,9 +324,7 @@ cPhs_State daNpc_kam_c::create() {
     cPhs_State phase_state = dComIfG_resLoad(&mPhs, "Kamome");
     
     if (phase_state == cPhs_COMPLEATE_e) {
-#if VERSION == VERSION_DEMO
-        fopAcM_ct(this, daNpc_kam_c);
-#endif
+        fopAcM_ct_Demo(this, daNpc_kam_c);
 
         if (!fopAcM_entrySolidHeap(this, checkCreateHeap, l_heap_size)) {
 #if VERSION > VERSION_DEMO

--- a/src/d/actor/d_a_npc_kamome.cpp
+++ b/src/d/actor/d_a_npc_kamome.cpp
@@ -313,7 +313,7 @@ static BOOL checkCreateHeap(fopAc_ac_c* i_this) {
 /* 00000ED8-0000101C       .text create__11daNpc_kam_cFv */
 cPhs_State daNpc_kam_c::create() {
 #if VERSION > VERSION_DEMO
-    fopAcM_SetupActor(this, daNpc_kam_c);
+    fopAcM_ct(this, daNpc_kam_c);
 #endif
     
     if (l_act != NULL && l_act != this) {
@@ -327,7 +327,7 @@ cPhs_State daNpc_kam_c::create() {
     
     if (phase_state == cPhs_COMPLEATE_e) {
 #if VERSION == VERSION_DEMO
-        fopAcM_SetupActor(this, daNpc_kam_c);
+        fopAcM_ct(this, daNpc_kam_c);
 #endif
 
         if (!fopAcM_entrySolidHeap(this, checkCreateHeap, l_heap_size)) {

--- a/src/d/actor/d_a_npc_km1.cpp
+++ b/src/d/actor/d_a_npc_km1.cpp
@@ -709,9 +709,7 @@ cPhs_State daNpc_Km1_c::_create() {
         0x272E0
     };
 
-#if VERSION > VERSION_DEMO
-    fopAcM_ct(this, daNpc_Km1_c);
-#endif
+    fopAcM_ct_Retail(this, daNpc_Km1_c);
 
     if (!decideType(fopAcM_GetParam(this) & 0xFF )) {
         return cPhs_ERROR_e;
@@ -728,9 +726,7 @@ cPhs_State daNpc_Km1_c::_create() {
     }
     l_HIO.field_0x8 += 1;
 
-#if VERSION == VERSION_DEMO
-    fopAcM_ct(this, daNpc_Km1_c);
-#endif
+    fopAcM_ct_Demo(this, daNpc_Km1_c);
 
     if(fopAcM_entrySolidHeap(this,CheckCreateHeap,a_heap_size_tbl[field_0x7D3])){
         fopAcM_SetMtx(this,mpMorf->getModel()->getBaseTRMtx());

--- a/src/d/actor/d_a_npc_km1.cpp
+++ b/src/d/actor/d_a_npc_km1.cpp
@@ -710,7 +710,7 @@ cPhs_State daNpc_Km1_c::_create() {
     };
 
 #if VERSION > VERSION_DEMO
-    fopAcM_SetupActor(this, daNpc_Km1_c);
+    fopAcM_ct(this, daNpc_Km1_c);
 #endif
 
     if (!decideType(fopAcM_GetParam(this) & 0xFF )) {
@@ -729,7 +729,7 @@ cPhs_State daNpc_Km1_c::_create() {
     l_HIO.field_0x8 += 1;
 
 #if VERSION == VERSION_DEMO
-    fopAcM_SetupActor(this, daNpc_Km1_c);
+    fopAcM_ct(this, daNpc_Km1_c);
 #endif
 
     if(fopAcM_entrySolidHeap(this,CheckCreateHeap,a_heap_size_tbl[field_0x7D3])){

--- a/src/d/actor/d_a_npc_ls1.cpp
+++ b/src/d/actor/d_a_npc_ls1.cpp
@@ -2210,9 +2210,7 @@ cPhs_State daNpc_Ls1_c::_create() {
 
     cPhs_State state;
 
-#if VERSION > VERSION_DEMO
-    fopAcM_ct(this, daNpc_Ls1_c);
-#endif 
+    fopAcM_ct_Retail(this, daNpc_Ls1_c); 
 
     if (!decideType(fopAcM_GetParam(this) & 0xFF)) {
         return cPhs_ERROR_e;

--- a/src/d/actor/d_a_npc_ls1.cpp
+++ b/src/d/actor/d_a_npc_ls1.cpp
@@ -2211,7 +2211,7 @@ cPhs_State daNpc_Ls1_c::_create() {
     cPhs_State state;
 
 #if VERSION > VERSION_DEMO
-    fopAcM_SetupActor(this, daNpc_Ls1_c);
+    fopAcM_ct(this, daNpc_Ls1_c);
 #endif 
 
     if (!decideType(fopAcM_GetParam(this) & 0xFF)) {
@@ -2226,7 +2226,7 @@ cPhs_State daNpc_Ls1_c::_create() {
 
 #if VERSION == VERSION_DEMO
     l_HIO.entryHIO("アリル"); // Aryll
-    fopAcM_SetupActor(this, daNpc_Ls1_c);
+    fopAcM_ct(this, daNpc_Ls1_c);
 #endif
 
     if (!fopAcM_entrySolidHeap(this, CheckCreateHeap, a_siz_tbl[m854])) {

--- a/src/d/actor/d_a_npc_md.cpp
+++ b/src/d/actor/d_a_npc_md.cpp
@@ -375,7 +375,7 @@ cPhs_State daNpc_Md_c::create() {
     int heapSizeIdx = 0;
     
 #if VERSION > VERSION_DEMO
-    fopAcM_SetupActor(this, daNpc_Md_c);
+    fopAcM_ct(this, daNpc_Md_c);
 #endif
     
     mType = fopAcM_GetParam(this) >> 0x08;
@@ -431,7 +431,7 @@ cPhs_State daNpc_Md_c::create() {
     m313D = 1;
     if (phase_state == cPhs_COMPLEATE_e) {
 #if VERSION == VERSION_DEMO
-        fopAcM_SetupActor(this, daNpc_Md_c);
+        fopAcM_ct(this, daNpc_Md_c);
 #endif
         
         if (dComIfGp_getCb1Player() != NULL) {

--- a/src/d/actor/d_a_npc_md.cpp
+++ b/src/d/actor/d_a_npc_md.cpp
@@ -374,9 +374,7 @@ cPhs_State daNpc_Md_c::create() {
     strcpy(mModelArcName, l_arc_name);
     int heapSizeIdx = 0;
     
-#if VERSION > VERSION_DEMO
-    fopAcM_ct(this, daNpc_Md_c);
-#endif
+    fopAcM_ct_Retail(this, daNpc_Md_c);
     
     mType = fopAcM_GetParam(this) >> 0x08;
     if ((int)mType == -2) { // Bug: Comparing unsigned value with -2 is always false.
@@ -430,9 +428,7 @@ cPhs_State daNpc_Md_c::create() {
     cPhs_State phase_state = dComIfG_resLoad(&mPhase, mModelArcName);
     m313D = 1;
     if (phase_state == cPhs_COMPLEATE_e) {
-#if VERSION == VERSION_DEMO
-        fopAcM_ct(this, daNpc_Md_c);
-#endif
+        fopAcM_ct_Demo(this, daNpc_Md_c);
         
         if (dComIfGp_getCb1Player() != NULL) {
             return cPhs_ERROR_e;

--- a/src/d/actor/d_a_npc_nz.cpp
+++ b/src/d/actor/d_a_npc_nz.cpp
@@ -928,7 +928,7 @@ void daNpc_Nz_c::getArg() {
 
 /* 00002830-000028FC       .text _create__10daNpc_Nz_cFv */
 cPhs_State daNpc_Nz_c::_create() {
-    fopAcM_SetupActor(this, daNpc_Nz_c);
+    fopAcM_ct(this, daNpc_Nz_c);
 
     getArg();
 

--- a/src/d/actor/d_a_npc_os.cpp
+++ b/src/d/actor/d_a_npc_os.cpp
@@ -204,7 +204,7 @@ static BOOL CheckCreateHeap(fopAc_ac_c* i_this) {
 
 /* 00000374-00000538       .text create__10daNpc_Os_cFv */
 cPhs_State daNpc_Os_c::create() {
-    fopAcM_SetupActor(this, daNpc_Os_c)
+    fopAcM_ct(this, daNpc_Os_c)
 
     static u32 l_heap_size = 0xFA0;
 

--- a/src/d/actor/d_a_npc_people.cpp
+++ b/src/d/actor/d_a_npc_people.cpp
@@ -4232,7 +4232,7 @@ static BOOL CheckCreateHeap(fopAc_ac_c* i_this) {
 
 /* 0000075C-000008E0       .text phase_1__FP13daNpcPeople_c */
 static cPhs_State phase_1(daNpcPeople_c* i_this) {
-    fopAcM_SetupActor(i_this, daNpcPeople_c);
+    fopAcM_ct(i_this, daNpcPeople_c);
 
     s16 arg0 = i_this->getPrmArg0();
     switch(i_this->getNpcNo()) {

--- a/src/d/actor/d_a_npc_photo.cpp
+++ b/src/d/actor/d_a_npc_photo.cpp
@@ -615,7 +615,7 @@ static BOOL CheckCreateHeap(fopAc_ac_c* i_this) {
 
 /* 00000878-0000095C       .text phase_1__FP12daNpcPhoto_c */
 static cPhs_State phase_1(daNpcPhoto_c* i_this) {
-    fopAcM_SetupActor(i_this, daNpcPhoto_c);
+    fopAcM_ct(i_this, daNpcPhoto_c);
     s16 arg0 = i_this->getPrmArg0();
     if(arg0 != 255){
         if(arg0 == 0){

--- a/src/d/actor/d_a_npc_roten.cpp
+++ b/src/d/actor/d_a_npc_roten.cpp
@@ -1611,7 +1611,7 @@ static BOOL CheckCreateHeap(fopAc_ac_c* i_this) {
 
 /* 000008EC-00000974       .text phase_1__FP12daNpcRoten_c */
 static cPhs_State phase_1(daNpcRoten_c* i_this) {
-    fopAcM_SetupActor(i_this, daNpcRoten_c);
+    fopAcM_ct(i_this, daNpcRoten_c);
 
     i_this->setNpcNo(i_this->getPrmNpcNo());
 

--- a/src/d/actor/d_a_npc_rsh1.cpp
+++ b/src/d/actor/d_a_npc_rsh1.cpp
@@ -1796,17 +1796,13 @@ static BOOL CheckCreateHeap(fopAc_ac_c* i_this) {
 
 /* 00004328-00004464       .text _create__12daNpc_Rsh1_cFv */
 cPhs_State daNpc_Rsh1_c::_create() {
-#if VERSION > VERSION_DEMO
-    fopAcM_ct(this, daNpc_Rsh1_c);
-#endif
+    fopAcM_ct_Retail(this, daNpc_Rsh1_c);
 
     cPhs_State state = dComIfG_resLoad(&mPhs, m_arcname);
 
 
     if (state == cPhs_COMPLEATE_e) {
-#if VERSION == VERSION_DEMO
-        fopAcM_ct(this, daNpc_Rsh1_c);
-#endif
+        fopAcM_ct_Demo(this, daNpc_Rsh1_c);
         m95E = (fopAcM_GetParam(this) >> 0x14) & 0xF;
 
         switch (m95E) {

--- a/src/d/actor/d_a_npc_rsh1.cpp
+++ b/src/d/actor/d_a_npc_rsh1.cpp
@@ -1797,7 +1797,7 @@ static BOOL CheckCreateHeap(fopAc_ac_c* i_this) {
 /* 00004328-00004464       .text _create__12daNpc_Rsh1_cFv */
 cPhs_State daNpc_Rsh1_c::_create() {
 #if VERSION > VERSION_DEMO
-    fopAcM_SetupActor(this, daNpc_Rsh1_c);
+    fopAcM_ct(this, daNpc_Rsh1_c);
 #endif
 
     cPhs_State state = dComIfG_resLoad(&mPhs, m_arcname);
@@ -1805,7 +1805,7 @@ cPhs_State daNpc_Rsh1_c::_create() {
 
     if (state == cPhs_COMPLEATE_e) {
 #if VERSION == VERSION_DEMO
-        fopAcM_SetupActor(this, daNpc_Rsh1_c);
+        fopAcM_ct(this, daNpc_Rsh1_c);
 #endif
         m95E = (fopAcM_GetParam(this) >> 0x14) & 0xF;
 

--- a/src/d/actor/d_a_npc_tc.cpp
+++ b/src/d/actor/d_a_npc_tc.cpp
@@ -1853,15 +1853,10 @@ bool daNpc_Tc_c::isCreate() {
 
 /* 00003FC0-00004090       .text _create__10daNpc_Tc_cFv */
 cPhs_State daNpc_Tc_c::_create() {
-#if VERSION == VERSION_DEMO
+    fopAcM_ct_Retail(this, daNpc_Tc_c);
     cPhs_State phase_state = dComIfG_resLoad(&mPhs, "Tc");
     if(phase_state == cPhs_COMPLEATE_e) {
-        fopAcM_ct(this, daNpc_Tc_c);
-#else
-    fopAcM_ct(this, daNpc_Tc_c);
-    cPhs_State phase_state = dComIfG_resLoad(&mPhs, "Tc");
-    if(phase_state == cPhs_COMPLEATE_e) {
-#endif
+        fopAcM_ct_Demo(this, daNpc_Tc_c);
         getArg();
 
         if(!isCreate()) {

--- a/src/d/actor/d_a_npc_tc.cpp
+++ b/src/d/actor/d_a_npc_tc.cpp
@@ -1856,9 +1856,9 @@ cPhs_State daNpc_Tc_c::_create() {
 #if VERSION == VERSION_DEMO
     cPhs_State phase_state = dComIfG_resLoad(&mPhs, "Tc");
     if(phase_state == cPhs_COMPLEATE_e) {
-        fopAcM_SetupActor(this, daNpc_Tc_c);
+        fopAcM_ct(this, daNpc_Tc_c);
 #else
-    fopAcM_SetupActor(this, daNpc_Tc_c);
+    fopAcM_ct(this, daNpc_Tc_c);
     cPhs_State phase_state = dComIfG_resLoad(&mPhs, "Tc");
     if(phase_state == cPhs_COMPLEATE_e) {
 #endif

--- a/src/d/actor/d_a_npc_zl1.cpp
+++ b/src/d/actor/d_a_npc_zl1.cpp
@@ -2882,9 +2882,7 @@ cPhs_State daNpc_Zl1_c::_create() {
     };
 
     cPhs_State state;
-#if VERSION > VERSION_DEMO
-    fopAcM_ct(this, daNpc_Zl1_c);
-#endif
+    fopAcM_ct_Retail(this, daNpc_Zl1_c);
     if(!decideType(fopAcM_GetParam(this) & 0xFF)) { // idk if this is supposed to be here
         return cPhs_ERROR_e;
     }

--- a/src/d/actor/d_a_npc_zl1.cpp
+++ b/src/d/actor/d_a_npc_zl1.cpp
@@ -2883,7 +2883,7 @@ cPhs_State daNpc_Zl1_c::_create() {
 
     cPhs_State state;
 #if VERSION > VERSION_DEMO
-    fopAcM_SetupActor(this, daNpc_Zl1_c);
+    fopAcM_ct(this, daNpc_Zl1_c);
 #endif
     if(!decideType(fopAcM_GetParam(this) & 0xFF)) { // idk if this is supposed to be here
         return cPhs_ERROR_e;
@@ -2896,7 +2896,7 @@ cPhs_State daNpc_Zl1_c::_create() {
     } 
 #if VERSION == VERSION_DEMO
     l_HIO.entryHIO("海賊ゼルダ");
-    fopAcM_SetupActor(this, daNpc_Zl1_c);
+    fopAcM_ct(this, daNpc_Zl1_c);
 #endif
 
     if(!fopAcM_entrySolidHeap(this, CheckCreateHeap, a_siz_tbl[field_0x84E])) {

--- a/src/d/actor/d_a_nzg.cpp
+++ b/src/d/actor/d_a_nzg.cpp
@@ -161,14 +161,10 @@ static BOOL useHeapInit(fopAc_ac_c* i_this) {
 /* 00000620-00000864       .text daNZG_Create__FP10fopAc_ac_c */
 static cPhs_State daNZG_Create(fopAc_ac_c* i_this) {
     nzg_class* nzg_this = (nzg_class*)i_this;
-#if VERSION > VERSION_DEMO
-    fopAcM_ct(i_this, nzg_class);
-#endif
+    fopAcM_ct_Retail(i_this, nzg_class);
     cPhs_State phase_state = dComIfG_resLoad(&nzg_this->mPhs, "NZG");
     if (phase_state == cPhs_COMPLEATE_e) {
-#if VERSION == VERSION_DEMO
-        fopAcM_ct(i_this, nzg_class);
-#endif
+        fopAcM_ct_Demo(i_this, nzg_class);
         if (!fopAcM_entrySolidHeap(&nzg_this->actor, useHeapInit, 0x680)) {
             return cPhs_ERROR_e;
         }

--- a/src/d/actor/d_a_nzg.cpp
+++ b/src/d/actor/d_a_nzg.cpp
@@ -162,12 +162,12 @@ static BOOL useHeapInit(fopAc_ac_c* i_this) {
 static cPhs_State daNZG_Create(fopAc_ac_c* i_this) {
     nzg_class* nzg_this = (nzg_class*)i_this;
 #if VERSION > VERSION_DEMO
-    fopAcM_SetupActor(i_this, nzg_class);
+    fopAcM_ct(i_this, nzg_class);
 #endif
     cPhs_State phase_state = dComIfG_resLoad(&nzg_this->mPhs, "NZG");
     if (phase_state == cPhs_COMPLEATE_e) {
 #if VERSION == VERSION_DEMO
-        fopAcM_SetupActor(i_this, nzg_class);
+        fopAcM_ct(i_this, nzg_class);
 #endif
         if (!fopAcM_entrySolidHeap(&nzg_this->actor, useHeapInit, 0x680)) {
             return cPhs_ERROR_e;

--- a/src/d/actor/d_a_obj_AjavW.cpp
+++ b/src/d/actor/d_a_obj_AjavW.cpp
@@ -48,7 +48,7 @@ bool daObjAjavW_c::create_heap() {
 
 /* 00000208-00000350       .text _create__12daObjAjavW_cFv */
 cPhs_State daObjAjavW_c::_create() {
-    fopAcM_SetupActor(this, daObjAjavW_c);
+    fopAcM_ct(this, daObjAjavW_c);
 
     cPhs_State ret = dComIfG_resLoad(&mPhs, l_arcname);
 

--- a/src/d/actor/d_a_obj_Vteng.cpp
+++ b/src/d/actor/d_a_obj_Vteng.cpp
@@ -84,7 +84,7 @@ bool daObjVteng_c::jokai_demo() {
 
 /* 00000324-000003F4       .text _create__12daObjVteng_cFv */
 cPhs_State daObjVteng_c::_create() {
-    fopAcM_SetupActor(this, daObjVteng_c);
+    fopAcM_ct(this, daObjVteng_c);
 
     cPhs_State ret = dComIfG_resLoad(&mPhs, l_arcname);
 

--- a/src/d/actor/d_a_obj_Yboil.cpp
+++ b/src/d/actor/d_a_obj_Yboil.cpp
@@ -85,7 +85,7 @@ void daObjYboil_c::set_mtx() {
 }
 
 cPhs_State daObjYboil_c::_create() {
-    fopAcM_SetupActor(this, daObjYboil_c);
+    fopAcM_ct(this, daObjYboil_c);
 
     cPhs_State ret;
     if (dComIfGs_isEventBit(dSv_event_flag_c::UNK_1902)) {

--- a/src/d/actor/d_a_obj_Ygush00.cpp
+++ b/src/d/actor/d_a_obj_Ygush00.cpp
@@ -65,7 +65,7 @@ bool daObjYgush00_c::create_heap() {
 
 /* 00000250-000003F4       .text _create__14daObjYgush00_cFv */
 cPhs_State daObjYgush00_c::_create() {
-    fopAcM_SetupActor(this, daObjYgush00_c);
+    fopAcM_ct(this, daObjYgush00_c);
 
     if (fopAcM_IsFirstCreating(this)) {
         u32 type = param_get_arg();

--- a/src/d/actor/d_a_obj_adnno.cpp
+++ b/src/d/actor/d_a_obj_adnno.cpp
@@ -79,7 +79,7 @@ void daObjAdnno_c::set_mtx() {
 }
 
 cPhs_State daObjAdnno_c::_create() {
-    fopAcM_SetupActor(this, daObjAdnno_c);
+    fopAcM_ct(this, daObjAdnno_c);
 
     cPhs_State ret = dComIfG_resLoad(&mPhs, "Adnno");
 

--- a/src/d/actor/d_a_obj_ajav.cpp
+++ b/src/d/actor/d_a_obj_ajav.cpp
@@ -460,7 +460,7 @@ BOOL daObjAjav::Act_c::create_heap() {
 cPhs_State daObjAjav::Act_c::_create() {
     cPhs_State rt = cPhs_ERROR_e;
 
-    fopAcM_SetupActor(this, daObjAjav::Act_c);
+    fopAcM_ct(this, daObjAjav::Act_c);
 
     mSwNo = fopAcM_GetParam(this) & 0xFF;
     mbResLoaded = false;

--- a/src/d/actor/d_a_obj_akabe.cpp
+++ b/src/d/actor/d_a_obj_akabe.cpp
@@ -64,7 +64,7 @@ namespace daObjAkabe {
         else
             mType = 0;
 
-        fopAcM_SetupActor(this, daObjAkabe::Act_c);
+        fopAcM_ct(this, daObjAkabe::Act_c);
 
         mbAppear = chk_appear();
         if (mbAppear) {

--- a/src/d/actor/d_a_obj_apzl.cpp
+++ b/src/d/actor/d_a_obj_apzl.cpp
@@ -937,7 +937,7 @@ void daObjApzl_c::set_mtx() {
 }
 
 cPhs_State daObjApzl_c::_create(){
-    fopAcM_SetupActor(this, daObjApzl_c);
+    fopAcM_ct(this, daObjApzl_c);
     cPhs_State phase_state = dComIfG_resLoad(&mPhs, "Apzl");
     if (phase_state == cPhs_COMPLEATE_e) {
         if (!fopAcM_entrySolidHeap(this, CheckCreateHeap, 0x1460)) {

--- a/src/d/actor/d_a_obj_auzu.cpp
+++ b/src/d/actor/d_a_obj_auzu.cpp
@@ -66,7 +66,7 @@ bool daObjAuzu::Act_c::create_heap() {
 cPhs_State daObjAuzu::Act_c::_create() {
     cPhs_State state = cPhs_ERROR_e;
     mType = prm_get_type();
-    fopAcM_SetupActor(this, daObjAuzu::Act_c);
+    fopAcM_ct(this, daObjAuzu::Act_c);
 
     mbIsExist = is_exist();
     if (mbIsExist != 0) {

--- a/src/d/actor/d_a_obj_barrel.cpp
+++ b/src/d/actor/d_a_obj_barrel.cpp
@@ -108,7 +108,7 @@ bool daObjBarrel::Act_c::create_heap() {
 
 /* 00000160-00000474       .text _create__Q211daObjBarrel5Act_cFv */
 cPhs_State daObjBarrel::Act_c::_create() {
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
     cPhs_State rt = dComIfG_resLoad(&mPhs, M_arcname);
     if (rt == cPhs_COMPLEATE_e) {
         if(fopAcM_entrySolidHeap(this, solidHeapCB, 0x820) != 0) {

--- a/src/d/actor/d_a_obj_barrel2.cpp
+++ b/src/d/actor/d_a_obj_barrel2.cpp
@@ -213,7 +213,7 @@ bool daObjBarrel2::Act_c::create_heap() {
 
 /* 00000308-0000089C       .text _create__Q212daObjBarrel25Act_cFv */
 cPhs_State daObjBarrel2::Act_c::_create() {
-    fopAcM_SetupActor(this, daObjBarrel2::Act_c);
+    fopAcM_ct(this, daObjBarrel2::Act_c);
 
     m410 = prm_get_type();
 

--- a/src/d/actor/d_a_obj_barrier.cpp
+++ b/src/d/actor/d_a_obj_barrier.cpp
@@ -497,7 +497,7 @@ void daObjBarrier_ef_c::draw() {
 /* 00001638-0000182C       .text _create__14daObjBarrier_cFv */
 cPhs_State daObjBarrier_c::_create() {
     cPhs_State phase = cPhs_ERROR_e;
-    fopAcM_SetupActor(this, daObjBarrier_c);
+    fopAcM_ct(this, daObjBarrier_c);
 
     if (fopAcM_IsFirstCreating(this)) {
         mMoya = param_get_moya();

--- a/src/d/actor/d_a_obj_bemos.cpp
+++ b/src/d/actor/d_a_obj_bemos.cpp
@@ -474,19 +474,12 @@ cPhs_State daBemos_c::CreateInit() {
 
 /* 00003F90-0000403C       .text _create__9daBemos_cFv */
 cPhs_State daBemos_c::_create() {
-#if VERSION == VERSION_DEMO
+    fopAcM_ct_Retail(this, daBemos_c);
     cPhs_State ret = dComIfG_resLoad(&mPhase, m_arcname);
     m6B8 = fopAcM_GetParam(this) >> 0x1C;
-#else
-    fopAcM_ct(this, daBemos_c);
-    cPhs_State ret = dComIfG_resLoad(&mPhase, m_arcname);
-    m6B8 = fopAcM_GetParam(this) >> 0x1C;
-#endif
 
     if (ret == cPhs_COMPLEATE_e) {
-#if VERSION == VERSION_DEMO
-        fopAcM_ct(this, daBemos_c);
-#endif
+        fopAcM_ct_Demo(this, daBemos_c);
 
         static s32 SHeapSize[] = {0x1740, 0x1E00, 0xBA0};
         if (fopAcM_entrySolidHeap(this, CheckCreateHeap, SHeapSize[m6B8])) {

--- a/src/d/actor/d_a_obj_bemos.cpp
+++ b/src/d/actor/d_a_obj_bemos.cpp
@@ -478,14 +478,14 @@ cPhs_State daBemos_c::_create() {
     cPhs_State ret = dComIfG_resLoad(&mPhase, m_arcname);
     m6B8 = fopAcM_GetParam(this) >> 0x1C;
 #else
-    fopAcM_SetupActor(this, daBemos_c);
+    fopAcM_ct(this, daBemos_c);
     cPhs_State ret = dComIfG_resLoad(&mPhase, m_arcname);
     m6B8 = fopAcM_GetParam(this) >> 0x1C;
 #endif
 
     if (ret == cPhs_COMPLEATE_e) {
 #if VERSION == VERSION_DEMO
-        fopAcM_SetupActor(this, daBemos_c);
+        fopAcM_ct(this, daBemos_c);
 #endif
 
         static s32 SHeapSize[] = {0x1740, 0x1E00, 0xBA0};

--- a/src/d/actor/d_a_obj_bscurtain.cpp
+++ b/src/d/actor/d_a_obj_bscurtain.cpp
@@ -61,7 +61,7 @@ cPhs_State daObj_Bscurtain_c::CreateInit() {
 }
 
 cPhs_State daObj_Bscurtain_c::_create() {
-    fopAcM_SetupActor(this, daObj_Bscurtain_c);
+    fopAcM_ct(this, daObj_Bscurtain_c);
 
     cPhs_State ret = dComIfG_resLoad(&mPhs, M_arcname);
 

--- a/src/d/actor/d_a_obj_buoyrace.cpp
+++ b/src/d/actor/d_a_obj_buoyrace.cpp
@@ -69,7 +69,7 @@ cPhs_State daObjBuoyrace::Act_c::create_load() {
 
 /* 00000238-00000374       .text _create__Q213daObjBuoyrace5Act_cFv */
 cPhs_State daObjBuoyrace::Act_c::_create() {
-    fopAcM_SetupActor(this, daObjBuoyrace::Act_c);
+    fopAcM_ct(this, daObjBuoyrace::Act_c);
 
 #if VERSION > VERSION_DEMO
     cPhs_State result = create_load();

--- a/src/d/actor/d_a_obj_cafelmp.cpp
+++ b/src/d/actor/d_a_obj_cafelmp.cpp
@@ -48,7 +48,7 @@ void daObjCafelmp_c::set_mtx() {
 }
 
 cPhs_State daObjCafelmp_c::_create() {
-    fopAcM_SetupActor(this, daObjCafelmp_c);
+    fopAcM_ct(this, daObjCafelmp_c);
 
     cPhs_State ret = dComIfG_resLoad(&mPhs, "Cafelmp");
 

--- a/src/d/actor/d_a_obj_canon.cpp
+++ b/src/d/actor/d_a_obj_canon.cpp
@@ -579,7 +579,7 @@ void daObj_Canon_c::getArg() {
 
 /* 00001880-000019D8       .text _create__13daObj_Canon_cFv */
 cPhs_State daObj_Canon_c::_create() {
-    fopAcM_SetupActor(this, daObj_Canon_c);
+    fopAcM_ct(this, daObj_Canon_c);
 
     int result = dComIfG_resLoad(&mPhs, m_arc_name);
     if(result == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_obj_coming.cpp
+++ b/src/d/actor/d_a_obj_coming.cpp
@@ -210,7 +210,7 @@ bool daObjComing::Act_c::chk_switch() {
 
 /* 000003B0-000004B0       .text _create__Q211daObjComing5Act_cFv */
 cPhs_State daObjComing::Act_c::_create() {
-    fopAcM_SetupActor(this, daObjComing::Act_c);
+    fopAcM_ct(this, daObjComing::Act_c);
 
     m290 = prm_get_type();
     fopAcM_offDraw(this);

--- a/src/d/actor/d_a_obj_correct.cpp
+++ b/src/d/actor/d_a_obj_correct.cpp
@@ -49,7 +49,7 @@ inline static const Attr_c& attr(daObjCorrect::Type_e type) { return L_attr[type
 cPhs_State daObjCorrect::Act_c::_create() {
     int swSave = prm_get_swSave();
 
-    fopAcM_SetupActor(this, daObjCorrect::Act_c);
+    fopAcM_ct(this, daObjCorrect::Act_c);
 
     if (swSave == 0xFF) {
         return cPhs_ERROR_e;

--- a/src/d/actor/d_a_obj_demo_barrel.cpp
+++ b/src/d/actor/d_a_obj_demo_barrel.cpp
@@ -67,9 +67,9 @@ cPhs_State daObj_Demo_Barrel_c::_create() {
 #if VERSION == VERSION_DEMO
     cPhs_State ret = dComIfG_resLoad(&mPhase, M_arcname);
     if (ret == cPhs_COMPLEATE_e) {
-        fopAcM_SetupActor(this, daObj_Demo_Barrel_c);
+        fopAcM_ct(this, daObj_Demo_Barrel_c);
 #else
-    fopAcM_SetupActor(this, daObj_Demo_Barrel_c);
+    fopAcM_ct(this, daObj_Demo_Barrel_c);
     cPhs_State ret = dComIfG_resLoad(&mPhase, M_arcname);
     if (ret == cPhs_COMPLEATE_e) {
 #endif

--- a/src/d/actor/d_a_obj_demo_barrel.cpp
+++ b/src/d/actor/d_a_obj_demo_barrel.cpp
@@ -64,15 +64,10 @@ BOOL daObj_Demo_Barrel_c::CreateHeap() {
 }
 
 cPhs_State daObj_Demo_Barrel_c::_create() {
-#if VERSION == VERSION_DEMO
+    fopAcM_ct_Retail(this, daObj_Demo_Barrel_c);
     cPhs_State ret = dComIfG_resLoad(&mPhase, M_arcname);
     if (ret == cPhs_COMPLEATE_e) {
-        fopAcM_ct(this, daObj_Demo_Barrel_c);
-#else
-    fopAcM_ct(this, daObj_Demo_Barrel_c);
-    cPhs_State ret = dComIfG_resLoad(&mPhase, M_arcname);
-    if (ret == cPhs_COMPLEATE_e) {
-#endif
+        fopAcM_ct_Demo(this, daObj_Demo_Barrel_c);
         if (!fopAcM_entrySolidHeap(this, CheckCreateHeap, 0x22E0)) {
             return cPhs_ERROR_e;
         }

--- a/src/d/actor/d_a_obj_dmgroom.cpp
+++ b/src/d/actor/d_a_obj_dmgroom.cpp
@@ -53,7 +53,7 @@ void daObjDmgroom_c::set_mtx() {
 }
 
 cPhs_State daObjDmgroom_c::_create() {
-    fopAcM_SetupActor(this, daObjDmgroom_c);
+    fopAcM_ct(this, daObjDmgroom_c);
 
     cPhs_State ret = dComIfG_resLoad(&mPhs, "Dmgroom");
 

--- a/src/d/actor/d_a_obj_doguu.cpp
+++ b/src/d/actor/d_a_obj_doguu.cpp
@@ -528,7 +528,7 @@ static cPhs_State daObjDoguu_Create(void* i_this) {
 
 /* 000016C4-0000178C       .text _create__12daObjDoguu_cFv */
 cPhs_State daObjDoguu_c::_create() {
-    fopAcM_SetupActor(this, daObjDoguu_c);
+    fopAcM_ct(this, daObjDoguu_c);
     if(argument >= 1) {
         field_0x894 = argument - 1;
     } else {

--- a/src/d/actor/d_a_obj_doguu_demo.cpp
+++ b/src/d/actor/d_a_obj_doguu_demo.cpp
@@ -64,7 +64,7 @@ void daObjDoguuD_c::set_mtx() {
 }
 
 cPhs_State daObjDoguuD_c::_create() {
-    fopAcM_SetupActor(this, daObjDoguuD_c);
+    fopAcM_ct(this, daObjDoguuD_c);
     mBgwRegistered = false;
 
     cPhs_State phase_state = dComIfG_resLoad(&mPhs, "DoguuD");

--- a/src/d/actor/d_a_obj_dragonhead.cpp
+++ b/src/d/actor/d_a_obj_dragonhead.cpp
@@ -113,7 +113,7 @@ void daObjDragonhead_c::set_mtx() {
 }
 
 cPhs_State daObjDragonhead_c::_create() {
-    fopAcM_SetupActor(this, daObjDragonhead_c);
+    fopAcM_ct(this, daObjDragonhead_c);
 
     cPhs_State ret = dComIfG_resLoad(&mPhs, "Qdghd");
 

--- a/src/d/actor/d_a_obj_eayogn.cpp
+++ b/src/d/actor/d_a_obj_eayogn.cpp
@@ -45,7 +45,7 @@ BOOL daObjEayogn_c::create_heap() {
 cPhs_State daObjEayogn_c::_create() {
     cPhs_State ret = cPhs_ERROR_e;
 
-    fopAcM_SetupActor(this, daObjEayogn_c);
+    fopAcM_ct(this, daObjEayogn_c);
 
     if (check_ev_bit()) {
         ret = dComIfG_resLoad(&mPhs, M_arcname);

--- a/src/d/actor/d_a_obj_ebomzo.cpp
+++ b/src/d/actor/d_a_obj_ebomzo.cpp
@@ -83,7 +83,7 @@ BOOL daObjEbomzo::Act_c::Create() {
 
 /* 0000021C-000003A0       .text Mthd_Create__Q211daObjEbomzo5Act_cFv */
 cPhs_State daObjEbomzo::Act_c::Mthd_Create() {
-    fopAcM_SetupActor(this, daObjEbomzo::Act_c);
+    fopAcM_ct(this, daObjEbomzo::Act_c);
     
     cPhs_State phase_state = dComIfG_resLoad(&mPhs, M_arcname);
     if (phase_state == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_obj_eff.cpp
+++ b/src/d/actor/d_a_obj_eff.cpp
@@ -284,7 +284,7 @@ cPhs_State daObjEff::Act_c::_create() {
     };
 
     mProcIndex = prm_get_type();
-    fopAcM_SetupActor(this, daObjEff::Act_c);
+    fopAcM_ct(this, daObjEff::Act_c);
     int phase = cPhs_COMPLEATE_e;
     if (fopAcM_entrySolidHeap(this, &solidHeapCB, heap_size[mProcIndex])) {
         if ((u8) eff_set() != 0) {

--- a/src/d/actor/d_a_obj_eskban.cpp
+++ b/src/d/actor/d_a_obj_eskban.cpp
@@ -148,7 +148,7 @@ BOOL daObjEskban::Act_c::Create() {
 /* 000003A4-000004D0       .text Mthd_Create__Q211daObjEskban5Act_cFv */
 cPhs_State daObjEskban::Act_c::Mthd_Create() {
     cPhs_State phase_state;
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
     M_smoke = NULL;
 
     s32 swSave = param_get_swSave();

--- a/src/d/actor/d_a_obj_ferris.cpp
+++ b/src/d/actor/d_a_obj_ferris.cpp
@@ -163,7 +163,7 @@ void daObjFerris::Act_c::ride_call_back(dBgW* bgw, fopAc_ac_c* i_ac, fopAc_ac_c*
 
 /* 000004DC-00000898       .text _create__Q211daObjFerris5Act_cFv */
 cPhs_State daObjFerris::Act_c::_create() {
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
 
     cPhs_State ret = dComIfG_resLoad(&mPhs, M_arcname);
 

--- a/src/d/actor/d_a_obj_figure.cpp
+++ b/src/d/actor/d_a_obj_figure.cpp
@@ -398,7 +398,7 @@ static BOOL CheckCreateHeap(fopAc_ac_c* i_this) {
 
 /* 000005A8-00000624       .text phase_1__FP13daObjFigure_c */
 static cPhs_State phase_1(daObjFigure_c* i_this) {
-    fopAcM_SetupActor(i_this, daObjFigure_c)
+    fopAcM_ct(i_this, daObjFigure_c)
     i_this->setResFlag(0x1);
 
     cPhs_State status = dComIfG_resLoad(i_this->getPhase1P(), "Figure");

--- a/src/d/actor/d_a_obj_ganonbed.cpp
+++ b/src/d/actor/d_a_obj_ganonbed.cpp
@@ -77,7 +77,7 @@ bool daObjGbed_c::create_heap() {
 
 /* 00000224-000002F8       .text _create__11daObjGbed_cFv */
 cPhs_State daObjGbed_c::_create() {
-    fopAcM_SetupActor(this, daObjGbed_c);
+    fopAcM_ct(this, daObjGbed_c);
 
     cPhs_State ret = dComIfG_resLoad(&mPhs, l_arcname);
 

--- a/src/d/actor/d_a_obj_gaship.cpp
+++ b/src/d/actor/d_a_obj_gaship.cpp
@@ -65,7 +65,7 @@ bool daObjGaship::Act_c::create_heap() {
 
 /* 00000448-000004F8       .text _create__Q211daObjGaship5Act_cFv */
 cPhs_State daObjGaship::Act_c::_create() {
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
 
     cPhs_State ret = dComIfG_resLoad(&mPhs, M_arcname);
     if (ret == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_obj_gaship2.cpp
+++ b/src/d/actor/d_a_obj_gaship2.cpp
@@ -53,7 +53,7 @@ bool daObjGaship2::Act_c::create_heap() {
 
 /* 00000220-000002F8       .text _create__Q212daObjGaship25Act_cFv */
 cPhs_State daObjGaship2::Act_c::_create() {
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
     cPhs_State phase_state = dComIfG_resLoad(&mphs, M_arcname);
     if (phase_state == cPhs_COMPLEATE_e) {
         if (fopAcM_entrySolidHeap(this, solidHeapCB, 0x0)) {

--- a/src/d/actor/d_a_obj_gnnbtltaki.cpp
+++ b/src/d/actor/d_a_obj_gnnbtltaki.cpp
@@ -38,7 +38,7 @@ BOOL daObjGnnbtaki_c::create_heap() {
 
 /* 000001F4-00000348       .text _create__15daObjGnnbtaki_cFv */
 cPhs_State daObjGnnbtaki_c::_create() {
-    fopAcM_SetupActor(this, daObjGnnbtaki_c);
+    fopAcM_ct(this, daObjGnnbtaki_c);
     cPhs_State state = dComIfG_resLoad(&mPhase, M_arcname);
     if (state == cPhs_COMPLEATE_e) {
         state = cPhs_ERROR_e;

--- a/src/d/actor/d_a_obj_gnndemotakie.cpp
+++ b/src/d/actor/d_a_obj_gnndemotakie.cpp
@@ -39,7 +39,7 @@ BOOL daObjGnntakie_c::create_heap() {
 
 /* 000001F4-00000300       .text _create__15daObjGnntakie_cFv */
 cPhs_State daObjGnntakie_c::_create() {
-    fopAcM_SetupActor(this, daObjGnntakie_c);
+    fopAcM_ct(this, daObjGnntakie_c);
     cPhs_State state = dComIfG_resLoad(&mPhase, M_arcname);
     if (state == cPhs_COMPLEATE_e) {
         state = cPhs_ERROR_e;

--- a/src/d/actor/d_a_obj_gnndemotakis.cpp
+++ b/src/d/actor/d_a_obj_gnndemotakis.cpp
@@ -39,7 +39,7 @@ BOOL daObjGnntakis_c::create_heap() {
 
 /* 000001F4-00000308       .text _create__15daObjGnntakis_cFv */
 cPhs_State daObjGnntakis_c::_create() {
-    fopAcM_SetupActor(this, daObjGnntakis_c);
+    fopAcM_ct(this, daObjGnntakis_c);
 
     cPhs_State state = dComIfG_resLoad(&mPhs, M_arcname);
 

--- a/src/d/actor/d_a_obj_gong.cpp
+++ b/src/d/actor/d_a_obj_gong.cpp
@@ -72,7 +72,7 @@ bool daObjGong::Act_c::create_heap() {
 
 /* 0000028C-00000374       .text _create__Q29daObjGong5Act_cFv */
 cPhs_State daObjGong::Act_c::_create() {
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
 
     cPhs_State ret = dComIfG_resLoad(&mPhs, M_arcname);
 

--- a/src/d/actor/d_a_obj_gryw00.cpp
+++ b/src/d/actor/d_a_obj_gryw00.cpp
@@ -152,7 +152,7 @@ BOOL daObjGryw00_c::Create() {
 
 /* 000007D4-0000090C       .text Mthd_Create__13daObjGryw00_cFv */
 cPhs_State daObjGryw00_c::Mthd_Create() {
-    fopAcM_SetupActor(this, daObjGryw00_c);
+    fopAcM_ct(this, daObjGryw00_c);
 
     cPhs_State phase_state = dComIfG_resLoad(&mPhs, l_arcname);
     if (phase_state == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_obj_gtaki.cpp
+++ b/src/d/actor/d_a_obj_gtaki.cpp
@@ -138,7 +138,7 @@ static cPhs_State daObjGtaki_Create(void* i_this) {
 
 /* 000006A4-0000087C       .text _create__12daObjGtaki_cFv */
 cPhs_State daObjGtaki_c::_create() {
-    fopAcM_SetupActor(this, daObjGtaki_c);
+    fopAcM_ct(this, daObjGtaki_c);
     cPhs_State state = dComIfG_resLoad(&mPhase, "Gtaki");
     if(state == cPhs_COMPLEATE_e){
         if(!fopAcM_entrySolidHeap(this, CheckCreateHeap, DEMO_SELECT(0xD20, 0x3450))){

--- a/src/d/actor/d_a_obj_hami3.cpp
+++ b/src/d/actor/d_a_obj_hami3.cpp
@@ -82,7 +82,7 @@ BOOL daObjHami3::Act_c::Create() {
 
 /* 00000354-00000450       .text Mthd_Create__Q210daObjHami35Act_cFv */
 cPhs_State daObjHami3::Act_c::Mthd_Create() {
-    fopAcM_SetupActor(this, daObjHami3::Act_c);
+    fopAcM_ct(this, daObjHami3::Act_c);
     cPhs_State phase_state = dComIfG_resLoad(&field_0x2CC, M_arcname);
     if (phase_state == cPhs_COMPLEATE_e) {
         phase_state = MoveBGCreate(M_arcname, HAMI3_DZB_HAMI3, dBgS_MoveBGProc_Typical, 0x1fc0);

--- a/src/d/actor/d_a_obj_hami4.cpp
+++ b/src/d/actor/d_a_obj_hami4.cpp
@@ -116,7 +116,7 @@ void daObjHami4_c::daObjHami4_open_demo() {
 void daObjHami4_c::daObjHami4_open_stop() {}
 
 cPhs_State daObjHami4_c::_create() {
-    fopAcM_SetupActor(this, daObjHami4_c);
+    fopAcM_ct(this, daObjHami4_c);
     for (int i = 0; i < 4; i++){
         mdBgW[i] = NULL;
     }

--- a/src/d/actor/d_a_obj_hat.cpp
+++ b/src/d/actor/d_a_obj_hat.cpp
@@ -63,7 +63,7 @@ static BOOL CheckCreateHeap(fopAc_ac_c* actor) {
 
 /* 000003CC-0000045C       .text _create__10daObjHat_cFv */
 cPhs_State daObjHat_c::_create() {
-    fopAcM_SetupActor(this, daObjHat_c);
+    fopAcM_ct(this, daObjHat_c);
 
     cPhs_State phase_state = dComIfG_resLoad(&mPhs, "Ro");
 

--- a/src/d/actor/d_a_obj_hbrf1.cpp
+++ b/src/d/actor/d_a_obj_hbrf1.cpp
@@ -51,7 +51,7 @@ BOOL daObjHbrf1::Act_c::Create() {
 
 /* 000002B4-000003B0       .text Mthd_Create__Q210daObjHbrf15Act_cFv */
 cPhs_State daObjHbrf1::Act_c::Mthd_Create() {
-    fopAcM_SetupActor(this, daObjHbrf1::Act_c);
+    fopAcM_ct(this, daObjHbrf1::Act_c);
 
     cPhs_State phase_state = dComIfG_resLoad(&mPhs, M_arcname);
 

--- a/src/d/actor/d_a_obj_hfuck1.cpp
+++ b/src/d/actor/d_a_obj_hfuck1.cpp
@@ -119,7 +119,7 @@ bool daObjHfuck1_c::checkCollision() {
 
 /* 000002AC-000004B0       .text _create__13daObjHfuck1_cFv */
 cPhs_State daObjHfuck1_c::_create() {
-    fopAcM_SetupActor(this, daObjHfuck1_c);
+    fopAcM_ct(this, daObjHfuck1_c);
 
     cPhs_State ret = dComIfG_resLoad(&mPhs, l_arcname);
 

--- a/src/d/actor/d_a_obj_hha.cpp
+++ b/src/d/actor/d_a_obj_hha.cpp
@@ -310,7 +310,7 @@ cPhs_State daObjHha_c::_create() {
     static const float splash_z[2] = {0.0f, 100.0f};
 
 
-    fopAcM_SetupActor(this, daObjHha_c);
+    fopAcM_ct(this, daObjHha_c);
     cPhs_State ret = dComIfG_resLoad(&mPhs, M_arcname);
     if(ret == cPhs_COMPLEATE_e){
         ret = cPhs_ERROR_e;

--- a/src/d/actor/d_a_obj_hole.cpp
+++ b/src/d/actor/d_a_obj_hole.cpp
@@ -256,7 +256,7 @@ cPhs_State daObj_Hole_c::_create() {
     if (result == cPhs_COMPLEATE_e)
 #endif
     {
-        fopAcM_SetupActor(this, daObj_Hole_c);
+        fopAcM_ct(this, daObj_Hole_c);
 
 #if VERSION > VERSION_DEMO
         result = dComIfG_resLoad(&mPhs, m_arc_name);

--- a/src/d/actor/d_a_obj_homen.cpp
+++ b/src/d/actor/d_a_obj_homen.cpp
@@ -265,7 +265,7 @@ bool Act_c::create_heap() {
 
 /* 000002B4-000005B0       .text _create__Q210daObjHomen5Act_cFv */
 cPhs_State Act_c::_create() {
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
     
     if (param_get_sw() != 0xFF && is_switch() == true) {
         return cPhs_ERROR_e;

--- a/src/d/actor/d_a_obj_homensmoke.cpp
+++ b/src/d/actor/d_a_obj_homensmoke.cpp
@@ -35,7 +35,7 @@ namespace daObjHomensmoke {
 
     /* 0000026C-0000048C       .text _create__Q215daObjHomensmoke5Act_cFv */
     cPhs_State Act_c::_create() {
-        fopAcM_SetupActor(this, Act_c);
+        fopAcM_ct(this, Act_c);
         
         mbInitialized = FALSE;
         

--- a/src/d/actor/d_a_obj_ice.cpp
+++ b/src/d/actor/d_a_obj_ice.cpp
@@ -228,7 +228,7 @@ void daObjIce_c::tg_hitCallback(fopAc_ac_c* a_this, dCcD_GObjInf* arg1, fopAc_ac
 /* 000005F4-000008C0       .text _create__10daObjIce_cFv */
 cPhs_State daObjIce_c::_create() {
     cPhs_State ret = cPhs_ERROR_e;
-    fopAcM_SetupActor(this, daObjIce_c);
+    fopAcM_ct(this, daObjIce_c);
 
     if (fopAcM_IsFirstCreating(this)) {
         m448 = chk_appear();

--- a/src/d/actor/d_a_obj_iceisland.cpp
+++ b/src/d/actor/d_a_obj_iceisland.cpp
@@ -168,7 +168,7 @@ void daObjIceisland_c::daObjIceisland_fail_demo_main() {
 }
 
 cPhs_State daObjIceisland_c::_create(){
-    fopAcM_SetupActor(this, daObjIceisland_c);
+    fopAcM_ct(this, daObjIceisland_c);
     cPhs_State phase_state = dComIfG_resLoad(&mPhs, "GiceL");
     if (phase_state == cPhs_COMPLEATE_e) {
         if (!fopAcM_entrySolidHeap(this, CheckCreateHeap, DEMO_SELECT(0x300, 0x13D0))) {

--- a/src/d/actor/d_a_obj_ikada.cpp
+++ b/src/d/actor/d_a_obj_ikada.cpp
@@ -1495,7 +1495,7 @@ BOOL daObj_Ikada_c::_createHeap() {
 
 /* 00004B60-00004C18       .text _create__13daObj_Ikada_cFv */
 cPhs_State daObj_Ikada_c::_create() {
-    fopAcM_SetupActor(this, daObj_Ikada_c);
+    fopAcM_ct(this, daObj_Ikada_c);
 
     cPhs_State ret = dComIfG_resLoad(&mPhase, m_arc_name);
     if (ret == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_obj_kanat.cpp
+++ b/src/d/actor/d_a_obj_kanat.cpp
@@ -35,7 +35,7 @@ BOOL daObjKanat::Act_c::Create() {
 
 /* 000001AC-000002EC       .text Mthd_Create__Q210daObjKanat5Act_cFv */
 cPhs_State daObjKanat::Act_c::Mthd_Create() {
-    fopAcM_SetupActor(this, daObjKanat::Act_c);
+    fopAcM_ct(this, daObjKanat::Act_c);
     
     if (fopAcM_isSwitch(this, prm_get_swSave())) {
         return cPhs_STOP_e;

--- a/src/d/actor/d_a_obj_ladder.cpp
+++ b/src/d/actor/d_a_obj_ladder.cpp
@@ -105,7 +105,7 @@ BOOL daObjLadder::Act_c::Create() {
 
 /* 000002F0-000004F8       .text Mthd_Create__Q211daObjLadder5Act_cFv */
 cPhs_State daObjLadder::Act_c::Mthd_Create() {
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
     cPhs_State phase_state = dComIfG_resLoad(&mPhs, M_arcname);
 
     if (phase_state == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_obj_leaves.cpp
+++ b/src/d/actor/d_a_obj_leaves.cpp
@@ -474,7 +474,7 @@ void daObjLeaves_c::registFireCollision() {
 cPhs_State daObjLeaves_c::_create() {
     cPhs_State PVar4 = cPhs_ERROR_e;
 
-    fopAcM_SetupActor(this, daObjLeaves_c);
+    fopAcM_ct(this, daObjLeaves_c);
 
     if (fopAcM_IsFirstCreating(this)) {
         m43C = chk_appear();

--- a/src/d/actor/d_a_obj_lpalm.cpp
+++ b/src/d/actor/d_a_obj_lpalm.cpp
@@ -84,9 +84,9 @@ cPhs_State daObjLpalm_c::_create() {
 #if VERSION == VERSION_DEMO
     cPhs_State ret = dComIfG_resLoad(&mPhs, M_arcname);
     if (ret == cPhs_COMPLEATE_e) {
-        fopAcM_SetupActor(this, daObjLpalm_c);
+        fopAcM_ct(this, daObjLpalm_c);
 #else
-    fopAcM_SetupActor(this, daObjLpalm_c);
+    fopAcM_ct(this, daObjLpalm_c);
     cPhs_State ret = dComIfG_resLoad(&mPhs, M_arcname);
     if (ret == cPhs_COMPLEATE_e) {
 #endif

--- a/src/d/actor/d_a_obj_lpalm.cpp
+++ b/src/d/actor/d_a_obj_lpalm.cpp
@@ -81,15 +81,10 @@ void daObjLpalm_c::CreateInit() {
 }
 
 cPhs_State daObjLpalm_c::_create() {
-#if VERSION == VERSION_DEMO
+    fopAcM_ct_Retail(this, daObjLpalm_c);
     cPhs_State ret = dComIfG_resLoad(&mPhs, M_arcname);
     if (ret == cPhs_COMPLEATE_e) {
-        fopAcM_ct(this, daObjLpalm_c);
-#else
-    fopAcM_ct(this, daObjLpalm_c);
-    cPhs_State ret = dComIfG_resLoad(&mPhs, M_arcname);
-    if (ret == cPhs_COMPLEATE_e) {
-#endif
+        fopAcM_ct_Demo(this, daObjLpalm_c);
         if (fopAcM_entrySolidHeap(this, CheckCreateHeap, 0xf00) == 0) {
             ret = cPhs_ERROR_e;
         } else {

--- a/src/d/actor/d_a_obj_mkie.cpp
+++ b/src/d/actor/d_a_obj_mkie.cpp
@@ -201,7 +201,7 @@ BOOL daObjMkie::Act_c::Create() {
 /* 00000568-00000754       .text Mthd_Create__Q29daObjMkie5Act_cFv */
 cPhs_State daObjMkie::Act_c::Mthd_Create() {
     cPhs_State phase_state = cPhs_ERROR_e;
-    fopAcM_SetupActor(this, daObjMkie::Act_c);
+    fopAcM_ct(this, daObjMkie::Act_c);
     mSwitch = !fopAcM_isSwitch(this, prm_get_swSave());
     if (mSwitch && (phase_state = dComIfG_resLoad(&mPhs, M_arcname), phase_state == cPhs_COMPLEATE_e)) {
         mType = prm_get_type();

--- a/src/d/actor/d_a_obj_mkiek.cpp
+++ b/src/d/actor/d_a_obj_mkiek.cpp
@@ -86,7 +86,7 @@ BOOL daObjMkiek::Act_c::Create() {
 
 /* 00000314-000004F8       .text Mthd_Create__Q210daObjMkiek5Act_cFv */
 cPhs_State daObjMkiek::Act_c::Mthd_Create() {
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
 
     int switch_index = daObj::PrmAbstract(this, PRM_SWSAVE_W, PRM_SWSAVE_S);
     if (fopAcM_isSwitch(this, switch_index)) {

--- a/src/d/actor/d_a_obj_mknjd.cpp
+++ b/src/d/actor/d_a_obj_mknjd.cpp
@@ -297,7 +297,7 @@ BOOL daObjMknjD::Act_c::Create() {
 
 /* 000008E8-00000A84       .text Mthd_Create__Q210daObjMknjD5Act_cFv */
 cPhs_State daObjMknjD::Act_c::Mthd_Create() {
-    fopAcM_SetupActor(this, daObjMknjD::Act_c);
+    fopAcM_ct(this, daObjMknjD::Act_c);
 
     m043E = prm_get_Type();
 

--- a/src/d/actor/d_a_obj_monument.cpp
+++ b/src/d/actor/d_a_obj_monument.cpp
@@ -58,7 +58,7 @@ bool daObjMonument::Act_c::create_heap() {
 
 /* 00000238-00000318       .text _create__Q213daObjMonument5Act_cFv */
 cPhs_State daObjMonument::Act_c::_create() {
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
 
     cPhs_State ret = dComIfG_resLoad(&mPhs, M_arcname);
 

--- a/src/d/actor/d_a_obj_movebox.cpp
+++ b/src/d/actor/d_a_obj_movebox.cpp
@@ -67,7 +67,7 @@ namespace daObjMovebox {
     };
     
     cPhs_State Act_c::Mthd_Create() {
-        fopAcM_SetupActor(this, Act_c);
+        fopAcM_ct(this, Act_c);
         
         cPhs_State phase_state;
         mType = prm_get_type();

--- a/src/d/actor/d_a_obj_msdan_sub.cpp
+++ b/src/d/actor/d_a_obj_msdan_sub.cpp
@@ -51,7 +51,7 @@ BOOL daObjMsdanSub::Act_c::Create() {
 
 /* 00000304-00000400       .text Mthd_Create__Q213daObjMsdanSub5Act_cFv */
 cPhs_State daObjMsdanSub::Act_c::Mthd_Create() {
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
     cPhs_State phase_state = dComIfG_resLoad(&mPhs, M_arcname);
 
     if (phase_state == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_obj_mshokki.cpp
+++ b/src/d/actor/d_a_obj_mshokki.cpp
@@ -250,7 +250,7 @@ void daObjMshokki_c::set_se() {
 
 /* 00000740-00000A1C       .text _create__14daObjMshokki_cFv */
 cPhs_State daObjMshokki_c::_create() {
-    fopAcM_SetupActor(this, daObjMshokki_c);
+    fopAcM_ct(this, daObjMshokki_c);
 
     if (fopAcM_IsFirstCreating(this)) {
         m60C = param_get_arg();

--- a/src/d/actor/d_a_obj_mtest.cpp
+++ b/src/d/actor/d_a_obj_mtest.cpp
@@ -241,7 +241,7 @@ cPhs_State daObjMtest::Act_c::Mthd_Create() {
         },
     };
     
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
     
     M_type = prm_get_type();
     JUT_ASSERT(327, M_type < Type_Max);

--- a/src/d/actor/d_a_obj_nest.cpp
+++ b/src/d/actor/d_a_obj_nest.cpp
@@ -73,7 +73,7 @@ BOOL daObjNest::Act_c::Create() {
 
 /* 000001F0-000002E8       .text Mthd_Create__Q29daObjNest5Act_cFv */
 cPhs_State daObjNest::Act_c::Mthd_Create() {
-    fopAcM_SetupActor(this, daObjNest::Act_c);
+    fopAcM_ct(this, daObjNest::Act_c);
     
     cPhs_State phase_state = dComIfG_resLoad(&mPhs, M_arcname);
     if (phase_state == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_obj_ohatch.cpp
+++ b/src/d/actor/d_a_obj_ohatch.cpp
@@ -130,7 +130,7 @@ bool daObjOhatch_c::create_heap() {
 
 /* 000003CC-00000548       .text _create__13daObjOhatch_cFv */
 cPhs_State daObjOhatch_c::_create() {
-    fopAcM_SetupActor(this, daObjOhatch_c);
+    fopAcM_ct(this, daObjOhatch_c);
     cPhs_State ret = dComIfG_resLoad(&mPhase, l_arcname);
     if (ret == cPhs_COMPLEATE_e) {
         if (fopAcM_entrySolidHeap(this, solidHeapCB, 0xB90)) {

--- a/src/d/actor/d_a_obj_ojtree.cpp
+++ b/src/d/actor/d_a_obj_ojtree.cpp
@@ -39,7 +39,7 @@ BOOL daObjOjtree::Act_c::Create() {
 
 /* 000001EC-000002E4       .text Mthd_Create__Q211daObjOjtree5Act_cFv */
 cPhs_State daObjOjtree::Act_c::Mthd_Create() {
-    fopAcM_SetupActor(this, daObjOjtree::Act_c);
+    fopAcM_ct(this, daObjOjtree::Act_c);
        
     cPhs_State phase_state = dComIfG_resLoad(&mPhs, M_arcname);
     if (phase_state == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_obj_ospbox.cpp
+++ b/src/d/actor/d_a_obj_ospbox.cpp
@@ -80,7 +80,7 @@ Mtx daObjOspbox::Act_c::M_tmp_mtx;
 
 /* 00000294-000004F8       .text Mthd_Create__Q211daObjOspbox5Act_cFv */
 cPhs_State daObjOspbox::Act_c::Mthd_Create() {
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
     cPhs_State phase_state = dComIfG_resLoad(&mPhase, M_arcname);
     if (phase_state == cPhs_COMPLEATE_e) {
         #if VERSION == VERSION_DEMO

--- a/src/d/actor/d_a_obj_otble.cpp
+++ b/src/d/actor/d_a_obj_otble.cpp
@@ -127,9 +127,9 @@ cPhs_State daObj_Otble::Act_c::_create() {
 
     cPhs_State ret = dComIfG_resLoad(&mPhase, "Okmono");
     if (ret == cPhs_COMPLEATE_e) {
-        fopAcM_SetupActor(this, daObj_Otble::Act_c);
+        fopAcM_ct(this, daObj_Otble::Act_c);
 #else
-    fopAcM_SetupActor(this, daObj_Otble::Act_c);
+    fopAcM_ct(this, daObj_Otble::Act_c);
     m294 = fopAcM_GetParam(this) & 0xFF;
     if (m294 > 1) {
         m294 = 1;

--- a/src/d/actor/d_a_obj_otble.cpp
+++ b/src/d/actor/d_a_obj_otble.cpp
@@ -119,7 +119,7 @@ void daObj_Otble::Act_c::CreateInit() {
 cPhs_State daObj_Otble::Act_c::_create() {
     static const u32 heapsize[] = {0x1240, 0x1240};
 
-#if VERSION == VERSION_DEMO
+    fopAcM_ct_Retail(this, daObj_Otble::Act_c);
     m294 = fopAcM_GetParam(this) & 0xff;
     if (m294 > 1) {
         m294 = 1;
@@ -127,17 +127,7 @@ cPhs_State daObj_Otble::Act_c::_create() {
 
     cPhs_State ret = dComIfG_resLoad(&mPhase, "Okmono");
     if (ret == cPhs_COMPLEATE_e) {
-        fopAcM_ct(this, daObj_Otble::Act_c);
-#else
-    fopAcM_ct(this, daObj_Otble::Act_c);
-    m294 = fopAcM_GetParam(this) & 0xFF;
-    if (m294 > 1) {
-        m294 = 1;
-    }
-
-    cPhs_State ret = dComIfG_resLoad(&mPhase, "Okmono");
-    if (ret == cPhs_COMPLEATE_e) {
-#endif
+        fopAcM_ct_Demo(this, daObj_Otble::Act_c);
         if (!fopAcM_entrySolidHeap(this, createHeap_CB, heapsize[m294])) {
             return cPhs_ERROR_e;
         }

--- a/src/d/actor/d_a_obj_paper.cpp
+++ b/src/d/actor/d_a_obj_paper.cpp
@@ -148,7 +148,7 @@ namespace daObjPaper {
 
     /* 00000170-000004E0       .text _create__Q210daObjPaper5Act_cFv */
     cPhs_State Act_c::_create() {
-        fopAcM_SetupActor(this, Act_c);
+        fopAcM_ct(this, Act_c);
 
         mType = prm_get_type();
 

--- a/src/d/actor/d_a_obj_pbco.cpp
+++ b/src/d/actor/d_a_obj_pbco.cpp
@@ -65,7 +65,7 @@ cPhs_State daObj_Pbco_c::CreateInit() {
 }
 
 cPhs_State daObj_Pbco_c::_create() {
-    fopAcM_SetupActor(this, daObj_Pbco_c);
+    fopAcM_ct(this, daObj_Pbco_c);
     cPhs_State phase_state = dComIfG_resLoad(&mPhs, M_arcname);
     if (phase_state == cPhs_COMPLEATE_e) {
         if (fopAcM_entrySolidHeap(this, CheckCreateHeap, 0x10000)) {

--- a/src/d/actor/d_a_obj_pbka.cpp
+++ b/src/d/actor/d_a_obj_pbka.cpp
@@ -46,7 +46,7 @@ void daObjPbka_c::set_mtx() {
 }
 
 cPhs_State daObjPbka_c::_create() {
-    fopAcM_SetupActor(this, daObjPbka_c);
+    fopAcM_ct(this, daObjPbka_c);
 
     cPhs_State phase_state = dComIfG_resLoad(&mPhase, "Pbka");
     if (phase_state == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_obj_pfall.cpp
+++ b/src/d/actor/d_a_obj_pfall.cpp
@@ -183,16 +183,12 @@ void daObj_Pfall_c::CreateInit() {
 
 /* 000008CC-000009E8       .text _create__13daObj_Pfall_cFv */
 cPhs_State daObj_Pfall_c::_create() {
-#if VERSION > VERSION_DEMO
-    fopAcM_ct(this, daObj_Pfall_c);
-#endif
+    fopAcM_ct_Retail(this, daObj_Pfall_c);
 
     cPhs_State phase = dComIfG_resLoad(&mPhsPfall, "Pfall");
 
     if (phase == cPhs_COMPLEATE_e) {
-#if VERSION == VERSION_DEMO
-            fopAcM_ct(this, daObj_Pfall_c);
-#endif
+        fopAcM_ct_Demo(this, daObj_Pfall_c);
 
         if (!fopAcM_entrySolidHeap(this, CallbackCreateHeap, 0x38E0)) {
             return cPhs_ERROR_e;

--- a/src/d/actor/d_a_obj_pfall.cpp
+++ b/src/d/actor/d_a_obj_pfall.cpp
@@ -184,14 +184,14 @@ void daObj_Pfall_c::CreateInit() {
 /* 000008CC-000009E8       .text _create__13daObj_Pfall_cFv */
 cPhs_State daObj_Pfall_c::_create() {
 #if VERSION > VERSION_DEMO
-    fopAcM_SetupActor(this, daObj_Pfall_c);
+    fopAcM_ct(this, daObj_Pfall_c);
 #endif
 
     cPhs_State phase = dComIfG_resLoad(&mPhsPfall, "Pfall");
 
     if (phase == cPhs_COMPLEATE_e) {
 #if VERSION == VERSION_DEMO
-            fopAcM_SetupActor(this, daObj_Pfall_c);
+            fopAcM_ct(this, daObj_Pfall_c);
 #endif
 
         if (!fopAcM_entrySolidHeap(this, CallbackCreateHeap, 0x38E0)) {

--- a/src/d/actor/d_a_obj_pirateship.cpp
+++ b/src/d/actor/d_a_obj_pirateship.cpp
@@ -462,7 +462,7 @@ bool daObjPirateship::Act_c::_execute() {
 
 /* 00000F10-000012A4       .text _create__Q215daObjPirateship5Act_cFv */
 cPhs_State daObjPirateship::Act_c::_create() {
-    fopAcM_SetupActor(this, daObjPirateship::Act_c);
+    fopAcM_ct(this, daObjPirateship::Act_c);
 
     cPhs_State PVar1 = dComIfG_resLoad(&mPhase, mArcname);
     if (PVar1 == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_obj_plant.cpp
+++ b/src/d/actor/d_a_obj_plant.cpp
@@ -47,7 +47,7 @@ static BOOL _CheckCreateHeap(fopAc_ac_c* i_this) {
 }
 
 cPhs_State daObjPlant_c::_create() {
-    fopAcM_SetupActor(this, daObjPlant_c);
+    fopAcM_ct(this, daObjPlant_c);
 
     cPhs_State phase_state = dComIfG_resLoad(&mPhase, "Plant");
 

--- a/src/d/actor/d_a_obj_quake.cpp
+++ b/src/d/actor/d_a_obj_quake.cpp
@@ -28,7 +28,7 @@ daObjQuake_HIO_c::daObjQuake_HIO_c() {
 
 /* 00000134-000002C4       .text _create__12daObjQuake_cFv */
 cPhs_State daObjQuake_c::_create() {
-    fopAcM_SetupActor(this, daObjQuake_c);
+    fopAcM_ct(this, daObjQuake_c);
 
     if (dComIfGs_isSymbol(1)) {
         return cPhs_STOP_e;

--- a/src/d/actor/d_a_obj_rcloud.cpp
+++ b/src/d/actor/d_a_obj_rcloud.cpp
@@ -85,9 +85,9 @@ bool daObjRcloud_c::create_heap() {
 cPhs_State daObjRcloud_c::_create() {
 #if VERSION == VERSION_DEMO
     cPhs_State phase = cPhs_ERROR_e;
-    fopAcM_SetupActor(this, daObjRcloud_c);
+    fopAcM_ct(this, daObjRcloud_c);
 #else
-    fopAcM_SetupActor(this, daObjRcloud_c);
+    fopAcM_ct(this, daObjRcloud_c);
     cPhs_State phase = cPhs_ERROR_e;
 #endif
 

--- a/src/d/actor/d_a_obj_rcloud.cpp
+++ b/src/d/actor/d_a_obj_rcloud.cpp
@@ -83,13 +83,9 @@ bool daObjRcloud_c::create_heap() {
 
 /* 00000238-000003B4       .text _create__13daObjRcloud_cFv */
 cPhs_State daObjRcloud_c::_create() {
-#if VERSION == VERSION_DEMO
+    fopAcM_ct_Retail(this, daObjRcloud_c);
     cPhs_State phase = cPhs_ERROR_e;
-    fopAcM_ct(this, daObjRcloud_c);
-#else
-    fopAcM_ct(this, daObjRcloud_c);
-    cPhs_State phase = cPhs_ERROR_e;
-#endif
+    fopAcM_ct_Demo(this, daObjRcloud_c);
 
     if (fopAcM_IsFirstCreating(this)) {
         mDemoNameIndex = param_get_arg();

--- a/src/d/actor/d_a_obj_rflw.cpp
+++ b/src/d/actor/d_a_obj_rflw.cpp
@@ -113,7 +113,7 @@ void daObjRflw_c::set_mtx() {
 
 inline cPhs_State daObjRflw_c::_create() {
     cPhs_State rt = cPhs_ERROR_e;
-    fopAcM_SetupActor(this, daObjRflw_c);
+    fopAcM_ct(this, daObjRflw_c);
 
     rt = dComIfG_resLoad(&mPhs, "Rflw");
 

--- a/src/d/actor/d_a_obj_rforce.cpp
+++ b/src/d/actor/d_a_obj_rforce.cpp
@@ -51,7 +51,7 @@ bool daObjRforce::Act_c::create_heap() {
 
 /* 00000220-000002F8       .text _create__Q211daObjRforce5Act_cFv */
 cPhs_State daObjRforce::Act_c::_create() {
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
 
     cPhs_State ret = dComIfG_resLoad(&mPhs, M_arcname);
     

--- a/src/d/actor/d_a_obj_roten.cpp
+++ b/src/d/actor/d_a_obj_roten.cpp
@@ -99,7 +99,7 @@ static BOOL Roten_create_check(u8 type) {
 
 
 cPhs_State daObj_Roten_c::_create() {
-    fopAcM_SetupActor(this, daObj_Roten_c);
+    fopAcM_ct(this, daObj_Roten_c);
 
     mType = fopAcM_GetParam(this) >> 0x18;
     mType = cLib_minMaxLimit<u8>(mType, 0, 2);

--- a/src/d/actor/d_a_obj_shelf.cpp
+++ b/src/d/actor/d_a_obj_shelf.cpp
@@ -75,7 +75,7 @@ BOOL daObjShelf::Act_c::Create() {
 
 /* 000001A0-0000029C       .text Mthd_Create__Q210daObjShelf5Act_cFv */
 cPhs_State daObjShelf::Act_c::Mthd_Create() {
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
 
     cPhs_State phase_state = dComIfG_resLoad(&mPhs, M_arcname);
     if (phase_state == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_obj_shmrgrd.cpp
+++ b/src/d/actor/d_a_obj_shmrgrd.cpp
@@ -197,7 +197,7 @@ BOOL daObjShmrgrd_c::create_heap() {
 
 /* 000006E0-00000964       .text _create__14daObjShmrgrd_cFv */
 cPhs_State daObjShmrgrd_c::_create() {
-    fopAcM_SetupActor(this, daObjShmrgrd_c);
+    fopAcM_ct(this, daObjShmrgrd_c);
     cPhs_State phase_state = dComIfG_resLoad(&mPhs, M_arcname);
     if (phase_state == cPhs_COMPLEATE_e) {
         phase_state = cPhs_ERROR_e;

--- a/src/d/actor/d_a_obj_smplbg.cpp
+++ b/src/d/actor/d_a_obj_smplbg.cpp
@@ -57,18 +57,14 @@ BOOL daObjSmplbg::Act_c::Create() {
 
 /* 0000032C-00000474       .text Mthd_Create__Q211daObjSmplbg5Act_cFv */
 cPhs_State daObjSmplbg::Act_c::Mthd_Create() {
-#if VERSION > VERSION_DEMO
-    fopAcM_ct(this, Act_c);
-#endif
+    fopAcM_ct_Retail(this, Act_c);
 
     mType = prm_get_type();
     if(mType >= 1){
         mType = 0;
     }
 
-#if VERSION == VERSION_DEMO
-    fopAcM_ct(this, Act_c);
-#endif
+    fopAcM_ct_Demo(this, Act_c);
 
     cPhs_State phase_state = dComIfG_resLoad(&mPhs, attr().mResName);
     if(phase_state == cPhs_COMPLEATE_e){

--- a/src/d/actor/d_a_obj_smplbg.cpp
+++ b/src/d/actor/d_a_obj_smplbg.cpp
@@ -58,7 +58,7 @@ BOOL daObjSmplbg::Act_c::Create() {
 /* 0000032C-00000474       .text Mthd_Create__Q211daObjSmplbg5Act_cFv */
 cPhs_State daObjSmplbg::Act_c::Mthd_Create() {
 #if VERSION > VERSION_DEMO
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
 #endif
 
     mType = prm_get_type();
@@ -67,7 +67,7 @@ cPhs_State daObjSmplbg::Act_c::Mthd_Create() {
     }
 
 #if VERSION == VERSION_DEMO
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
 #endif
 
     cPhs_State phase_state = dComIfG_resLoad(&mPhs, attr().mResName);

--- a/src/d/actor/d_a_obj_stair.cpp
+++ b/src/d/actor/d_a_obj_stair.cpp
@@ -146,7 +146,7 @@ static cPhs_State daObj_StairCreate(void* i_this) {
 /* 000004D8-00000854       .text _create__13daObj_Stair_cFv */
 cPhs_State daObj_Stair_c::_create() {
     cPhs_State phase_state;
-    fopAcM_SetupActor(this, daObj_Stair_c);
+    fopAcM_ct(this, daObj_Stair_c);
     u32 switchIdx = fopAcM_GetParam(this) & 0xFF;
 
     if(switchIdx != 0xff && fopAcM_isSwitch(this, switchIdx)) {

--- a/src/d/actor/d_a_obj_swhammer.cpp
+++ b/src/d/actor/d_a_obj_swhammer.cpp
@@ -168,7 +168,7 @@ BOOL daObjSwhammer::Act_c::Create() {
 
 /* 0000070C-000007F8       .text _create__Q213daObjSwhammer5Act_cFv */
 cPhs_State daObjSwhammer::Act_c::_create() {
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
 
     cPhs_State phase_state = dComIfG_resLoad(&mPhs, M_arcname);
     if (phase_state == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_obj_swheavy.cpp
+++ b/src/d/actor/d_a_obj_swheavy.cpp
@@ -106,7 +106,7 @@ u8 daObjSwheavy::Act_c::create_heap() {
 
 /* 0000032C-00000628       .text _create__Q212daObjSwheavy5Act_cFv */
 cPhs_State daObjSwheavy::Act_c::_create() {
-    fopAcM_SetupActor(this, daObjSwheavy::Act_c);
+    fopAcM_ct(this, daObjSwheavy::Act_c);
     
     cPhs_State phase_state = dComIfG_resLoad(&mPhs, M_arcname);
     if (phase_state == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_obj_swlight.cpp
+++ b/src/d/actor/d_a_obj_swlight.cpp
@@ -109,15 +109,11 @@ bool Act_c::create_heap() {
 
 /* 0000045C-00000704       .text _create__Q212daObjSwlight5Act_cFv */
 cPhs_State Act_c::_create() {
-#if VERSION > VERSION_DEMO
-    fopAcM_ct(this, Act_c);
-#endif
+    fopAcM_ct_Retail(this, Act_c);
 
     mF24 = prm_get_type();
 
-#if VERSION == VERSION_DEMO
-    fopAcM_ct(this, Act_c);
-#endif
+    fopAcM_ct_Demo(this, Act_c);
 
     cPhs_State PVar2 = dComIfG_resLoad(&mPhase, M_arcname);
     if (PVar2 == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_obj_swlight.cpp
+++ b/src/d/actor/d_a_obj_swlight.cpp
@@ -110,13 +110,13 @@ bool Act_c::create_heap() {
 /* 0000045C-00000704       .text _create__Q212daObjSwlight5Act_cFv */
 cPhs_State Act_c::_create() {
 #if VERSION > VERSION_DEMO
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
 #endif
 
     mF24 = prm_get_type();
 
 #if VERSION == VERSION_DEMO
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
 #endif
 
     cPhs_State PVar2 = dComIfG_resLoad(&mPhase, M_arcname);

--- a/src/d/actor/d_a_obj_swpush.cpp
+++ b/src/d/actor/d_a_obj_swpush.cpp
@@ -203,7 +203,7 @@ cPhs_State daObjSwpush::Act_c::create_res_load() {
 
 /* 0000051C-000008C4       .text Mthd_Create__Q211daObjSwpush5Act_cFv */
 cPhs_State daObjSwpush::Act_c::Mthd_Create() {
-    fopAcM_SetupActor(this, daObjSwpush::Act_c);
+    fopAcM_ct(this, daObjSwpush::Act_c);
 
     prmZ_init();
     mType = prm_get_type();

--- a/src/d/actor/d_a_obj_table.cpp
+++ b/src/d/actor/d_a_obj_table.cpp
@@ -57,7 +57,7 @@ BOOL daObjTable::Act_c::Create() {
 /* 00000284-000003B4       .text Mthd_Create__Q210daObjTable5Act_cFv */
 cPhs_State daObjTable::Act_c::Mthd_Create() {
     cPhs_State phase_state;
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
 
     phase_state = dComIfG_resLoad(&mPhs, M_arcname);
     if (phase_state == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_obj_tenmado.cpp
+++ b/src/d/actor/d_a_obj_tenmado.cpp
@@ -54,7 +54,7 @@ BOOL daObjTenmado::Act_c::Create() {
 cPhs_State daObjTenmado::Act_c::Mthd_Create() {
     cPhs_State phase_state;
 
-    fopAcM_SetupActor(this, daObjTenmado::Act_c);
+    fopAcM_ct(this, daObjTenmado::Act_c);
 
     phase_state = dComIfG_resLoad(&mPhase, M_arcname);
     if (phase_state == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_obj_tide.cpp
+++ b/src/d/actor/d_a_obj_tide.cpp
@@ -148,7 +148,7 @@ BOOL Act_c::Create() {
 
 /* 000007BC-00000998       .text Mthd_Create__Q29daObjTide5Act_cFv */
 cPhs_State Act_c::Mthd_Create() {
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
 
     M_type = prm_get_type();
     se_init_gmtw();

--- a/src/d/actor/d_a_obj_timer.cpp
+++ b/src/d/actor/d_a_obj_timer.cpp
@@ -11,7 +11,7 @@
 
 /* 00000078-00000114       .text _create__Q210daObjTimer5Act_cFv */
 cPhs_State daObjTimer::Act_c::_create() {
-    fopAcM_SetupActor(this, daObjTimer::Act_c);
+    fopAcM_ct(this, daObjTimer::Act_c);
 
     fopAcM_offDraw(this);
 

--- a/src/d/actor/d_a_obj_toripost.cpp
+++ b/src/d/actor/d_a_obj_toripost.cpp
@@ -974,7 +974,7 @@ void daObjTpost_c::getArg() {
 
 /* 00001BA8-00001D88       .text _create__12daObjTpost_cFv */
 cPhs_State daObjTpost_c::_create() {
-    fopAcM_SetupActor(this, daObjTpost_c);
+    fopAcM_ct(this, daObjTpost_c);
 
     getArg();
     cPhs_State step = dComIfG_resLoad(&mPhs, m_arc_name);

--- a/src/d/actor/d_a_obj_tousekiki.cpp
+++ b/src/d/actor/d_a_obj_tousekiki.cpp
@@ -61,9 +61,9 @@ cPhs_State daObj_Tousekiki_c::_create() {
 #if VERSION == VERSION_DEMO
     cPhs_State PVar1 = dComIfG_resLoad(&mPhase, M_arcname);
     if (PVar1 == cPhs_COMPLEATE_e) {
-        fopAcM_SetupActor(this, daObj_Tousekiki_c);
+        fopAcM_ct(this, daObj_Tousekiki_c);
 #else
-    fopAcM_SetupActor(this, daObj_Tousekiki_c);
+    fopAcM_ct(this, daObj_Tousekiki_c);
 
     cPhs_State PVar1 = dComIfG_resLoad(&mPhase, M_arcname);
     if (PVar1 == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_obj_tousekiki.cpp
+++ b/src/d/actor/d_a_obj_tousekiki.cpp
@@ -58,16 +58,10 @@ static cPhs_State daObj_TousekikiCreate(void* i_this) {
 
 /* 000002DC-000004F4       .text _create__17daObj_Tousekiki_cFv */
 cPhs_State daObj_Tousekiki_c::_create() {
-#if VERSION == VERSION_DEMO
+    fopAcM_ct_Retail(this, daObj_Tousekiki_c);
     cPhs_State PVar1 = dComIfG_resLoad(&mPhase, M_arcname);
     if (PVar1 == cPhs_COMPLEATE_e) {
-        fopAcM_ct(this, daObj_Tousekiki_c);
-#else
-    fopAcM_ct(this, daObj_Tousekiki_c);
-
-    cPhs_State PVar1 = dComIfG_resLoad(&mPhase, M_arcname);
-    if (PVar1 == cPhs_COMPLEATE_e) {
-#endif
+        fopAcM_ct_Demo(this, daObj_Tousekiki_c);
         if (!fopAcM_entrySolidHeap(this, CheckCreateHeap, 0x900)) {
             return cPhs_ERROR_e;
         }

--- a/src/d/actor/d_a_obj_tower.cpp
+++ b/src/d/actor/d_a_obj_tower.cpp
@@ -60,7 +60,7 @@ void daObjTower_c::set_mtx() {
 }
 
 cPhs_State daObjTower_c::_create() {
-    fopAcM_SetupActor(this, daObjTower_c);
+    fopAcM_ct(this, daObjTower_c);
 
     field_0x2d0 = 0;
 

--- a/src/d/actor/d_a_obj_usovmc.cpp
+++ b/src/d/actor/d_a_obj_usovmc.cpp
@@ -31,7 +31,7 @@ BOOL daObjUsovmc::Act_c::Create() {
 
 /* 00000198-00000290       .text Mthd_Create__Q211daObjUsovmc5Act_cFv */
 cPhs_State daObjUsovmc::Act_c::Mthd_Create() {
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
 
     cPhs_State phase_state = dComIfG_resLoad(&mPhs, M_arcname);
     if (phase_state == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_obj_vfan.cpp
+++ b/src/d/actor/d_a_obj_vfan.cpp
@@ -86,7 +86,7 @@ BOOL daObjVfan::Act_c::Create() {
 
 /* 00000214-000003D0       .text Mthd_Create__Q29daObjVfan5Act_cFv */
 cPhs_State daObjVfan::Act_c::Mthd_Create() {
-    fopAcM_SetupActor(this, daObjVfan::Act_c);
+    fopAcM_ct(this, daObjVfan::Act_c);
 
     cPhs_State phase_state;
     if (fopAcM_isSwitch(this, prm_get_swSave())) {

--- a/src/d/actor/d_a_obj_vgnfd.cpp
+++ b/src/d/actor/d_a_obj_vgnfd.cpp
@@ -167,7 +167,7 @@ BOOL daObjVgnfd_c::create_heap() {
 cPhs_State daObjVgnfd_c::_create() {
     cPhs_State ret = cPhs_ERROR_e;
 
-    fopAcM_SetupActor(this, daObjVgnfd_c);
+    fopAcM_ct(this, daObjVgnfd_c);
 
     if (!check_fin()) {
         ret = dComIfG_resLoad(&mPhs, M_arcname);

--- a/src/d/actor/d_a_obj_vmc.cpp
+++ b/src/d/actor/d_a_obj_vmc.cpp
@@ -178,7 +178,7 @@ void daObjVmc::Act_c::CreateInit() {
 
 /* 000005BC-00000730       .text _create__Q28daObjVmc5Act_cFv */
 cPhs_State daObjVmc::Act_c::_create() {
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
 
     mHasTreeBg = false;
 

--- a/src/d/actor/d_a_obj_vmsdz.cpp
+++ b/src/d/actor/d_a_obj_vmsdz.cpp
@@ -39,7 +39,7 @@ BOOL daObjVmsdz_c::create_heap() {
 cPhs_State daObjVmsdz_c::_create() {
     cPhs_State ret = cPhs_ERROR_e;
 
-    fopAcM_SetupActor(this, daObjVmsdz_c);
+    fopAcM_ct(this, daObjVmsdz_c);
 
     ret = dComIfG_resLoad(&mPhs, M_arcname);
     if (ret == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_obj_vmsms.cpp
+++ b/src/d/actor/d_a_obj_vmsms.cpp
@@ -39,7 +39,7 @@ BOOL daObjVmsms_c::create_heap() {
 cPhs_State daObjVmsms_c::_create() {
     cPhs_State ret = cPhs_ERROR_e;
 
-    fopAcM_SetupActor(this, daObjVmsms_c);
+    fopAcM_ct(this, daObjVmsms_c);
 
     if (!check_demo()) {
         ret = dComIfG_resLoad(&mPhs, M_arcname);

--- a/src/d/actor/d_a_obj_volcano.cpp
+++ b/src/d/actor/d_a_obj_volcano.cpp
@@ -195,7 +195,7 @@ BOOL daObjVolcano::Act_c::Create() {
 
 /* 000009C8-00000BA0       .text Mthd_Create__Q212daObjVolcano5Act_cFv */
 cPhs_State daObjVolcano::Act_c::Mthd_Create() {
-    fopAcM_SetupActor(this, daObjVolcano::Act_c);
+    fopAcM_ct(this, daObjVolcano::Act_c);
     cPhs_State phase_state = dComIfG_resLoad(&field_0x2F0, M_arcname);
     if (phase_state == cPhs_COMPLEATE_e) {
         phase_state = MoveBGCreate(M_arcname, 0x11, NULL, 0xaed0);

--- a/src/d/actor/d_a_obj_warpt.cpp
+++ b/src/d/actor/d_a_obj_warpt.cpp
@@ -810,7 +810,7 @@ void daObj_Warpt_c::createInit() {
 
 /* 0000215C-00002378       .text _create__13daObj_Warpt_cFv */
 cPhs_State daObj_Warpt_c::_create() {
-    fopAcM_SetupActor(this, daObj_Warpt_c);
+    fopAcM_ct(this, daObj_Warpt_c);
     cPhs_State PVar1 = dComIfG_resLoad(&mPhase, m_arc_name);
     if (PVar1 == cPhs_COMPLEATE_e) {
         getArg();

--- a/src/d/actor/d_a_obj_wood.cpp
+++ b/src/d/actor/d_a_obj_wood.cpp
@@ -12,7 +12,7 @@
 #include "f_op/f_op_actor_mng.h"
 
 cPhs_State daObjWood::Act_c::_create() {
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
     if (dComIfGp_createWood() != NULL)
         dComIfGp_getWood()->put_unit(current.pos, fopAcM_GetRoomNo(this));
     return cPhs_ERROR_e;

--- a/src/d/actor/d_a_obj_xfuta.cpp
+++ b/src/d/actor/d_a_obj_xfuta.cpp
@@ -60,7 +60,7 @@ bool Act_c::create_heap() {
 
 /* 0000015C-00000214       .text _create__Q210daObjXfuta5Act_cFv */
 cPhs_State Act_c::_create() {
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
     cPhs_State phase_state = dComIfG_resLoad(&mPhs, M_arcname);
     if (phase_state == cPhs_COMPLEATE_e) {
         if (fopAcM_entrySolidHeap(this, solidHeapCB, 0x0)) {

--- a/src/d/actor/d_a_obj_zouK.cpp
+++ b/src/d/actor/d_a_obj_zouK.cpp
@@ -138,7 +138,7 @@ bool daObjZouk::Act_c::create_heap() {
 
 /* 00000468-00000724       .text _create__Q29daObjZouk5Act_cFv */
 cPhs_State daObjZouk::Act_c::_create() {
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
 
     cPhs_State ret = dComIfG_resLoad(&mPhs, M_arcname);
 

--- a/src/d/actor/d_a_oship.cpp
+++ b/src/d/actor/d_a_oship.cpp
@@ -1013,7 +1013,7 @@ void daOship_c::getArg() {
 
 /* 00002F90-000030EC       .text _create__9daOship_cFv */
 cPhs_State daOship_c::_create() {
-    fopAcM_SetupActor(this, daOship_c);
+    fopAcM_ct(this, daOship_c);
 
     cPhs_State state = dComIfG_resLoad(&mPhs, m_arc_name);
     

--- a/src/d/actor/d_a_pedestal.cpp
+++ b/src/d/actor/d_a_pedestal.cpp
@@ -96,7 +96,7 @@ void daPds_c::CreateInit() {
 
 /* 00000380-00000474       .text _create__Q210daPedestal7daPds_cFv */
 cPhs_State daPds_c::_create() {
-    fopAcM_SetupActor(this, daPds_c);
+    fopAcM_ct(this, daPds_c);
 
     cPhs_State phase_state = dComIfG_resLoad(&mPhase, m_arcname);
 

--- a/src/d/actor/d_a_pirate_flag.cpp
+++ b/src/d/actor/d_a_pirate_flag.cpp
@@ -534,7 +534,7 @@ static BOOL daPirate_Flag_Delete(pirate_flag_class* i_this) {
 /* 00001A90-00001C8C       .text daPirate_Flag_Create__FP10fopAc_ac_c */
 static cPhs_State daPirate_Flag_Create(fopAc_ac_c* i_this) {
     pirate_flag_class* a_this = static_cast<pirate_flag_class*>(i_this);
-    fopAcM_SetupActor(i_this, pirate_flag_class);
+    fopAcM_ct(i_this, pirate_flag_class);
 
     cPhs_State result = dComIfG_resLoad(&a_this->mPhs1, "Cloth");
     if (result != cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_player_main.cpp
+++ b/src/d/actor/d_a_player_main.cpp
@@ -12457,7 +12457,7 @@ cPhs_State phase_2(daPy_lk_c* i_this) {
     if (dComIfGp_getCamera(dComIfGp_getPlayerCameraID(0)) == NULL)  {
         result = cPhs_INIT_e;
     } else {
-        fopAcM_SetupActor(i_this, daPy_lk_c);
+        fopAcM_ct(i_this, daPy_lk_c);
         i_this->playerInit();
 
         result = cPhs_NEXT_e;

--- a/src/d/actor/d_a_pw.cpp
+++ b/src/d/actor/d_a_pw.cpp
@@ -544,7 +544,7 @@ static cPhs_State daPW_Create(fopAc_ac_c* i_actor) {
             /* Radius */ 15.0f,
         }},
     };
-    fopAcM_SetupActor(i_actor, pw_class);
+    fopAcM_ct(i_actor, pw_class);
 }
 
 static actor_method_class l_daPW_Method = {

--- a/src/d/actor/d_a_race_item.cpp
+++ b/src/d/actor/d_a_race_item.cpp
@@ -58,7 +58,7 @@ BOOL daRaceItem_c::Delete() {
 
 /* 0000012C-00000318       .text create__12daRaceItem_cFv */
 cPhs_State daRaceItem_c::create() {
-    fopAcM_SetupActor(this, daRaceItem_c);
+    fopAcM_ct(this, daRaceItem_c);
 
     m_itemNo = fopAcM_GetParam(this) & 0xFF;
     mItemBitNo = fopAcM_GetParam(this) >> 8 & 0x7F;

--- a/src/d/actor/d_a_rd.cpp
+++ b/src/d/actor/d_a_rd.cpp
@@ -1876,7 +1876,7 @@ void daRd_c::getArg() {
 
 /* 00004720-000047C8       .text _create__6daRd_cFv */
 cPhs_State daRd_c::_create() {
-    fopAcM_SetupActor(this, daRd_c);
+    fopAcM_ct(this, daRd_c);
     
     cPhs_State phase_state = dComIfG_resLoad(&mPhs, m_arc_name);
     

--- a/src/d/actor/d_a_sail.cpp
+++ b/src/d/actor/d_a_sail.cpp
@@ -807,7 +807,7 @@ static BOOL daSail_checkCreateHeap(fopAc_ac_c* i_actor) {
 
 /* 00002254-000024E4       .text daSail_Create__FP10fopAc_ac_c */
 static cPhs_State daSail_Create(fopAc_ac_c* i_actor) {
-    fopAcM_SetupActor(i_actor, sail_class);
+    fopAcM_ct(i_actor, sail_class);
     sail_class* i_this = (sail_class*)i_actor;
     
     {

--- a/src/d/actor/d_a_salvage.cpp
+++ b/src/d/actor/d_a_salvage.cpp
@@ -88,7 +88,7 @@ bool daSalvage_c::CreateInit() {
 
 /* 00000570-00000728       .text _create__11daSalvage_cFv */
 cPhs_State daSalvage_c::_create() {
-    fopAcM_SetupActor(this, daSalvage_c);
+    fopAcM_ct(this, daSalvage_c);
 
     cPhs_State PVar3 = dComIfG_resLoad(&mPhase, m_arcname);
     if (PVar3 == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_sbox.cpp
+++ b/src/d/actor/d_a_sbox.cpp
@@ -249,9 +249,9 @@ cPhs_State daSbox_c::create() {
     if (PVar1 != cPhs_COMPLEATE_e) {
         return PVar1;
     }
-    fopAcM_SetupActor(this, daSbox_c);
+    fopAcM_ct(this, daSbox_c);
 #else
-    fopAcM_SetupActor(this, daSbox_c);
+    fopAcM_ct(this, daSbox_c);
     cPhs_State PVar1 = dComIfG_resLoad(&mPhase, M_arcname);
     if (PVar1 != cPhs_COMPLEATE_e) {
         return PVar1;

--- a/src/d/actor/d_a_sbox.cpp
+++ b/src/d/actor/d_a_sbox.cpp
@@ -244,19 +244,12 @@ BOOL daSbox_c::CreateInit() {
 
 /* 000008F0-000009F0       .text create__8daSbox_cFv */
 cPhs_State daSbox_c::create() {
-#if VERSION == VERSION_DEMO
+    fopAcM_ct_Retail(this, daSbox_c);
     cPhs_State PVar1 = dComIfG_resLoad(&mPhase, M_arcname);
     if (PVar1 != cPhs_COMPLEATE_e) {
         return PVar1;
     }
-    fopAcM_ct(this, daSbox_c);
-#else
-    fopAcM_ct(this, daSbox_c);
-    cPhs_State PVar1 = dComIfG_resLoad(&mPhase, M_arcname);
-    if (PVar1 != cPhs_COMPLEATE_e) {
-        return PVar1;
-    }
-#endif
+    fopAcM_ct_Demo(this, daSbox_c);
 
     if (!fopAcM_entrySolidHeap(this, CheckCreateHeap, 0x15C0)) {
         return cPhs_ERROR_e;

--- a/src/d/actor/d_a_scene_change.cpp
+++ b/src/d/actor/d_a_scene_change.cpp
@@ -24,7 +24,7 @@ daSceneChgHIO_c::daSceneChgHIO_c() {
 static cPhs_State daSceneChgCreate(void* i_this) {
     d_a_scene_change_c* scnChg = static_cast<d_a_scene_change_c*>(i_this);
     
-    fopAcM_SetupActor(scnChg, d_a_scene_change_c);
+    fopAcM_ct(scnChg, d_a_scene_change_c);
     
     mDoMtx_stack_c::transS(scnChg->current.pos);
     mDoMtx_stack_c::ZXYrotM(scnChg->shape_angle);

--- a/src/d/actor/d_a_sea.cpp
+++ b/src/d/actor/d_a_sea.cpp
@@ -1173,7 +1173,7 @@ static BOOL CheckCreateHeap(fopAc_ac_c* i_this) {
 
 /* 8015D924-8015D99C       .text daSea_Create__FP10fopAc_ac_c */
 static cPhs_State daSea_Create(fopAc_ac_c* i_this) {
-    fopAcM_SetupActor(i_this, sea_class);
+    fopAcM_ct(i_this, sea_class);
     if (!fopAcM_entrySolidHeap(i_this, CheckCreateHeap, 0xA000))
         return cPhs_ERROR_e;
     return cPhs_COMPLEATE_e;

--- a/src/d/actor/d_a_seatag.cpp
+++ b/src/d/actor/d_a_seatag.cpp
@@ -29,7 +29,7 @@ static BOOL daSeatag_Delete(daSeatag_c* a_this) {
 
 /* 000000C0-00000110       .text daSeatag_Create__FP10fopAc_ac_c */
 static cPhs_State daSeatag_Create(fopAc_ac_c* a_this) {
-    fopAcM_SetupActor(a_this, daSeatag_c);
+    fopAcM_ct(a_this, daSeatag_c);
     return cPhs_COMPLEATE_e;
 }
 

--- a/src/d/actor/d_a_shand.cpp
+++ b/src/d/actor/d_a_shand.cpp
@@ -476,7 +476,7 @@ static cPhs_State daShand_Create(fopAc_ac_c* i_this) {
     };
 
     shand_class* s_this = static_cast<shand_class*>(i_this);
-    fopAcM_SetupActor(i_this, shand_class);
+    fopAcM_ct(i_this, shand_class);
 
     cPhs_State ret = dComIfG_resLoad(&s_this->mPhs, "Shand");
     if(ret == cPhs_COMPLEATE_e){

--- a/src/d/actor/d_a_ship.cpp
+++ b/src/d/actor/d_a_ship.cpp
@@ -4563,7 +4563,7 @@ cPhs_State daShip_c::create() {
         }},
     };
     
-    fopAcM_SetupActor(this, daShip_c);
+    fopAcM_ct(this, daShip_c);
     
     if (!dComIfGs_isEventBit(dSv_event_flag_c::MET_KORL)) {
         return cPhs_ERROR_e;

--- a/src/d/actor/d_a_shop_item.cpp
+++ b/src/d/actor/d_a_shop_item.cpp
@@ -194,7 +194,7 @@ static cPhs_State daShopItem_Create(void* i_this) {
 
 /* 000007C4-00000AA4       .text _create__12daShopItem_cFv */
 cPhs_State daShopItem_c::_create() {
-    fopAcM_SetupActor(this, daShopItem_c);
+    fopAcM_ct(this, daShopItem_c);
     
     m_itemNo = fopAcM_GetParamBit(fopAcM_GetParam(this), 0, 8);
     

--- a/src/d/actor/d_a_shutter.cpp
+++ b/src/d/actor/d_a_shutter.cpp
@@ -103,7 +103,7 @@ BOOL daShutter_c::Create() {
 
 /* 000004B4-000005A0       .text _create__11daShutter_cFv */
 cPhs_State daShutter_c::_create() {
-    fopAcM_SetupActor(this, daShutter_c);
+    fopAcM_ct(this, daShutter_c);
     mType = daShutter_prm::getType(this);
     cPhs_State result = dComIfG_resLoad(&mPhs, m_arcname[mType]);
     if (result == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_shutter2.cpp
+++ b/src/d/actor/d_a_shutter2.cpp
@@ -72,7 +72,7 @@ BOOL daShutter2_c::Create() {
 
 /* 00000350-0000041C       .text _create__12daShutter2_cFv */
 cPhs_State daShutter2_c::_create() {
-    fopAcM_SetupActor(this, daShutter2_c);
+    fopAcM_ct(this, daShutter2_c);
     mType = 0;
     cPhs_State phase_state = dComIfG_resLoad(&mPhs, m_arcname[mType]);
     if (phase_state == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_sie_flag.cpp
+++ b/src/d/actor/d_a_sie_flag.cpp
@@ -139,9 +139,9 @@ cPhs_State daSie_Flag_c::_create() {
         return rt2;
     }
 
-    fopAcM_SetupActor(this, daSie_Flag_c);
+    fopAcM_ct(this, daSie_Flag_c);
 #else
-    fopAcM_SetupActor(this, daSie_Flag_c);
+    fopAcM_ct(this, daSie_Flag_c);
     
     cPhs_State result = dComIfG_resLoad(&mPhsEshata, M_arcname);
     if (result != cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_sk.cpp
+++ b/src/d/actor/d_a_sk.cpp
@@ -291,9 +291,9 @@ static cPhs_State daSk_Create(fopAc_ac_c* a_this) {
 #if VERSION == VERSION_DEMO
     cPhs_State PVar2 = dComIfG_resLoad(&i_this->mPhase, "Sk");
     if (PVar2 == cPhs_COMPLEATE_e) {
-        fopAcM_SetupActor(a_this, sk_class);
+        fopAcM_ct(a_this, sk_class);
 #else
-    fopAcM_SetupActor(a_this, sk_class);
+    fopAcM_ct(a_this, sk_class);
 
     cPhs_State PVar2 = dComIfG_resLoad(&i_this->mPhase, "Sk");
     if (PVar2 == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_sk.cpp
+++ b/src/d/actor/d_a_sk.cpp
@@ -287,17 +287,10 @@ static cPhs_State daSk_Create(fopAc_ac_c* a_this) {
     };
 
     sk_class* i_this = (sk_class*)a_this;
-
-#if VERSION == VERSION_DEMO
+    fopAcM_ct_Retail(a_this, sk_class);
     cPhs_State PVar2 = dComIfG_resLoad(&i_this->mPhase, "Sk");
     if (PVar2 == cPhs_COMPLEATE_e) {
-        fopAcM_ct(a_this, sk_class);
-#else
-    fopAcM_ct(a_this, sk_class);
-
-    cPhs_State PVar2 = dComIfG_resLoad(&i_this->mPhase, "Sk");
-    if (PVar2 == cPhs_COMPLEATE_e) {
-#endif
+        fopAcM_ct_Demo(a_this, sk_class);
         i_this->m2B4 = fopAcM_GetParam(i_this);
         if (i_this->m2B4 == 0xff) {
             i_this->m2B4 = 0;

--- a/src/d/actor/d_a_sk2.cpp
+++ b/src/d/actor/d_a_sk2.cpp
@@ -191,9 +191,9 @@ static cPhs_State daSk2_Create(fopAc_ac_c* a_this) {
 #if VERSION == VERSION_DEMO
     cPhs_State PVar1 = dComIfG_resLoad(&i_this->mPhase, "Sk2");
     if (PVar1 == cPhs_COMPLEATE_e) {
-        fopAcM_SetupActor(a_this, sk2_class);
+        fopAcM_ct(a_this, sk2_class);
 #else
-    fopAcM_SetupActor(a_this, sk2_class);
+    fopAcM_ct(a_this, sk2_class);
     cPhs_State PVar1 = dComIfG_resLoad(&i_this->mPhase, "Sk2");
     if (PVar1 == cPhs_COMPLEATE_e) {
 #endif

--- a/src/d/actor/d_a_sk2.cpp
+++ b/src/d/actor/d_a_sk2.cpp
@@ -188,15 +188,10 @@ static BOOL useHeapInit(fopAc_ac_c* a_this) {
 /* 00000918-00000BC4       .text daSk2_Create__FP10fopAc_ac_c */
 static cPhs_State daSk2_Create(fopAc_ac_c* a_this) {
     sk2_class* i_this = (sk2_class*)a_this;
-#if VERSION == VERSION_DEMO
+    fopAcM_ct_Retail(a_this, sk2_class);
     cPhs_State PVar1 = dComIfG_resLoad(&i_this->mPhase, "Sk2");
     if (PVar1 == cPhs_COMPLEATE_e) {
-        fopAcM_ct(a_this, sk2_class);
-#else
-    fopAcM_ct(a_this, sk2_class);
-    cPhs_State PVar1 = dComIfG_resLoad(&i_this->mPhase, "Sk2");
-    if (PVar1 == cPhs_COMPLEATE_e) {
-#endif
+        fopAcM_ct_Demo(a_this, sk2_class);
         i_this->m2B4 = fopAcM_GetParam(a_this);
         i_this->m2B5 = fopAcM_GetParam(a_this) >> 8;
 

--- a/src/d/actor/d_a_spc_item01.cpp
+++ b/src/d/actor/d_a_spc_item01.cpp
@@ -76,7 +76,7 @@ BOOL daSpcItem01_c::_delete() {
 
 /* 8015DBF4-8015DDD0       .text _create__13daSpcItem01_cFv */
 cPhs_State daSpcItem01_c::_create() {
-    fopAcM_SetupActor(this, daSpcItem01_c);
+    fopAcM_ct(this, daSpcItem01_c);
 
     m_itemNo = daSpcItem01_prm::getItemNo(this);
     if (m_itemNo == dItem_SHIELD_e && dComIfGs_isEventBit(dSv_event_flag_c::UNK_0E20)) {

--- a/src/d/actor/d_a_spotbox.cpp
+++ b/src/d/actor/d_a_spotbox.cpp
@@ -12,7 +12,7 @@
 #include "d/d_priority.h"
 
 cPhs_State daSpotbox_c::create() {
-    fopAcM_SetupActor(this, daSpotbox_c);
+    fopAcM_ct(this, daSpotbox_c);
     f32 baseScale = getType() != 0 ? 1000.0f : 100.0f;
     scale.x *= baseScale;
     scale.y *= baseScale;

--- a/src/d/actor/d_a_ssk.cpp
+++ b/src/d/actor/d_a_ssk.cpp
@@ -365,15 +365,10 @@ static cPhs_State daSsk_Create(fopAc_ac_c* a_this) {
 
     ssk_class* i_this = (ssk_class*)a_this;
 
-#if VERSION == VERSION_DEMO
+    fopAcM_ct_Retail(a_this, ssk_class);
     cPhs_State PVar2 = dComIfG_resLoad(&i_this->mPhase, "Ssk");
     if (PVar2 == cPhs_COMPLEATE_e) {
-        fopAcM_ct(a_this, ssk_class);
-#else
-    fopAcM_ct(a_this, ssk_class);
-    cPhs_State PVar2 = dComIfG_resLoad(&i_this->mPhase, "Ssk");
-    if (PVar2 == cPhs_COMPLEATE_e) {
-#endif
+        fopAcM_ct_Demo(a_this, ssk_class);
         i_this->m2D0.setRateOff(0);
         i_this->m2B4 = fopAcM_GetParam(a_this);
         i_this->m2B5 = fopAcM_GetParam(a_this) >> 8;

--- a/src/d/actor/d_a_ssk.cpp
+++ b/src/d/actor/d_a_ssk.cpp
@@ -368,9 +368,9 @@ static cPhs_State daSsk_Create(fopAc_ac_c* a_this) {
 #if VERSION == VERSION_DEMO
     cPhs_State PVar2 = dComIfG_resLoad(&i_this->mPhase, "Ssk");
     if (PVar2 == cPhs_COMPLEATE_e) {
-        fopAcM_SetupActor(a_this, ssk_class);
+        fopAcM_ct(a_this, ssk_class);
 #else
-    fopAcM_SetupActor(a_this, ssk_class);
+    fopAcM_ct(a_this, ssk_class);
     cPhs_State PVar2 = dComIfG_resLoad(&i_this->mPhase, "Ssk");
     if (PVar2 == cPhs_COMPLEATE_e) {
 #endif

--- a/src/d/actor/d_a_steam_tag.cpp
+++ b/src/d/actor/d_a_steam_tag.cpp
@@ -204,7 +204,7 @@ daSteamTag_c::~daSteamTag_c() {
 }
 
 cPhs_State daSteamTag_c::create() {
-    fopAcM_SetupActor(this, daSteamTag_c);
+    fopAcM_ct(this, daSteamTag_c);
     CreateInit();
 
     cPhs_State phase_state;

--- a/src/d/actor/d_a_stone.cpp
+++ b/src/d/actor/d_a_stone.cpp
@@ -189,7 +189,7 @@ bool Act_c::chk_appear() {
 
 /* 0000033C-00000744       .text _create__Q27daStone5Act_cFv */
 cPhs_State Act_c::_create() {
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
     m670 = prm_get_type();
     m68C = chk_appear();
 

--- a/src/d/actor/d_a_stone2.cpp
+++ b/src/d/actor/d_a_stone2.cpp
@@ -177,7 +177,7 @@ bool Act_c::chk_appear() {
 
 /* 000009F4-00000B3C       .text Mthd_Create__Q28daStone25Act_cFv */
 cPhs_State Act_c::Mthd_Create() {
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
     prmZ_init();
     m644 = prm_get_type();
     m659 = chk_appear();

--- a/src/d/actor/d_a_swattack.cpp
+++ b/src/d/actor/d_a_swattack.cpp
@@ -60,7 +60,7 @@ void daSwAt_c::CreateInit() {
 
 /* 00000120-0000020C       .text _create__8daSwAt_cFv */
 cPhs_State daSwAt_c::_create() {
-    fopAcM_SetupActor(this, daSwAt_c);
+    fopAcM_ct(this, daSwAt_c);
     CreateInit();
     return cPhs_COMPLEATE_e;
 }

--- a/src/d/actor/d_a_swc00.cpp
+++ b/src/d/actor/d_a_swc00.cpp
@@ -47,7 +47,7 @@ static BOOL daSwc00_Delete(swc00_class* i_this) {
 /* 00000190-00000274       .text daSwc00_Create__FP10fopAc_ac_c */
 static cPhs_State daSwc00_Create(fopAc_ac_c* i_this) {
 #if VERSION > VERSION_DEMO
-    fopAcM_SetupActor(i_this, swc00_class);
+    fopAcM_ct(i_this, swc00_class);
 #endif
 
     swc00_class* a_this = (swc00_class*)i_this;
@@ -63,7 +63,7 @@ static cPhs_State daSwc00_Create(fopAc_ac_c* i_this) {
     }
 
 #if VERSION == VERSION_DEMO
-    fopAcM_SetupActor(i_this, swc00_class);
+    fopAcM_ct(i_this, swc00_class);
 #endif
 
     i_this->scale.x *= 100.0f;

--- a/src/d/actor/d_a_swc00.cpp
+++ b/src/d/actor/d_a_swc00.cpp
@@ -46,9 +46,7 @@ static BOOL daSwc00_Delete(swc00_class* i_this) {
 
 /* 00000190-00000274       .text daSwc00_Create__FP10fopAc_ac_c */
 static cPhs_State daSwc00_Create(fopAc_ac_c* i_this) {
-#if VERSION > VERSION_DEMO
-    fopAcM_ct(i_this, swc00_class);
-#endif
+    fopAcM_ct_Retail(i_this, swc00_class);
 
     swc00_class* a_this = (swc00_class*)i_this;
 
@@ -62,9 +60,7 @@ static cPhs_State daSwc00_Create(fopAc_ac_c* i_this) {
         }
     }
 
-#if VERSION == VERSION_DEMO
-    fopAcM_ct(i_this, swc00_class);
-#endif
+    fopAcM_ct_Demo(i_this, swc00_class);
 
     i_this->scale.x *= 100.0f;
     i_this->scale.x += 30.0f;

--- a/src/d/actor/d_a_swhit0.cpp
+++ b/src/d/actor/d_a_swhit0.cpp
@@ -191,7 +191,7 @@ static BOOL CheckCreateHeap(fopAc_ac_c* i_actr) {
 
 /* 00000508-000006C0       .text create__10daSwhit0_cFv */
 cPhs_State daSwhit0_c::create() {
-    fopAcM_SetupActor(this, daSwhit0_c);
+    fopAcM_ct(this, daSwhit0_c);
 
     shape_angle.z = 0;
     current.angle.z = 0;

--- a/src/d/actor/d_a_switem.cpp
+++ b/src/d/actor/d_a_switem.cpp
@@ -69,7 +69,7 @@ BOOL daSwItem_c::CreateInit() {
 
 /* 00000154-00000250       .text _create__10daSwItem_cFv */
 cPhs_State daSwItem_c::_create() {
-    fopAcM_SetupActor(this, daSwItem_c);
+    fopAcM_ct(this, daSwItem_c);
 
     if (!CreateInit()) {
         return cPhs_ERROR_e;

--- a/src/d/actor/d_a_swtact.cpp
+++ b/src/d/actor/d_a_swtact.cpp
@@ -72,7 +72,7 @@ void daSwTact_c::set_mtx() {
 
 /* 000002CC-0000038C       .text _create__10daSwTact_cFv */
 cPhs_State daSwTact_c::_create() {
-    fopAcM_SetupActor(this, daSwTact_c);
+    fopAcM_ct(this, daSwTact_c);
 
     s32 result = cPhs_COMPLEATE_e;
     if (daSwTact_prm::getModel(this) == 1) {

--- a/src/d/actor/d_a_swtdoor.cpp
+++ b/src/d/actor/d_a_swtdoor.cpp
@@ -62,7 +62,7 @@ static BOOL useHeapInit(fopAc_ac_c* i_ac) {
 static cPhs_State daSwtdoor_Create(fopAc_ac_c* i_ac) {
     swtdoor_class * i_this;
 
-    fopAcM_SetupActor(i_ac, swtdoor_class);
+    fopAcM_ct(i_ac, swtdoor_class);
     i_this = (swtdoor_class *)i_ac;
 
     cPhs_State rt = dComIfG_resLoad(&i_this->mPhs, "Swtdoor");

--- a/src/d/actor/d_a_syan.cpp
+++ b/src/d/actor/d_a_syan.cpp
@@ -205,7 +205,7 @@ static BOOL daSyan_solidHeapCB(fopAc_ac_c* i_ac) {
 
 /* 00000E10-00000FE0       .text daSyan_Create__FP10fopAc_ac_c */
 static cPhs_State daSyan_Create(fopAc_ac_c* i_ac) {
-    fopAcM_SetupActor(i_ac, syan_class);
+    fopAcM_ct(i_ac, syan_class);
     syan_class* i_this = (syan_class*)i_ac;
     cPhs_State rt = dComIfG_resLoad(&i_this->mPhs, "Syan");
     if (rt == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_tag_attention.cpp
+++ b/src/d/actor/d_a_tag_attention.cpp
@@ -41,7 +41,7 @@ static dCcD_SrcSph sph_check_src = {
 
 /* 00000078-00000188       .text _create__Q214daTagAttention5Act_cFv */
 cPhs_State daTagAttention::Act_c::_create() {
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
     mStts.Init(0xFF, 0xFF, this);
     mSph.Set(sph_check_src);
     mSph.SetStts(&mStts);

--- a/src/d/actor/d_a_tag_etc.cpp
+++ b/src/d/actor/d_a_tag_etc.cpp
@@ -104,7 +104,7 @@ cPhs_State daTag_Etc_c::create() {
     float fVar1;
     u8 stageEVNTListIndex;
 
-    fopAcM_SetupActor(this, daTag_Etc_c);
+    fopAcM_ct(this, daTag_Etc_c);
 
     stageEVNTListIndex = getEventNo();
     mEventIdx = dComIfGp_evmng_getEventIdx(NULL, stageEVNTListIndex);

--- a/src/d/actor/d_a_tag_event.cpp
+++ b/src/d/actor/d_a_tag_event.cpp
@@ -505,7 +505,7 @@ BOOL daTag_Event_c::execute() {
 }
 
 cPhs_State daTag_Event_c::create() {
-    fopAcM_SetupActor(this, daTag_Event_c);
+    fopAcM_ct(this, daTag_Event_c);
 
     int swbit = getSwbit();
 

--- a/src/d/actor/d_a_tag_evsw.cpp
+++ b/src/d/actor/d_a_tag_evsw.cpp
@@ -11,7 +11,7 @@
 
 /* 00000078-000001F8       .text _create__Q29daTagEvsw5Act_cFv */
 cPhs_State daTagEvsw::Act_c::_create() {
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
     
     if (dComIfGs_isEventBit(prm_get_eventbitID())) {
         fopAcM_onSwitch(this, prm_get_swSave());

--- a/src/d/actor/d_a_tag_ghostship.cpp
+++ b/src/d/actor/d_a_tag_ghostship.cpp
@@ -125,7 +125,7 @@ void daTag_Gship_c::getArg() {
 
 /* 00000594-000005EC .text _create__13daTag_Gship_cFv */
 cPhs_State daTag_Gship_c::_create() {
-    fopAcM_SetupActor(this, daTag_Gship_c);
+    fopAcM_ct(this, daTag_Gship_c);
 
     getArg();
 

--- a/src/d/actor/d_a_tag_hint.cpp
+++ b/src/d/actor/d_a_tag_hint.cpp
@@ -739,7 +739,7 @@ static BOOL daTag_Hint_Delete(daTag_Hint_c* i_this) {
 }
 
 cPhs_State daTag_Hint_c::create() {
-    fopAcM_SetupActor(this, daTag_Hint_c);
+    fopAcM_ct(this, daTag_Hint_c);
 
     m2A8 = SQUARE(scale.x) * SQUARE(100.0f);
     m2AC = scale.y * 100.0f;

--- a/src/d/actor/d_a_tag_island.cpp
+++ b/src/d/actor/d_a_tag_island.cpp
@@ -449,7 +449,7 @@ BOOL daTag_Island_c::actionWait() {
 }
 
 cPhs_State daTag_Island_c::create() {
-    fopAcM_SetupActor(this, daTag_Island_c);
+    fopAcM_ct(this, daTag_Island_c);
     s32 swbit = getSwbit();
     makeEvId();
     eventInfo.setEventId(mEventId);

--- a/src/d/actor/d_a_tag_kb_item.cpp
+++ b/src/d/actor/d_a_tag_kb_item.cpp
@@ -33,7 +33,7 @@ void daTagKbItem_c::CreateInit() {
 
 /* 0000010C-000001BC       .text _create__13daTagKbItem_cFv */
 cPhs_State daTagKbItem_c::_create() {
-    fopAcM_SetupActor(this, daTagKbItem_c);
+    fopAcM_ct(this, daTagKbItem_c);
 
     CreateInit();
     if ((field_0x29c != 0x1f && dComIfGs_isItem(field_0x29c, fopAcM_GetHomeRoomNo(this))) ||

--- a/src/d/actor/d_a_tag_kk1.cpp
+++ b/src/d/actor/d_a_tag_kk1.cpp
@@ -82,7 +82,7 @@ cPhs_State daTag_Kk1_c::_create() {
     u32 name_int = 0;
     s32 o_phsState = cPhs_COMPLEATE_e;
 
-    fopAcM_SetupActor(this, daTag_Kk1_c);
+    fopAcM_ct(this, daTag_Kk1_c);
 
     switch(fopAcM_GetName(this)){
         case PROC_TAG_KK1:

--- a/src/d/actor/d_a_tag_light.cpp
+++ b/src/d/actor/d_a_tag_light.cpp
@@ -127,7 +127,7 @@ bool Act_c::create_heap() {
 /* 0000035C-000006F0       .text _create__Q210daTagLight5Act_cFv */
 cPhs_State Act_c::_create() {
 #if VERSION > VERSION_DEMO
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
 #endif
 
     m2A0 = prm_get_type();
@@ -144,7 +144,7 @@ cPhs_State Act_c::_create() {
     m4A4.z = sp08.z;
 
 #if VERSION == VERSION_DEMO
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
 #endif
 
     mDoMtx_stack_c::transS(current.pos);

--- a/src/d/actor/d_a_tag_light.cpp
+++ b/src/d/actor/d_a_tag_light.cpp
@@ -126,9 +126,7 @@ bool Act_c::create_heap() {
 
 /* 0000035C-000006F0       .text _create__Q210daTagLight5Act_cFv */
 cPhs_State Act_c::_create() {
-#if VERSION > VERSION_DEMO
-    fopAcM_ct(this, Act_c);
-#endif
+    fopAcM_ct_Retail(this, Act_c);
 
     m2A0 = prm_get_type();
     cXyz sp08;
@@ -143,9 +141,7 @@ cPhs_State Act_c::_create() {
     m4A4.y = sp08.y;
     m4A4.z = sp08.z;
 
-#if VERSION == VERSION_DEMO
-    fopAcM_ct(this, Act_c);
-#endif
+    fopAcM_ct_Demo(this, Act_c);
 
     mDoMtx_stack_c::transS(current.pos);
     mDoMtx_stack_c::ZXYrotM(shape_angle);

--- a/src/d/actor/d_a_tag_msg.cpp
+++ b/src/d/actor/d_a_tag_msg.cpp
@@ -238,7 +238,7 @@ BOOL daTag_Msg_c::execute() {
 
 cPhs_State daTag_Msg_c::create() {
     int swBit;
-    fopAcM_SetupActor(this, daTag_Msg_c);
+    fopAcM_ct(this, daTag_Msg_c);
     swBit = (int)(getSwbit() & 0xFF);
     if ((getMessage() == 0x9c5) && dComIfGs_isEventBit(dSv_event_flag_c::UNK_0502)) {
         setActio(0);

--- a/src/d/actor/d_a_tag_photo.cpp
+++ b/src/d/actor/d_a_tag_photo.cpp
@@ -89,7 +89,7 @@ static BOOL CheckCreateHeap(fopAc_ac_c* i_this) {
 
 /* 000000F0-00000140       .text phase_1__FP12daTagPhoto_c */
 static cPhs_State phase_1(daTagPhoto_c* i_this) {
-    fopAcM_SetupActor(i_this, daTagPhoto_c);
+    fopAcM_ct(i_this, daTagPhoto_c);
 
     return cPhs_NEXT_e;
 }

--- a/src/d/actor/d_a_tag_ret.cpp
+++ b/src/d/actor/d_a_tag_ret.cpp
@@ -46,7 +46,7 @@ static dCcD_SrcCyl cyl_check_src = {
 namespace daTagRet {
     /* 00000078-000001D4       .text _create__Q28daTagRet5Act_cFv */
     cPhs_State Act_c::_create() {
-        fopAcM_SetupActor(this, daTagRet::Act_c);
+        fopAcM_ct(this, daTagRet::Act_c);
 
         #if VERSION > VERSION_DEMO
         if (checkItemGet(dItem_PEARL_FARORE_e, TRUE)) {

--- a/src/d/actor/d_a_tag_so.cpp
+++ b/src/d/actor/d_a_tag_so.cpp
@@ -56,7 +56,7 @@ void daTag_So_c::getArg() {
 
 /* 00000224-0000027C       .text _create__10daTag_So_cFv */
 cPhs_State daTag_So_c::_create() {
-    fopAcM_SetupActor(this, daTag_So_c);
+    fopAcM_ct(this, daTag_So_c);
     getArg();
     return cPhs_COMPLEATE_e;
 }

--- a/src/d/actor/d_a_tag_volcano.cpp
+++ b/src/d/actor/d_a_tag_volcano.cpp
@@ -25,7 +25,7 @@ namespace daTagvolcano {
 
 /* 00000078-000002B4       .text _create__Q212daTagvolcano5Act_cFv */
 cPhs_State daTagvolcano::Act_c::_create() {
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
 
     field_0x298 = 0;
     field_0x299 = 0;

--- a/src/d/actor/d_a_tag_waterlevel.cpp
+++ b/src/d/actor/d_a_tag_waterlevel.cpp
@@ -29,7 +29,7 @@ namespace daTagWaterlevel {
 
     /* 00000078-000001D4       .text _create__Q28daTagRet5Act_cFv */
     cPhs_State Act_c::_create() {
-        fopAcM_SetupActor(this, Act_c);
+        fopAcM_ct(this, Act_c);
 
         if ((prm_get_sch() & dKy_get_schbit() & 0xFF)) {
             M_now = 1.0f;

--- a/src/d/actor/d_a_tama.cpp
+++ b/src/d/actor/d_a_tama.cpp
@@ -108,7 +108,7 @@ BOOL daTama_c::_delete() {
 /* 000002DC-00000410       .text _create__8daTama_cFv */
 cPhs_State daTama_c::_create() {
     cPhs_State rt = cPhs_COMPLEATE_e;
-    fopAcM_SetupActor(this, daTama_c);
+    fopAcM_ct(this, daTama_c);
     if (!createInit())
         rt = cPhs_ERROR_e;
     return rt;

--- a/src/d/actor/d_a_tbox.cpp
+++ b/src/d/actor/d_a_tbox.cpp
@@ -1243,7 +1243,7 @@ static cPhs_State daTbox_Create(fopAc_ac_c* i_actor) {
 
     daTbox_c* tbox = static_cast<daTbox_c*>(i_actor);
 
-    fopAcM_SetupActor(tbox, daTbox_c);
+    fopAcM_ct(tbox, daTbox_c);
 
     cPhs_State result = dComIfG_resLoad(tbox->getPhase(), "Dalways");
 

--- a/src/d/actor/d_a_title.cpp
+++ b/src/d/actor/d_a_title.cpp
@@ -480,7 +480,7 @@ daTitle_c::~daTitle_c() {
 }
 
 cPhs_State daTitle_c::create() {
-    fopAcM_SetupActor(this, daTitle_c);
+    fopAcM_ct(this, daTitle_c);
 
 #if VERSION == VERSION_PAL
     // Use sprintf to modify the supposedly read-only "TlogoE0" string literal.

--- a/src/d/actor/d_a_toge.cpp
+++ b/src/d/actor/d_a_toge.cpp
@@ -151,7 +151,7 @@ BOOL daToge_c::Create() {
 
 /* 000004F4-00000620       .text _create__8daToge_cFv */
 cPhs_State daToge_c::_create() {
-    fopAcM_SetupActor(this, daToge_c);
+    fopAcM_ct(this, daToge_c);
 
     cPhs_State phase_state = dComIfG_resLoad(&m_Phs, m_arcname);
 

--- a/src/d/actor/d_a_tori_flag.cpp
+++ b/src/d/actor/d_a_tori_flag.cpp
@@ -125,7 +125,7 @@ cPhs_State daTori_Flag_c::_create() {
     }
     cPhs_State result3 = cPhs_COMPLEATE_e;
     if (result3 == cPhs_COMPLEATE_e) {
-        fopAcM_SetupActor(this, daTori_Flag_c);
+        fopAcM_ct(this, daTori_Flag_c);
         if (fopAcM_entrySolidHeap(this, CheckCreateHeap, 0x1020)) {
             result3 = CreateInit();
         }
@@ -135,7 +135,7 @@ cPhs_State daTori_Flag_c::_create() {
     }
     return result3;
 #else
-    fopAcM_SetupActor(this, daTori_Flag_c);
+    fopAcM_ct(this, daTori_Flag_c);
     cPhs_State result = dComIfG_resLoad(&mPhsTrflag, M_arcname);
     if (result != cPhs_COMPLEATE_e) {
         return result;

--- a/src/d/actor/d_a_tornado.cpp
+++ b/src/d/actor/d_a_tornado.cpp
@@ -293,7 +293,7 @@ cPhs_State daTornado_c::create() {
     static cXyz under_scale(1.01f, 1.0f, 1.01f);
 
     cPhs_State rt = dComIfG_resLoad(&mPhs, l_arcName);
-    fopAcM_SetupActor(this, daTornado_c);
+    fopAcM_ct(this, daTornado_c);
 
     if (rt == cPhs_COMPLEATE_e) {
         if (!fopAcM_entrySolidHeap(this, daTornado_createHeap, 0x8000)) {

--- a/src/d/actor/d_a_tpota.cpp
+++ b/src/d/actor/d_a_tpota.cpp
@@ -17,7 +17,7 @@ const u16 l_daTpota_idx_table[2] = {dPa_name::ID_IT_SN_TAKIURA_POTAA00, dPa_name
 
 /* 00000078-000001D0       .text _create__9daTpota_cFv */
 cPhs_State daTpota_c::_create() {
-    fopAcM_SetupActor(this, daTpota_c);
+    fopAcM_ct(this, daTpota_c);
     JPABaseEmitter* emitter;
     for (int i = 0; i < 2; i++) {
         mPositions[i] = current.pos;

--- a/src/d/actor/d_a_tsubo.cpp
+++ b/src/d/actor/d_a_tsubo.cpp
@@ -1280,7 +1280,7 @@ cPhs_State Act_c::_create() {
     prmZ_init();
     mType = prm_get_type();
 
-    fopAcM_SetupActor(this, Act_c);
+    fopAcM_ct(this, Act_c);
 
     cPhs_State PVar2;
     if (cLib_checkBit(data().mFlag, DATA_FLAG_1_e)) {

--- a/src/d/actor/d_a_vrbox.cpp
+++ b/src/d/actor/d_a_vrbox.cpp
@@ -180,7 +180,7 @@ static BOOL daVrbox_solidHeapCB(fopAc_ac_c* i_actor) {
 
 /* 8015E968-8015EA14       .text daVrbox_Create__FP10fopAc_ac_c */
 static cPhs_State daVrbox_Create(fopAc_ac_c* i_actor) {
-    fopAcM_SetupActor(i_actor, vrbox_class);
+    fopAcM_ct(i_actor, vrbox_class);
     vrbox_class* i_this = static_cast<vrbox_class*>(i_actor);
 
     i_this->m29C = 0;

--- a/src/d/actor/d_a_vrbox2.cpp
+++ b/src/d/actor/d_a_vrbox2.cpp
@@ -284,7 +284,7 @@ static BOOL daVrbox2_solidHeapCB(fopAc_ac_c* i_actor) {
 
 /* 8015F4D4-8015F550       .text daVrbox2_Create__FP10fopAc_ac_c */
 static cPhs_State daVrbox2_Create(fopAc_ac_c* i_actor) {
-    fopAcM_SetupActor(i_actor, vrbox2_class);
+    fopAcM_ct(i_actor, vrbox2_class);
     vrbox2_class* i_this = static_cast<vrbox2_class*>(i_actor);
 
 #if VERSION == VERSION_DEMO

--- a/src/d/actor/d_a_wall.cpp
+++ b/src/d/actor/d_a_wall.cpp
@@ -138,7 +138,7 @@ void daWall_c::CreateInit() {
 
 /* 00000380-000004EC       .text _create__8daWall_cFv */
 cPhs_State daWall_c::_create() {
-    fopAcM_SetupActor(this, daWall_c);
+    fopAcM_ct(this, daWall_c);
     mType = fopAcM_GetParam(this) >> 8;
     mSwitchNo = fopAcM_GetParam(this) & 0xFF;
     bool isSwitch = dComIfGs_isSwitch(mSwitchNo, fopAcM_GetHomeRoomNo(this));

--- a/src/d/actor/d_a_warpdm20.cpp
+++ b/src/d/actor/d_a_warpdm20.cpp
@@ -131,7 +131,7 @@ void daWarpdm20_c::CreateInit() {
 
 /* 000005C8-000006A0       .text _create__12daWarpdm20_cFv */
 cPhs_State daWarpdm20_c::_create() {
-    fopAcM_SetupActor(this, daWarpdm20_c);
+    fopAcM_ct(this, daWarpdm20_c);
 
     m2D6 = daWarpdm20_prm::getType(this);
     cPhs_State PVar1 = dComIfG_resLoad(&mPhase, m_arcname);

--- a/src/d/actor/d_a_warpfout.cpp
+++ b/src/d/actor/d_a_warpfout.cpp
@@ -36,7 +36,7 @@ void daWarpfout_c::CreateInit() {
 
 /* 0000008C-000000E4       .text _create__12daWarpfout_cFv */
 cPhs_State daWarpfout_c::_create() {
-    fopAcM_SetupActor(this, daWarpfout_c);
+    fopAcM_ct(this, daWarpfout_c);
     CreateInit();
 
     return cPhs_COMPLEATE_e;

--- a/src/d/actor/d_a_warpgn.cpp
+++ b/src/d/actor/d_a_warpgn.cpp
@@ -145,7 +145,7 @@ void daWarpgn_c::CreateInit() {
 cPhs_State daWarpgn_c::_create() {
     cPhs_State rt = cPhs_ERROR_e;
 
-    fopAcM_SetupActor(this, daWarpgn_c);
+    fopAcM_ct(this, daWarpgn_c);
 
     rt = dComIfG_resLoad(&mPhs, m_arcname);
 

--- a/src/d/actor/d_a_warphr.cpp
+++ b/src/d/actor/d_a_warphr.cpp
@@ -140,7 +140,7 @@ void daWarphr_c::CreateInit() {
 
 /* 000006BC-00000768       .text _create__10daWarphr_cFv */
 cPhs_State daWarphr_c::_create() {
-    fopAcM_SetupActor(this, daWarphr_c);
+    fopAcM_ct(this, daWarphr_c);
 
     m2FA = daWarphr_prm::getType(this);
     cPhs_State PVar1 = dComIfG_resLoad(&mPhase, m_arcname);

--- a/src/d/actor/d_a_wbird.cpp
+++ b/src/d/actor/d_a_wbird.cpp
@@ -75,7 +75,7 @@ BOOL daWbird_c::CreateInit() {
 
 /* 00000388-000003E0       .text create__9daWbird_cFv */
 cPhs_State daWbird_c::create() {
-    fopAcM_SetupActor(this, daWbird_c);
+    fopAcM_ct(this, daWbird_c);
     CreateInit();
     return cPhs_COMPLEATE_e;
 }

--- a/src/d/actor/d_a_wind_tag.cpp
+++ b/src/d/actor/d_a_wind_tag.cpp
@@ -207,7 +207,7 @@ void daWindTag_c::set_wind_angle() {
 
 /* 000008D4-0000099C       .text _create__Q29daWindTag11daWindTag_cFv */
 cPhs_State daWindTag_c::_create() {
-    fopAcM_SetupActor(this, daWindTag_c);
+    fopAcM_ct(this, daWindTag_c);
     mType = daWindTag_prm::getType(this);
     cPhs_State rt = dComIfG_resLoad(&mPhs, m_arcname[mType]);
     if (rt == cPhs_COMPLEATE_e) {

--- a/src/d/actor/d_a_windmill.cpp
+++ b/src/d/actor/d_a_windmill.cpp
@@ -270,7 +270,7 @@ void daWindMill_c::search_wind() {
 
 /* 00000670-00000804       .text _create__12daWindMill_cFv */
 cPhs_State daWindMill_c::_create() {
-    fopAcM_SetupActor(this, daWindMill_c);
+    fopAcM_ct(this, daWindMill_c);
 
     mType = fopAcM_GetParam(this) & 0xF;
     cPhs_State res = dComIfG_resLoad(&mPhs, m_arcname[mType]);

--- a/src/d/actor/d_a_ygcwp.cpp
+++ b/src/d/actor/d_a_ygcwp.cpp
@@ -81,7 +81,7 @@ BOOL daYgcwp_c::create_heap() {
 
 /* 0000023C-000003A0       .text _create__9daYgcwp_cFv */
 cPhs_State daYgcwp_c::_create() {
-    fopAcM_SetupActor(this, daYgcwp_c);
+    fopAcM_ct(this, daYgcwp_c);
     cPhs_State rt = dComIfG_resLoad(&mPhs, M_arcname);
     if (rt == cPhs_COMPLEATE_e) {
         rt = cPhs_ERROR_e;

--- a/src/d/actor/d_a_ykgr.cpp
+++ b/src/d/actor/d_a_ykgr.cpp
@@ -127,7 +127,7 @@ static cPhs_State daYkgrCreate(void* i_this) {
 cPhs_State daYkgr_c::_create() {
     u8 uVar4 = fopAcM_GetParam(this) >> 0x14 & 0xF;
 
-    fopAcM_SetupActor(this, daYkgr_c);
+    fopAcM_ct(this, daYkgr_c);
 
     u8 pathIndex = fopAcM_GetParam(this) >> 8 & 0xFF;
     if (pathIndex != 0xff) {

--- a/src/d/actor/d_a_yougan.cpp
+++ b/src/d/actor/d_a_yougan.cpp
@@ -216,7 +216,7 @@ static cPhs_State daYougan_Create(fopAc_ac_c* i_this) {
 
 /* 000008C4-000009C8       .text _daYougan_create__10daYougan_cFv */
 cPhs_State daYougan_c::_daYougan_create() {
-    fopAcM_SetupActor(this, daYougan_c);
+    fopAcM_ct(this, daYougan_c);
 
     cPhs_State state = dComIfG_resLoad(&this->mPhase, m_arcname);
 

--- a/src/d/d_throwstone.cpp
+++ b/src/d/d_throwstone.cpp
@@ -36,7 +36,7 @@ cPhs_State daThrowstone_c::_create() {
     cPhs_State result = dComIfG_resLoad(&mPhs, M_arcname);
 
     if (result == cPhs_COMPLEATE_e) {
-        fopAcM_SetupActor(this, daThrowstone_c);
+        fopAcM_ct(this, daThrowstone_c);
 
         if (!fopAcM_entrySolidHeap(this, CheckCreateHeap, 0x4C0)) {
             result = cPhs_ERROR_e;


### PR DESCRIPTION
The official name of fopAcM_SetupActor in TP is fopAcM_ct so I renamed it, while keeping the old alias around for legacy reasons.

Furthermore, since the devs always called fopAcM_ct in a different spot for the demo version compared to the retail versions, the macro now has two helpers called `fopAcM_ct_Demo` and `fopAcM_ct_Retail` which can be used from now on to simplify the ugly version if/else directives all over the place that make the code harder to read.