### PR TITLE
fix: make d_a_dk equivalent for usa and pal

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -354,7 +354,7 @@ def MatchingFor(*versions):
     return config.version in versions
 
 def EquivalentFor(*versions):
-    return False
+    return config.non_matching and config.version in versions
 
 config.warn_missing_config = True
 config.warn_missing_source = False
@@ -1589,7 +1589,7 @@ config.libs = [
     ActorRel(Matching,    "d_a_daiocta"),
     ActorRel(Matching,    "d_a_daiocta_eye"),
     ActorRel(Matching,    "d_a_deku_item"),
-    ActorRel(NonMatching, "d_a_dk"),
+    ActorRel(EquivalentFor("GZLE01", "GZLP01"), "d_a_dk"),
     ActorRel(Matching,    "d_a_dummy"),
     ActorRel(NonMatching, "d_a_fallrock_tag"),
     ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d_a_fan"),

--- a/src/d/actor/d_a_dk.cpp
+++ b/src/d/actor/d_a_dk.cpp
@@ -79,6 +79,7 @@ static void tail_control(dk_class* a_this, tail_s* tail) {
     csXyz* field_9C_ptr = &tail->field_0x09C[1];
     cXyz* field_D8_ptr = &tail->field_0x0D8[1];
 
+    f32 y_2;
     f32 unk = REG0_F(2) + 0.77000004f;
     f32 unk2;
     if (a_this->field_0x2B4 >= 2) {
@@ -102,7 +103,7 @@ static void tail_control(dk_class* a_this, tail_s* tail) {
             y_base = unk2;
         }
 
-        f32 y_2 = y_base - field_24_ptr_prev->y;
+        y_2 = y_base - field_24_ptr_prev->y;
         f32 x_2 = new_vec.x + (field_24_ptr->x - field_24_ptr_prev->x);
         f32 z_2 = new_vec.z + (field_24_ptr->z - field_24_ptr_prev->z);
 
@@ -116,8 +117,8 @@ static void tail_control(dk_class* a_this, tail_s* tail) {
         vec.x = 0.0f;
         vec.y = 0.0f;
 
-        f32 temp = l_HIO.field_0x10 * ((i * 0.03f) + 0.25f) * 20.0f;
-        vec.z = temp * (2.0f * l_HIO.field_0x0C);
+        vec.z = l_HIO.field_0x10 *
+                (2.0f * (((i * 0.03f) + 0.25f) * 20.0f) * l_HIO.field_0x0C);
 
         cMtx_YrotS(*calc_mtx, new_y_angle);
         cMtx_XrotM(*calc_mtx, new_x_angle);


### PR DESCRIPTION
## Summary
- Make `d_a_dk` source-equivalent for GZLE01 and GZLP01: objdiff reports 25/25 functions and 5024/5024 code bytes at 100%.
- Configure `d_a_dk` as `EquivalentFor("GZLE01", "GZLP01")` so normal CI keeps using the original REL and does not claim linked checksum completion.
- Leave JP/demo unclaimed.

## Remaining blocker
- Marking this as `MatchingFor("GZLE01", "GZLP01")` makes both retail CI jobs fail final `build.sha1` on `build/*/d_a_dk/d_a_dk.rel`.
- The remaining mismatch is REL rodata/layout-only: the linked target wants an extra unused `-1.0f` literal before `-10.0f`; source-level attempts either discard the literal or change text/relocation layout.

## Validation
- `uv run python configure.py --map --version GZLE01`
- `ninja all_source progress build/GZLE01/report.json` (`416 files OK`)
- `uv run python configure.py --map --version GZLP01`
- `ninja all_source progress build/GZLP01/report.json` (`416 files OK`)

Related: #285
