### PR TITLE
fix: match d_file_select on PAL

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -599,7 +599,7 @@ config.libs = [
             Object(NonMatching, "d/d_camera.cpp"),
             Object(Matching,    "d/d_envse.cpp"),
             Object(MatchingFor("GZLJ01", "GZLE01", "GZLP01"), "d/d_file_error.cpp"),
-            Object(MatchingFor("D44J01", "GZLJ01", "GZLE01"), "d/d_file_select.cpp"),
+            Object(MatchingFor("D44J01", "GZLJ01", "GZLE01", "GZLP01"), "d/d_file_select.cpp"),
             Object(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d/d_gameover.cpp"),
             Object(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d/d_kankyo.cpp"),
             Object(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d/d_kyeff.cpp"),


### PR DESCRIPTION
## Summary
- mark d/d_file_select.cpp as matching for GZLP01 as well
- closes #766

## Validation
- ninja
- objdiff report: framework/d/d_file_select is 100% fuzzy, 106/106 functions, 59676/59676 code bytes, 1956/1956 data bytes