### PR TITLE
d_a_grid: 100% equivalent

### DIFF
--- a/config/D44J01/config.yml
+++ b/config/D44J01/config.yml
@@ -3226,19 +3226,15 @@ extract:
 - symbol: l_pos!.data:0x8037F358
   binary: assets/l_grid_pos.bin
   header: assets/l_grid_pos.h
-  rename: l_grid_pos
 - symbol: l_texCoord!.data:0x8037F754
   binary: assets/l_grid_texCoord.bin
   header: assets/l_grid_texCoord.h
-  rename: l_grid_texCoord
 - symbol: l_DL!.data:0x8037FA00
   binary: assets/l_grid_DL.bin
   header: assets/l_grid_DL.h
-  rename: l_grid_DL
 - symbol: l_matDL!.data:0x8037FC40
   binary: assets/l_grid_matDL.bin
   header: assets/l_grid_matDL.h
-  rename: l_grid_matDL
 
 - symbol: l_matDL$4443
   binary: assets/l_matDL__clearAlphaBuffer__FP10view_class.bin

--- a/config/D44J01/config.yml
+++ b/config/D44J01/config.yml
@@ -3223,6 +3223,23 @@ extract:
   binary: assets/l_toonMat1DL.bin
   header: assets/l_toonMat1DL.h
 
+- symbol: l_pos!.data:0x8037F358
+  binary: assets/l_grid_pos.bin
+  header: assets/l_grid_pos.h
+  rename: l_grid_pos
+- symbol: l_texCoord!.data:0x8037F754
+  binary: assets/l_grid_texCoord.bin
+  header: assets/l_grid_texCoord.h
+  rename: l_grid_texCoord
+- symbol: l_DL!.data:0x8037FA00
+  binary: assets/l_grid_DL.bin
+  header: assets/l_grid_DL.h
+  rename: l_grid_DL
+- symbol: l_matDL!.data:0x8037FC40
+  binary: assets/l_grid_matDL.bin
+  header: assets/l_grid_matDL.h
+  rename: l_grid_matDL
+
 - symbol: l_matDL$4443
   binary: assets/l_matDL__clearAlphaBuffer__FP10view_class.bin
   header: assets/l_matDL__clearAlphaBuffer__FP10view_class.h

--- a/config/GZLE01/config.yml
+++ b/config/GZLE01/config.yml
@@ -2804,19 +2804,15 @@ extract:
 - symbol: l_pos!.data:0x8038B1D8
   binary: assets/l_grid_pos.bin
   header: assets/l_grid_pos.h
-  rename: l_grid_pos
 - symbol: l_texCoord!.data:0x8038B5D4
   binary: assets/l_grid_texCoord.bin
   header: assets/l_grid_texCoord.h
-  rename: l_grid_texCoord
 - symbol: l_DL!.data:0x8038B880
   binary: assets/l_grid_DL.bin
   header: assets/l_grid_DL.h
-  rename: l_grid_DL
 - symbol: l_matDL!.data:0x8038BAC0
   binary: assets/l_grid_matDL.bin
   header: assets/l_grid_matDL.h
-  rename: l_grid_matDL
 
 - symbol: l_matDL!.data:0x80376e20
   binary: assets/l_matDL__d_cloth_packet.bin

--- a/config/GZLE01/config.yml
+++ b/config/GZLE01/config.yml
@@ -2801,6 +2801,23 @@ extract:
   binary: assets/l_toonMat1DL.bin
   header: assets/l_toonMat1DL.h
 
+- symbol: l_pos!.data:0x8038B1D8
+  binary: assets/l_grid_pos.bin
+  header: assets/l_grid_pos.h
+  rename: l_grid_pos
+- symbol: l_texCoord!.data:0x8038B5D4
+  binary: assets/l_grid_texCoord.bin
+  header: assets/l_grid_texCoord.h
+  rename: l_grid_texCoord
+- symbol: l_DL!.data:0x8038B880
+  binary: assets/l_grid_DL.bin
+  header: assets/l_grid_DL.h
+  rename: l_grid_DL
+- symbol: l_matDL!.data:0x8038BAC0
+  binary: assets/l_grid_matDL.bin
+  header: assets/l_grid_matDL.h
+  rename: l_grid_matDL
+
 - symbol: l_matDL!.data:0x80376e20
   binary: assets/l_matDL__d_cloth_packet.bin
   header: assets/l_matDL__d_cloth_packet.h

--- a/config/GZLJ01/config.yml
+++ b/config/GZLJ01/config.yml
@@ -2385,6 +2385,23 @@ extract:
   binary: assets/l_toonMat1DL.bin
   header: assets/l_toonMat1DL.h
 
+- symbol: l_pos!.data:0x8037E878
+  binary: assets/l_grid_pos.bin
+  header: assets/l_grid_pos.h
+  rename: l_grid_pos
+- symbol: l_texCoord!.data:0x8037EC74
+  binary: assets/l_grid_texCoord.bin
+  header: assets/l_grid_texCoord.h
+  rename: l_grid_texCoord
+- symbol: l_DL!.data:0x8037EF20
+  binary: assets/l_grid_DL.bin
+  header: assets/l_grid_DL.h
+  rename: l_grid_DL
+- symbol: l_matDL!.data:0x8037F160
+  binary: assets/l_grid_matDL.bin
+  header: assets/l_grid_matDL.h
+  rename: l_grid_matDL
+
 - symbol: l_matDL!.data:0x8036A2C0
   binary: assets/l_matDL__d_cloth_packet.bin
   header: assets/l_matDL__d_cloth_packet.h

--- a/config/GZLJ01/config.yml
+++ b/config/GZLJ01/config.yml
@@ -2388,19 +2388,15 @@ extract:
 - symbol: l_pos!.data:0x8037E878
   binary: assets/l_grid_pos.bin
   header: assets/l_grid_pos.h
-  rename: l_grid_pos
 - symbol: l_texCoord!.data:0x8037EC74
   binary: assets/l_grid_texCoord.bin
   header: assets/l_grid_texCoord.h
-  rename: l_grid_texCoord
 - symbol: l_DL!.data:0x8037EF20
   binary: assets/l_grid_DL.bin
   header: assets/l_grid_DL.h
-  rename: l_grid_DL
 - symbol: l_matDL!.data:0x8037F160
   binary: assets/l_grid_matDL.bin
   header: assets/l_grid_matDL.h
-  rename: l_grid_matDL
 
 - symbol: l_matDL!.data:0x8036A2C0
   binary: assets/l_matDL__d_cloth_packet.bin

--- a/config/GZLP01/config.yml
+++ b/config/GZLP01/config.yml
@@ -2400,19 +2400,15 @@ extract:
 - symbol: l_pos!.data:0x80391EB8
   binary: assets/l_grid_pos.bin
   header: assets/l_grid_pos.h
-  rename: l_grid_pos
 - symbol: l_texCoord!.data:0x803922B4
   binary: assets/l_grid_texCoord.bin
   header: assets/l_grid_texCoord.h
-  rename: l_grid_texCoord
 - symbol: l_DL!.data:0x80392560
   binary: assets/l_grid_DL.bin
   header: assets/l_grid_DL.h
-  rename: l_grid_DL
 - symbol: l_matDL!.data:0x803927A0
   binary: assets/l_grid_matDL.bin
   header: assets/l_grid_matDL.h
-  rename: l_grid_matDL
 
 - symbol: l_matDL!.data:0x8037DB00
   binary: assets/l_matDL__d_cloth_packet.bin

--- a/config/GZLP01/config.yml
+++ b/config/GZLP01/config.yml
@@ -2397,6 +2397,23 @@ extract:
   binary: assets/l_toonMat1DL.bin
   header: assets/l_toonMat1DL.h
 
+- symbol: l_pos!.data:0x80391EB8
+  binary: assets/l_grid_pos.bin
+  header: assets/l_grid_pos.h
+  rename: l_grid_pos
+- symbol: l_texCoord!.data:0x803922B4
+  binary: assets/l_grid_texCoord.bin
+  header: assets/l_grid_texCoord.h
+  rename: l_grid_texCoord
+- symbol: l_DL!.data:0x80392560
+  binary: assets/l_grid_DL.bin
+  header: assets/l_grid_DL.h
+  rename: l_grid_DL
+- symbol: l_matDL!.data:0x803927A0
+  binary: assets/l_grid_matDL.bin
+  header: assets/l_grid_matDL.h
+  rename: l_grid_matDL
+
 - symbol: l_matDL!.data:0x8037DB00
   binary: assets/l_matDL__d_cloth_packet.bin
   header: assets/l_matDL__d_cloth_packet.h

--- a/configure.py
+++ b/configure.py
@@ -578,7 +578,7 @@ config.libs = [
             Object(NonMatching, "d/actor/d_a_demo00.cpp"),
             Object(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d/actor/d_a_disappear.cpp"),
             Object(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d/actor/d_a_esa.cpp"),
-            Object(NonMatching, "d/actor/d_a_grid.cpp"),
+            Object(Equivalent,  "d/actor/d_a_grid.cpp"), # weak func order
             Object(NonMatching, "d/actor/d_a_himo2.cpp"),
             Object(Matching,    "d/actor/d_a_hookshot.cpp"),
             Object(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d/actor/d_a_ib.cpp"),

--- a/include/d/actor/d_a_grid.h
+++ b/include/d/actor/d_a_grid.h
@@ -1,20 +1,55 @@
 #ifndef D_A_GRID_H
 #define D_A_GRID_H
 
+#include "JSystem/J3DGraphBase/J3DPacket.h"
+#include "SSystem/SComponent/c_phase.h"
 #include "f_op/f_op_actor.h"
+#include "m_Do/m_Do_hostIO.h"
 
-class daHo_packet_c {
+class daHo_packet_c : public J3DMatPacket {
 public:
+    daHo_packet_c() {
+        setShapePacket(&mShapePacket);
+        m189C = 0;
+        m189E = 0;
+        m18A0 = 0;
+        mActiveBuffer = 0;
+        mAlpha = 0xFF;
+    }
+
+    Mtx* getMtx() { return &mMtx; }
+    void setTevStr(dKy_tevstr_c* tevStr) { mTevStr = tevStr; }
+    cXyz* getPos() { return mPos[mActiveBuffer]; }
+    cXyz* getNrm() { return mNrm[mActiveBuffer]; }
+    cXyz* getBackNrm() { return mBackNrm[mActiveBuffer]; }
+
     void setBackNrm();
     void setNrmMtx(cXyz&);
     void setNrmVtx(cXyz*, int, int);
     void setTopNrmVtx(cXyz*);
-    void draw();
+    virtual void draw();
+    virtual ~daHo_packet_c() {}
+
+public:
+    /* 0x003C */ J3DShapePacket mShapePacket;
+    /* 0x0080 */ Mtx mMtx;
+    /* 0x00B0 */ dKy_tevstr_c* mTevStr;
+    /* 0x00B4 */ cXyz mPos[2][0x55];
+    /* 0x08AC */ cXyz mNrm[2][0x55];
+    /* 0x10A4 */ cXyz mBackNrm[2][0x55];
+    /* 0x189C */ s16 m189C;
+    /* 0x189E */ s16 m189E;
+    /* 0x18A0 */ s16 m18A0;
+    /* 0x18A2 */ u8 mActiveBuffer;
+    /* 0x18A3 */ u8 mAlpha;
 };
 
 class daGrid_c : public fopAc_ac_c {
 public:
-    void force_calc_wind_rel_angle(short param_1) { m2216 = param_1; m2218 = 1; }
+    void force_calc_wind_rel_angle(short param_1) {
+        mForceWindRelAngle = param_1;
+        mForceWindRelAngleFlag = 1;
+    }
 
     cPhs_State _create();
     bool _delete();
@@ -22,18 +57,67 @@ public:
     bool _draw();
 
 public:
-    /* 0x0290 */ u8 m0290[0x2200 - 0x290];
+    /* 0x0290 */ request_of_phase_process_class mClothPhase;
+    /* 0x0298 */ request_of_phase_process_class mShipPhase;
+    /* 0x02A0 */ daHo_packet_c mPacket;
+    /* 0x1B44 */ u32 m1B44;
+    /* 0x1B48 */ s8 mRoomNo;
+    /* 0x1B49 */ u8 m1B49;
+    /* 0x1B4A */ s16 m1B4A;
+    /* 0x1B4C */ s16 m1B4C;
+    /* 0x1B4E */ s16 m1B4E;
+    /* 0x1B50 */ u8 m1B50[0x1B54 - 0x1B50];
+    /* 0x1B54 */ f32 m1B54[0x55];
+    /* 0x1CA8 */ cXyz m1CA8[0x55];
+    /* 0x20A4 */ u8 m20A4[0x2200 - 0x20A4];
     /* 0x2200 */ f32 m2200;
-    /* 0x2204 */ u8 m2219[0x2216 - 0x2204];
-    /* 0x2216 */ s16 m2216;
-    /* 0x2218 */ u8 m2218;
+    /* 0x2204 */ f32 m2204;
+    /* 0x2208 */ f32 m2208;
+    /* 0x220C */ u8 m220C[0x2210 - 0x220C];
+    /* 0x2210 */ s16 m2210;
+    /* 0x2212 */ s16 m2212;
+    /* 0x2214 */ s16 m2214;
+    /* 0x2216 */ s16 mForceWindRelAngle;
+    /* 0x2218 */ u8 mForceWindRelAngleFlag;
+    /* 0x2219 */ u8 m2219[0x221C - 0x2219];
 };
 
-class daHo_HIO_c {
+class daHo_HIO_c : public JORReflexible {
 public:
-    virtual ~daHo_HIO_c() {}
+    daHo_HIO_c();
+    virtual ~daHo_HIO_c() { mNo = -1; }
 
-    u8 field_0x4[0xa4 - 0x04];
+    void genMessage(JORMContext*) {}
+
+public:
+    /* 0x04 */ s8 mNo;
+    /* 0x05 */ u8 m05;
+    /* 0x06 */ u8 m06;
+    /* 0x07 */ u8 m07;
+    /* 0x08 */ u8 m08;
+    /* 0x09 */ u8 m09[0x0C - 0x09];
+    /* 0x0C */ f32 m0C;
+    /* 0x10 */ f32 m10;
+    /* 0x14 */ f32 m14;
+    /* 0x18 */ f32 m18;
+    /* 0x1C */ f32 m1C;
+    /* 0x20 */ f32 m20;
+    /* 0x24 */ f32 mScaleX;
+    /* 0x28 */ f32 mScaleY;
+    /* 0x2C */ f32 mScaleZ;
+    /* 0x30 */ u8 mFarAlpha;
+    /* 0x31 */ u8 mNearAlpha;
+    /* 0x32 */ u8 m32[0x34 - 0x32];
+    /* 0x34 */ f32 mAlphaDist;
+    /* 0x38 */ u8 mStopMove;
+    /* 0x39 */ u8 mUseHioRates;
+    /* 0x3A */ u8 m3A[0x3C - 0x3A];
+    /* 0x3C */ f32 mDepthRate[0x0D];
+    /* 0x70 */ f32 mWaveRate[0x0D];
 };
+
+STATIC_ASSERT(sizeof(daHo_packet_c) == 0x18A4);
+STATIC_ASSERT(sizeof(daGrid_c) == 0x221C);
+STATIC_ASSERT(sizeof(daHo_HIO_c) == 0xA4);
 
 #endif /* D_A_GRID_H */

--- a/include/d/actor/d_a_grid.h
+++ b/include/d/actor/d_a_grid.h
@@ -9,12 +9,12 @@
 class daHo_packet_c : public J3DMatPacket {
 public:
     daHo_packet_c() {
-        setShapePacket(&mShapePacket);
-        m189C = 0;
-        m189E = 0;
-        m18A0 = 0;
         mActiveBuffer = 0;
+        m189C = 0;
+        m18A0 = 0;
+        m189E = 0;
         mAlpha = 0xFF;
+        setShapePacket(&mShapePacket);
     }
 
     Mtx* getMtx() { return &mMtx; }

--- a/include/d/actor/d_a_grid.h
+++ b/include/d/actor/d_a_grid.h
@@ -84,7 +84,54 @@ public:
 
 class daHo_HIO_c : public JORReflexible {
 public:
-    daHo_HIO_c();
+    daHo_HIO_c() {
+        mNo = -1;
+        m05 = 1;
+        m07 = 0;
+        m14 = 40.0f;
+        m06 = 0;
+        m08 = 0;
+        m18 = 0.5f;
+        m1C = 0.1f;
+        m0C = 0.1f;
+        m20 = 0.4f;
+        mScaleX = 1.0f;
+        mScaleY = 1.0f;
+        mScaleZ = 1.0f;
+        mFarAlpha = 0xFF;
+        mNearAlpha = 0x32;
+        mAlphaDist = 900.0f;
+        mStopMove = 0;
+        mUseHioRates = 0;
+
+        mWaveRate[0] = 1.0f;
+        mWaveRate[1] = 0.425f;
+        mWaveRate[2] = 0.45f;
+        mWaveRate[3] = 0.4f;
+        mWaveRate[4] = 0.2f;
+        mWaveRate[5] = 0.4f;
+        mWaveRate[6] = 0.45f;
+        mWaveRate[7] = 0.4f;
+        mWaveRate[8] = 0.2f;
+        mWaveRate[9] = 0.5f;
+        mWaveRate[10] = 0.75f;
+        mWaveRate[11] = 1.0f;
+        mWaveRate[12] = 1.0f;
+
+        mDepthRate[0] = 0.05f;
+        mDepthRate[1] = 0.125f;
+        mDepthRate[2] = 0.175f;
+        mDepthRate[3] = 0.15f;
+        mDepthRate[4] = 0.0625f;
+        mDepthRate[5] = 0.15f;
+        mDepthRate[6] = 0.2f;
+        mDepthRate[7] = 0.15f;
+        mDepthRate[8] = 0.075f;
+        mDepthRate[9] = 0.175f;
+        mDepthRate[10] = 0.175f;
+        mDepthRate[11] = 0.1f;
+        mDepthRate[12] = 0.0f;
+    }
     virtual ~daHo_HIO_c() { mNo = -1; }
 
     void genMessage(JORMContext*) {}

--- a/include/d/actor/d_a_grid.h
+++ b/include/d/actor/d_a_grid.h
@@ -19,6 +19,8 @@ public:
 
     Mtx* getMtx() { return &mMtx; }
     void setTevStr(dKy_tevstr_c* tevStr) { mTevStr = tevStr; }
+    void setAlpha(u8 alpha) { mAlpha = alpha; }
+    u8 getAlpha() { return mAlpha; }
     cXyz* getPos() { return mPos[mActiveBuffer]; }
     cXyz* getNrm() { return mNrm[mActiveBuffer]; }
     cXyz* getBackNrm() { return mBackNrm[mActiveBuffer]; }

--- a/include/d/actor/d_a_grid.h
+++ b/include/d/actor/d_a_grid.h
@@ -21,6 +21,7 @@ public:
     void setTevStr(dKy_tevstr_c* tevStr) { mTevStr = tevStr; }
     void setAlpha(u8 alpha) { mAlpha = alpha; }
     u8 getAlpha() { return mAlpha; }
+    void changeCurrentPos() { mActiveBuffer ^= 1; }
     cXyz* getPos() { return mPos[mActiveBuffer]; }
     cXyz* getNrm() { return mNrm[mActiveBuffer]; }
     cXyz* getBackNrm() { return mBackNrm[mActiveBuffer]; }

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -308,7 +308,7 @@ void ho_move(daGrid_c* i_this) {
     i_this->m1B4C = 0x1D4C;
     i_this->m1B4E = 0x1C20;
 
-    s16 shipSailAngle = l_ship->mSailAngle;
+    s16 shipSailAngle = l_ship->getSailAngle();
     s16 windAngle = cM_atan2s(windVec->x, windVec->z);
     s16 windRelAngle = (s16)(i_this->current.angle.y + shipSailAngle) - windAngle;
     s16 targetWindAngle = windRelAngle + 0x8000;
@@ -324,7 +324,7 @@ void ho_move(daGrid_c* i_this) {
     if (i_this->mForceWindRelAngleFlag == 0) {
         cLib_addCalcAngleS2(&i_this->m2210, targetAngle, 4, 0x1000);
     } else {
-        s16 forceTarget = i_this->mForceWindRelAngle - l_ship->mSailAngle + 0x8000;
+        s16 forceTarget = i_this->mForceWindRelAngle - l_ship->getSailAngle() + 0x8000;
         cLib_addCalcAngleS2(&i_this->m2210, forceTarget, 2, 0x1400);
     }
     i_this->mForceWindRelAngleFlag = 0;
@@ -344,13 +344,7 @@ void ho_move(daGrid_c* i_this) {
 
     f32 windWaveRate = 1.0f + (0.01f + REG6_F(15)) * (windSide * cM_ssin(i_this->m1B44));
     s32 calcWaveSpeed = 2500.0f + (9000.0f * (0.8f * windPow));
-    s32 waveSpeed;
-    if (calcWaveSpeed > 10000) {
-        waveSpeed = 10000;
-    } else {
-        waveSpeed = calcWaveSpeed;
-    }
-    i_this->m1B44 += waveSpeed;
+    i_this->m1B44 += cLib_maxLimit(calcWaveSpeed, (s32)10000);
 
     i_this->m2212 += (s16)(3000.0f * cM_scos(windRelAngle));
     s16 windAngleStep;
@@ -368,7 +362,7 @@ void ho_move(daGrid_c* i_this) {
     cXyz* pos = i_this->mPacket.getPos();
 
     if (l_HIO.m08 == 0) {
-        if (l_ship->mStateFlag & 0x200) {
+        if (l_ship->getSailOn()) {
             if (i_this->m2208 == 0.0f) {
                 if (i_this->m2200 <= 0.0001f + l_HIO.m0C) {
                     i_this->m2208 = 1.0f;
@@ -407,11 +401,11 @@ void ho_move(daGrid_c* i_this) {
         MtxPosition(&localIn, &localWind);
         f32 localWindX = localWind.x;
         f32 xLimit = 0.25f + 0.75f * windPow;
-        localWind.x = localWindX * (xLimit > 1.0f ? 1.0f : xLimit);
+        localWind.x = localWindX * cLib_maxLimit(xLimit, 1.0f);
 
         f32 localWindZ = localWind.z;
         f32 zLimit = 0.5f + 0.25f * windPow;
-        localWind.z = localWindZ * (zLimit > 1.0f ? 1.0f : zLimit);
+        localWind.z = localWindZ * cLib_maxLimit(zLimit, 1.0f);
 
         xWave += i_this->m2204 * (clothOpen * (windWaveRate * localWind.x));
         zWave += i_this->m2204 * (clothOpen * (windSide * localWind.z));
@@ -652,7 +646,7 @@ bool daGrid_c::_delete() {
 bool daGrid_c::_execute() {
     daGrid_c* i_this = this;
     u8 targetAlpha;
-    int alpha = i_this->mPacket.mAlpha;
+    int alpha = i_this->mPacket.getAlpha();
 
     if (!dComIfGp_event_runCheck()) {
         cXyz eye = dComIfGp_getCamera(0)->mCamera.Eye();
@@ -669,11 +663,11 @@ bool daGrid_c::_execute() {
     }
 
     if (targetAlpha > alpha + 5) {
-        i_this->mPacket.mAlpha = alpha + 5;
+        i_this->mPacket.setAlpha(alpha + 5);
     } else if (targetAlpha < alpha - 5) {
-        i_this->mPacket.mAlpha = alpha - 5;
+        i_this->mPacket.setAlpha(alpha - 5);
     } else {
-        i_this->mPacket.mAlpha = targetAlpha;
+        i_this->mPacket.setAlpha(targetAlpha);
     }
 
     if (i_this->scale.y < 0.06f) {
@@ -697,7 +691,7 @@ bool daGrid_c::_draw() {
     cMtx_YrotM(*calc_mtx, current.angle.y);
     cMtx_XrotM(*calc_mtx, current.angle.x);
     cMtx_ZrotM(*calc_mtx, current.angle.z);
-    s16 shipSailAngle = l_ship->mSailAngle;
+    s16 shipSailAngle = l_ship->getSailAngle();
     cMtx_YrotM(*calc_mtx, shipSailAngle);
     MtxScale(1.0f, scale.y, 1.0f, true);
     MtxScale(l_HIO.mScaleX, l_HIO.mScaleY, l_HIO.mScaleZ, true);

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -31,21 +31,6 @@ static daHo_HIO_c l_HIO;
 #include "assets/l_grid_DL.h"
 #include "assets/l_grid_matDL.h"
 
-static f32 l_defaultDepthRate[] = {
-    0.05f, 0.125f, 0.175f, 0.15f, 0.0625f, 0.15f, 0.2f,
-    0.15f, 0.075f, 0.175f, 0.175f, 0.1f, 0.0f,
-};
-
-static f32 l_defaultWaveRate[] = {
-    1.0f, 0.425f, 0.45f, 0.4f, 0.2f, 0.4f, 0.45f,
-    0.4f, 0.2f, 0.5f, 0.75f, 1.0f, 1.0f,
-};
-
-static f32 l_xRate[] = {
-    1.0f, 0.95f, 0.9f, 0.85f, 0.8f, 0.75f, 0.7f,
-    0.65f, 0.55f, 0.4f, 0.25f, 0.1f, 0.0f,
-};
-
 /* 800E8CC0-800E8D48       .text setBackNrm__13daHo_packet_cFv */
 void daHo_packet_c::setBackNrm() {
     cXyz* nrm = getNrm();
@@ -166,7 +151,7 @@ void daHo_packet_c::draw() {
 
     GXSetArray(GX_VA_POS, getPos(), sizeof(cXyz));
     GXSetArray(GX_VA_NRM, getNrm(), sizeof(cXyz));
-    GXSetArray(GX_VA_TEX0, l_grid_texCoord, sizeof(cXy));
+    GXSetArray(GX_VA_TEX0, l_texCoord, sizeof(cXy));
 
     GXTexObj texObj;
     GXTlutObj tlutObj;
@@ -275,17 +260,17 @@ void daHo_packet_c::draw() {
     GXSetTevColorS10(GX_TEVREG0, mTevStr->mColorC0);
     GXSetTevColor(GX_TEVREG1, mTevStr->mColorK0);
     GXSetTevColor(GX_TEVREG2, mTevStr->mColorK1);
-    GXCallDisplayList(l_grid_matDL, 0x20);
+    GXCallDisplayList(l_matDL, 0x20);
 
     GXLoadPosMtxImm(*getMtx(), 0);
     GXLoadNrmMtxImm(*getMtx(), 0);
 
     GXSetCullMode(GX_CULL_BACK);
-    GXCallDisplayList(l_grid_DL, 0x220);
+    GXCallDisplayList(l_DL, 0x220);
 
     GXSetCullMode(GX_CULL_FRONT);
     GXSetArray(GX_VA_NRM, getBackNrm(), sizeof(cXyz));
-    GXCallDisplayList(l_grid_DL, 0x220);
+    GXCallDisplayList(l_DL, 0x220);
 
     J3DShape::resetVcdVatCache();
 }
@@ -297,6 +282,21 @@ static BOOL daGrid_Draw(daGrid_c* i_this) {
 
 /* 800E9C0C-800EA928       .text ho_move__FP8daGrid_c */
 void ho_move(daGrid_c* i_this) {
+    static f32 z_rate_tbl[] = {
+        0.05f, 0.125f, 0.175f, 0.15f, 0.0625f, 0.15f, 0.2f,
+        0.15f, 0.075f, 0.175f, 0.175f, 0.1f, 0.0f,
+    };
+
+    static f32 z_rate_tbl2[] = {
+        1.0f, 0.425f, 0.45f, 0.4f, 0.2f, 0.4f, 0.45f,
+        0.4f, 0.2f, 0.5f, 0.75f, 1.0f, 1.0f,
+    };
+
+    static f32 x_rate_tbl[] = {
+        1.0f, 0.95f, 0.9f, 0.85f, 0.8f, 0.75f, 0.7f,
+        0.65f, 0.55f, 0.4f, 0.25f, 0.1f, 0.0f,
+    };
+
     if (l_HIO.mStopMove != 0) {
         return;
     }
@@ -362,7 +362,7 @@ void ho_move(daGrid_c* i_this) {
     i_this->m2212 += windAngleStep;
 
     f32 windBend = 0.5f * cM_ssin(windRelAngle);
-    Vec* gridPos = (Vec*)l_grid_pos;
+    Vec* gridPos = (Vec*)l_pos;
     localIn.x = 0.0f;
     localIn.z = 1.6f;
     cXyz* pos = i_this->mPacket.getPos();
@@ -398,7 +398,7 @@ void ho_move(daGrid_c* i_this) {
         f32 clothOpen = 1.0f - i_this->m2200;
         f32 colCenter = 3 - col;
         f32 rowCenter = row - 2;
-        f32 xRate = l_xRate[row];
+        f32 xRate = x_rate_tbl[row];
         s16 rowWaveAngle = 10922.0f * xRate;
 
         f32 xWave = windDepth * cM_ssin(i_this->m1B44 + i * i_this->m1B4C);
@@ -434,8 +434,8 @@ void ho_move(daGrid_c* i_this) {
             depthSwing *= depthRate * i_this->m2200;
             rowSwing = 5.0f * depthRate * col * i_this->m2200;
         } else {
-            foldRate *= clothOpen + l_defaultWaveRate[row] * i_this->m2200;
-            depthRate = l_defaultDepthRate[row];
+            foldRate *= clothOpen + z_rate_tbl2[row] * i_this->m2200;
+            depthRate = z_rate_tbl[row];
             depthSwing *= depthRate * i_this->m2200;
             rowSwing = 5.0f * depthRate * col * i_this->m2200;
         }
@@ -467,7 +467,7 @@ void ho_move(daGrid_c* i_this) {
         if (l_HIO.mUseHioRates != 0) {
             zSag *= i_this->m2200 * (6.0f * l_HIO.mDepthRate[row] * (col / 6.0f));
         } else {
-            zSag *= i_this->m2200 * (6.0f * l_defaultDepthRate[row] * (col / 6.0f));
+            zSag *= i_this->m2200 * (6.0f * z_rate_tbl[row] * (col / 6.0f));
         }
 
         pos->x += depthSwing + (0.35f * clothOpen + 0.65f) * (i_this->m2204 * xWave);
@@ -558,7 +558,7 @@ cPhs_State daGrid_c::_create() {
     }
 
     int i = 0;
-    Vec* gridPos = (Vec*)l_grid_pos;
+    Vec* gridPos = (Vec*)l_pos;
     for (; i < 0x55; i++) {
         f32 baseAmplitude;
         if (i >= 0 && i <= 6) {

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -555,8 +555,9 @@ cPhs_State daGrid_c::_create() {
         l_HIO.mNo = mDoHIO_root.m_subroot.createChild("\221D\202\314\224\277", &l_HIO);
     }
 
+    int i = 0;
     Vec* gridPos = (Vec*)l_grid_pos;
-    for (int i = 0; i < 0x55; i++) {
+    for (; i < 0x55; i++) {
         f32 baseAmplitude;
         if (i >= 0 && i <= 6) {
             baseAmplitude = 40.0f;

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -445,8 +445,9 @@ void ho_move(daGrid_c* i_this) {
         pos->z = foldRate * gridPos[i].z;
 
         s16 colWaveAngle = i_this->m2212 + rowWaveAngle * col;
+        f32 colWaveSin = cM_ssin(colWaveAngle);
         f32 rowShape = 9.0f - SQUARE(colCenter);
-        f32 depthShape = ((i_this->m2200 * cM_ssin(colWaveAngle) * rowShape) / 9.0f) -
+        f32 depthShape = ((i_this->m2200 * colWaveSin * rowShape) / 9.0f) -
                          ((windBend * rowShape) / 9.0f);
         depthSwing *= depthShape;
         rowSwing *= (i_this->m2200 * cM_scos(colWaveAngle) * col) / 6.0f;

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -557,6 +557,7 @@ cPhs_State daGrid_c::_create() {
         l_HIO.mNo = mDoHIO_root.m_subroot.createChild("\221D\202\314\224\277", &l_HIO);
     }
 
+    int columnTop;
     int i = 0;
     Vec* gridPos = (Vec*)l_pos;
     for (; i < 0x55; i++) {
@@ -571,7 +572,7 @@ cPhs_State daGrid_c::_create() {
             baseAmplitude = 80.0f;
         }
 
-        int columnTop = 6;
+        columnTop = 6;
 
         f32 edgeDistA = std::fabsf(gridPos[0].z - gridPos[i].z);
         f32 edgeDistB = std::fabsf(gridPos[6].z - gridPos[i].z);

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -410,11 +410,11 @@ void ho_move(daGrid_c* i_this) {
         f32 zLimit = 0.5f + 0.25f * windPow;
         localWind.z = localWindZ * cLib_maxLimit(zLimit, 1.0f);
 
-        xWave += i_this->m2204 * (clothOpen * (windWaveRate * localWind.x));
-        zWave += i_this->m2204 * (clothOpen * (windSide * localWind.z));
+        xWave += i_this->m2204 * (clothOpen * (localWind.x * windWaveRate));
+        zWave += i_this->m2204 * (clothOpen * (localWind.z * windSide));
 
         f32 waveLen = std::sqrtf(SQUARE(xWave) + SQUARE(zWave));
-        f32 yWave = 0.25f * waveLen;
+        f32 yWave = 0.05f * waveLen;
         f32 waveAmp = i_this->m1B54[i];
         xWave *= waveAmp;
         yWave *= waveAmp;
@@ -467,9 +467,9 @@ void ho_move(daGrid_c* i_this) {
             zSag *= i_this->m2200 * (6.0f * z_rate_tbl[row] * (col / 6.0f));
         }
 
-        pos->x += depthSwing + (0.35f * clothOpen + 0.65f) * (i_this->m2204 * xWave);
-        pos->y += rowSwing + (0.35f * clothOpen + 0.65f) * yWave;
-        pos->z += zSag + ((0.35f * clothOpen + 0.65f) * (i_this->m2204 * zWave) - 13.75f);
+        pos->x += depthSwing + (0.35f * clothOpen + 0.65f) * (xWave * i_this->m2204);
+        pos->y += rowSwing + yWave * (0.35f * clothOpen + 0.65f);
+        pos->z += zSag + ((0.35f * clothOpen + 0.65f) * (zWave * i_this->m2204) - 13.75f);
 
         row = col < 6 ? row : row + 1;
         col = col < 6 ? col + 1 : 0;

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -349,9 +349,11 @@ void ho_move(daGrid_c* i_this) {
     i_this->m1B44 += waveSpeed;
 
     i_this->m2212 += (s16)(3000.0f * cM_scos(windRelAngle));
-    s16 windAngleStep = -300;
+    s16 windAngleStep;
     if (i_this->m2212 > 0) {
         windAngleStep = 300;
+    } else {
+        windAngleStep = -300;
     }
     i_this->m2212 += windAngleStep;
 

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -390,7 +390,7 @@ void ho_move(daGrid_c* i_this) {
     MtxPosition(&localIn, &localWind);
     f32 windSide = std::fabsf(localWind.z) * (1.0f - i_this->m2200);
 
-    f32 windWaveRate = 1.0f + (0.01f + REG6_F(15)) * windSide * cM_ssin(i_this->m1B44);
+    f32 windWaveRate = 1.0f + (0.01f + REG6_F(15)) * (windSide * cM_ssin(i_this->m1B44));
     s32 waveSpeed = 2500.0f + (9000.0f * (0.8f * windPow));
     if (waveSpeed > 10000) {
         waveSpeed = 10000;
@@ -445,7 +445,7 @@ void ho_move(daGrid_c* i_this) {
         s16 rowWaveAngle = 10922.0f * xRate;
 
         f32 xWave = windDepth * cM_ssin(i_this->m1B44 + i * i_this->m1B4C);
-        f32 zWave = 0.5f * windDepth * cM_scos(i_this->m1B44 + i * i_this->m1B4E);
+        f32 zWave = 0.5f * (windDepth * cM_scos(i_this->m1B44 + i * i_this->m1B4E));
 
         MtxPosition(&localIn, &localWind);
         f32 xLimit = 0.25f + 0.75f * windPow;
@@ -460,8 +460,8 @@ void ho_move(daGrid_c* i_this) {
         }
         localWind.z *= zLimit;
 
-        xWave += i_this->m2204 * clothOpen * windWaveRate * localWind.x;
-        zWave += i_this->m2204 * clothOpen * windSide * localWind.z;
+        xWave += i_this->m2204 * (clothOpen * (windWaveRate * localWind.x));
+        zWave += i_this->m2204 * (clothOpen * (windSide * localWind.z));
 
         f32 waveLen = std::sqrtf(SQUARE(xWave) + SQUARE(zWave));
         f32 yWave = 0.25f * waveLen;
@@ -500,18 +500,18 @@ void ho_move(daGrid_c* i_this) {
         rowSwing *= xAtten;
 
         f32 swingLen = std::sqrtf(SQUARE(depthSwing) + SQUARE(rowSwing));
-        f32 zSag = -0.25f * swingLen;
+        f32 zSag = 0.25f * -swingLen;
         if (col > 4) {
-            f32 edgeWave = std::fabsf(cM_ssin(i_this->m2212 + rowWaveAngle * col * 2));
-            zSag += 4.25f * (col - 4) * edgeWave;
+            f32 edgeWave = std::fabsf(cM_ssin(i_this->m2212 + (rowWaveAngle * 2) * col));
+            zSag += 4.25f * ((col - 4) * edgeWave);
         }
 
         zSag *= i_this->m2200 * (6.0f * depthRate * (col / 6.0f));
 
         f32 waveScale = 0.35f * clothOpen + 0.65f;
-        pos->x += depthSwing + waveScale * i_this->m2204 * xWave;
+        pos->x += depthSwing + waveScale * (i_this->m2204 * xWave);
         pos->y += rowSwing + waveScale * yWave;
-        pos->z += zSag + waveScale * i_this->m2204 * zWave - 13.75f;
+        pos->z += zSag + waveScale * (i_this->m2204 * zWave) - 13.75f;
 
         if (col >= 6) {
             col = 0;
@@ -521,12 +521,12 @@ void ho_move(daGrid_c* i_this) {
         }
     }
 
-    f32 topZ = std::fabsf(i_this->mPacket.getPos()[59].z);
-    f32 row8Rate = 1.0f - topZ * (0.0015f + REG6_F(8));
-    f32 row7Rate = 1.0f - topZ * (0.00070000003f + REG6_F(9));
-    f32 row6Rate = 1.0f - topZ * (0.00020000007f + REG6_F(10));
-    f32 row9Rate = 1.0f - topZ * (0.0015f + REG6_F(11));
-    f32 row10Rate = 1.0f - topZ * (0.0012f + REG6_F(12));
+    f32 topX = std::fabsf(i_this->mPacket.getPos()[59].x);
+    f32 row8Rate = 1.0f - topX * (0.0015f + REG6_F(8));
+    f32 row7Rate = 1.0f - topX * (0.00070000003f + REG6_F(9));
+    f32 row6Rate = 1.0f - topX * (0.00020000007f + REG6_F(10));
+    f32 row9Rate = 1.0f - topX * (0.0015f + REG6_F(11));
+    f32 row10Rate = 1.0f - topX * (0.0012f + REG6_F(12));
 
     pos = i_this->mPacket.getPos();
     for (int i = 0; i < 0x55; i++, pos++) {

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -462,7 +462,11 @@ void ho_move(daGrid_c* i_this) {
             zSag += 4.25f * ((col - 4) * edgeWave);
         }
 
-        zSag *= i_this->m2200 * (6.0f * depthRate * (col / 6.0f));
+        if (l_HIO.mUseHioRates != 0) {
+            zSag *= i_this->m2200 * (6.0f * l_HIO.mDepthRate[row] * (col / 6.0f));
+        } else {
+            zSag *= i_this->m2200 * (6.0f * l_defaultDepthRate[row] * (col / 6.0f));
+        }
 
         f32 waveScale = 0.35f * clothOpen + 0.65f;
         pos->x += depthSwing + waveScale * (i_this->m2204 * xWave);

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -398,13 +398,17 @@ void ho_move(daGrid_c* i_this) {
     i_this->m1B44 += waveSpeed;
 
     i_this->m2212 += (s16)(3000.0f * cM_scos(windRelAngle));
+    s16 windAngleStep = -300;
     if (i_this->m2212 > 0) {
-        i_this->m2212 += 300;
-    } else {
-        i_this->m2212 -= 300;
+        windAngleStep = 300;
     }
+    i_this->m2212 += windAngleStep;
 
     f32 windBend = 0.5f * cM_ssin(windRelAngle);
+    Vec* gridPos = (Vec*)l_grid_pos;
+    cXyz* pos = i_this->mPacket.getPos();
+    localIn.x = 0.0f;
+    localIn.z = 1.6f;
 
     if (l_HIO.m08 == 0) {
         if (l_ship->mStateFlag & 0x200) {
@@ -430,12 +434,8 @@ void ho_move(daGrid_c* i_this) {
         i_this->m2200 = l_HIO.m10;
     }
 
-    Vec* gridPos = (Vec*)l_grid_pos;
-    cXyz* pos = i_this->mPacket.getPos();
     int row = 0;
     int col = 0;
-    localIn.x = 0.0f;
-    localIn.z = 1.6f;
 
     for (int i = 0; i < 0x55; i++, pos++) {
         f32 clothOpen = 1.0f - i_this->m2200;

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -446,11 +446,12 @@ void ho_move(daGrid_c* i_this) {
 
         s16 colWaveAngle = i_this->m2212 + rowWaveAngle * col;
         f32 colWaveSin = cM_ssin(colWaveAngle);
+        f32 colWaveCos = cM_scos(colWaveAngle);
         f32 rowShape = 9.0f - SQUARE(colCenter);
         f32 depthShape = ((i_this->m2200 * colWaveSin * rowShape) / 9.0f) -
                          ((windBend * rowShape) / 9.0f);
         depthSwing *= depthShape;
-        rowSwing *= (i_this->m2200 * cM_scos(colWaveAngle) * col) / 6.0f;
+        rowSwing *= (i_this->m2200 * colWaveCos * col) / 6.0f;
 
         f32 xAtten = 1.0f - 0.5f * (SQUARE(upperRow) * 0.25f);
         rowSwing *= xAtten;

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -390,8 +390,8 @@ void ho_move(daGrid_c* i_this) {
         i_this->m2200 = l_HIO.m10;
     }
 
-    int row = 0;
     int col = 0;
+    int row = 0;
 
     for (int i = 0; i < 0x55; i++, pos++) {
         f32 clothOpen = 1.0f - i_this->m2200;

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -577,7 +577,8 @@ cPhs_State daGrid_c::_create() {
         f32 edgeDistA = std::fabsf(gridPos[0].z - gridPos[i].z);
         f32 edgeDistB = std::fabsf(gridPos[6].z - gridPos[i].z);
         f32 edgeDist = std::fabsf(gridPos[0].z - gridPos[6].z);
-        f32 edgeRate = 1.05f * (1.5707964f / (edgeDist * 0.5f));
+        edgeDist *= 0.5f;
+        f32 edgeRate = 1.05f * (1.5707964f / edgeDist);
         if (edgeDistA > edgeDistB) {
             edgeDistA = edgeDistB;
         }
@@ -602,7 +603,8 @@ cPhs_State daGrid_c::_create() {
             verticalDistA = std::fabsf(gridPos[0].y - gridPos[i].y);
             verticalDistB = std::fabsf(gridPos[columnTop].y - gridPos[i].y);
             verticalEdgeDist = std::fabsf(gridPos[columnTop].y - gridPos[0].y);
-            verticalRate = 1.05f * (1.5707964f / (verticalEdgeDist * 0.5f));
+            verticalEdgeDist *= 0.5f;
+            verticalRate = 1.05f * (1.5707964f / verticalEdgeDist);
             if (columnTop == 56) {
                 verticalAmplitude = 35.0f;
             } else if (columnTop == 57) {
@@ -614,7 +616,8 @@ cPhs_State daGrid_c::_create() {
             verticalDistA = std::fabsf(gridPos[columnTop].y - gridPos[i].y);
             verticalDistB = std::fabsf(gridPos[84].y - gridPos[i].y);
             verticalEdgeDist = std::fabsf(gridPos[columnTop].y - gridPos[84].y);
-            verticalRate = 1.15f * (1.5707964f / (verticalEdgeDist * 0.5f));
+            verticalEdgeDist *= 0.5f;
+            verticalRate = 1.15f * (1.5707964f / verticalEdgeDist);
             verticalAmplitude = 20.0f;
         }
 

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -470,11 +470,9 @@ void ho_move(daGrid_c* i_this) {
         pos->z += zSag + waveScale * (i_this->m2204 * zWave) - 13.75f;
 
         if (col >= 6) {
-            col = 0;
             row++;
-        } else {
-            col++;
         }
+        col = col < 6 ? col + 1 : 0;
     }
 
     pos = i_this->mPacket.getPos();

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -646,7 +646,7 @@ bool daGrid_c::_delete() {
 bool daGrid_c::_execute() {
     daGrid_c* i_this = this;
     u8 targetAlpha;
-    int alpha = i_this->mPacket.getAlpha();
+    u8 alpha = i_this->mPacket.getAlpha();
 
     if (!dComIfGp_event_runCheck()) {
         cXyz eye = dComIfGp_getCamera(0)->mCamera.Eye();

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -446,11 +446,11 @@ void ho_move(daGrid_c* i_this) {
 
         s16 colWaveAngle = i_this->m2212 + rowWaveAngle * col;
         f32 colWaveSin = cM_ssin(colWaveAngle);
-        f32 colWaveCos = cM_scos(colWaveAngle);
         f32 rowShape = 9.0f - SQUARE(colCenter);
         f32 depthShape = ((i_this->m2200 * colWaveSin * rowShape) / 9.0f) -
                          ((windBend * rowShape) / 9.0f);
         depthSwing *= depthShape;
+        f32 colWaveCos = cM_scos(colWaveAngle);
         rowSwing *= (i_this->m2200 * colWaveCos * col) / 6.0f;
 
         f32 xAtten = 1.0f - 0.5f * (SQUARE(upperRow) * 0.25f);

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -426,17 +426,17 @@ void ho_move(daGrid_c* i_this) {
         f32 upperRow = rowCenter < 0.0f ? rowCenter : 0.0f;
         f32 foldRate = 1.0f - ((0.67f + 0.3f * (SQUARE(upperRow) * 0.25f)) * i_this->m2200);
         f32 depthRate;
-        f32 depthSwing;
+        f32 depthSwing = 120.0f;
         f32 rowSwing;
         if (l_HIO.mUseHioRates != 0) {
             foldRate *= clothOpen + l_HIO.mWaveRate[row] * i_this->m2200;
             depthRate = l_HIO.mDepthRate[row];
-            depthSwing = 120.0f * (depthRate * i_this->m2200);
+            depthSwing *= depthRate * i_this->m2200;
             rowSwing = 5.0f * depthRate * row * i_this->m2200;
         } else {
             foldRate *= clothOpen + l_defaultWaveRate[row] * i_this->m2200;
             depthRate = l_defaultDepthRate[row];
-            depthSwing = 120.0f * (depthRate * i_this->m2200);
+            depthSwing *= depthRate * i_this->m2200;
             rowSwing = 5.0f * depthRate * row * i_this->m2200;
         }
 

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -359,9 +359,9 @@ void ho_move(daGrid_c* i_this) {
 
     f32 windBend = 0.5f * cM_ssin(windRelAngle);
     Vec* gridPos = (Vec*)l_grid_pos;
-    cXyz* pos = i_this->mPacket.getPos();
     localIn.x = 0.0f;
     localIn.z = 1.6f;
+    cXyz* pos = i_this->mPacket.getPos();
 
     if (l_HIO.m08 == 0) {
         if (l_ship->mStateFlag & 0x200) {

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -304,7 +304,7 @@ void ho_move(daGrid_c* i_this) {
     cXyz* windVec = dKyw_get_wind_vec();
     f32 windPow = dKyw_get_wind_pow();
 
-    i_this->mPacket.mActiveBuffer ^= 1;
+    i_this->mPacket.changeCurrentPos();
     i_this->m1B4C = 0x1D4C;
     i_this->m1B4E = 0x1C20;
 

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -593,7 +593,7 @@ cPhs_State daGrid_c::_create() {
         f32 verticalLimit;
         f32 verticalRate;
         if (gridPos[i].y < gridPos[columnTop].y) {
-            verticalDist = std::fabsf(gridPos[0].y - gridPos[i].y);
+            verticalDist = std::fabsf(gridPos[i].y - gridPos[0].y);
             verticalLimit = std::fabsf(gridPos[columnTop].y - gridPos[i].y);
             f32 verticalEdgeDist = std::fabsf(gridPos[columnTop].y - gridPos[0].y);
             verticalEdgeDist *= 0.5f;
@@ -607,7 +607,7 @@ cPhs_State daGrid_c::_create() {
             }
         } else {
             verticalDist = std::fabsf(gridPos[columnTop].y - gridPos[i].y);
-            verticalLimit = std::fabsf(gridPos[84].y - gridPos[i].y);
+            verticalLimit = std::fabsf(gridPos[i].y - gridPos[84].y);
             f32 verticalEdgeDist = std::fabsf(gridPos[columnTop].y - gridPos[84].y);
             verticalEdgeDist *= 0.5f;
             verticalRate = 1.15f * (1.5707964f / verticalEdgeDist);

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -472,16 +472,12 @@ void ho_move(daGrid_c* i_this) {
 
         f32 upperRow = rowCenter < 0.0f ? rowCenter : 0.0f;
         f32 foldRate = 1.0f - ((0.67f + 0.3f * (SQUARE(upperRow) * 0.25f)) * i_this->m2200);
-        if (l_HIO.mUseHioRates != 0) {
-            foldRate *= clothOpen + l_HIO.mWaveRate[row] * i_this->m2200;
-        } else {
-            foldRate *= clothOpen + l_defaultWaveRate[row] * i_this->m2200;
-        }
-
         f32 depthRate;
         if (l_HIO.mUseHioRates != 0) {
+            foldRate *= clothOpen + l_HIO.mWaveRate[row] * i_this->m2200;
             depthRate = l_HIO.mDepthRate[row];
         } else {
+            foldRate *= clothOpen + l_defaultWaveRate[row] * i_this->m2200;
             depthRate = l_defaultDepthRate[row];
         }
 

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -592,10 +592,12 @@ cPhs_State daGrid_c::_create() {
         f32 verticalDist;
         f32 verticalLimit;
         f32 verticalRate;
-        if (gridPos[i].y < gridPos[columnTop].y) {
-            verticalDist = std::fabsf(gridPos[i].y - gridPos[0].y);
-            verticalLimit = std::fabsf(gridPos[columnTop].y - gridPos[i].y);
-            f32 verticalEdgeDist = std::fabsf(gridPos[columnTop].y - gridPos[0].y);
+        f32 currentY = gridPos[i].y;
+        Vec* topPos = &gridPos[columnTop];
+        if (currentY < topPos->y) {
+            verticalDist = std::fabsf(currentY - gridPos[0].y);
+            verticalLimit = std::fabsf(topPos->y - currentY);
+            f32 verticalEdgeDist = std::fabsf(gridPos[0].y - topPos->y);
             verticalEdgeDist *= 0.5f;
             verticalRate = 1.05f * (1.5707964f / verticalEdgeDist);
             if (columnTop == 56) {
@@ -606,9 +608,9 @@ cPhs_State daGrid_c::_create() {
                 verticalAmplitude = 80.0f;
             }
         } else {
-            verticalDist = std::fabsf(gridPos[columnTop].y - gridPos[i].y);
-            verticalLimit = std::fabsf(gridPos[i].y - gridPos[84].y);
-            f32 verticalEdgeDist = std::fabsf(gridPos[columnTop].y - gridPos[84].y);
+            verticalDist = std::fabsf(topPos->y - currentY);
+            verticalLimit = std::fabsf(currentY - gridPos[84].y);
+            f32 verticalEdgeDist = std::fabsf(gridPos[84].y - topPos->y);
             verticalEdgeDist *= 0.5f;
             verticalRate = 1.15f * (1.5707964f / verticalEdgeDist);
             verticalAmplitude = 20.0f;

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -405,16 +405,10 @@ void ho_move(daGrid_c* i_this) {
 
         MtxPosition(&localIn, &localWind);
         f32 xLimit = 0.25f + 0.75f * windPow;
-        if (xLimit > 1.0f) {
-            xLimit = 1.0f;
-        }
-        localWind.x *= xLimit;
+        localWind.x *= xLimit > 1.0f ? 1.0f : xLimit;
 
         f32 zLimit = 0.5f + 0.25f * windPow;
-        if (zLimit > 1.0f) {
-            zLimit = 1.0f;
-        }
-        localWind.z *= zLimit;
+        localWind.z *= zLimit > 1.0f ? 1.0f : zLimit;
 
         xWave += i_this->m2204 * (clothOpen * (windWaveRate * localWind.x));
         zWave += i_this->m2204 * (clothOpen * (windSide * localWind.z));

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -387,6 +387,8 @@ void ho_move(daGrid_c* i_this) {
 
     int col = 0;
     int row = 0;
+    f32 xWave;
+    f32 zWave;
 
     for (int i = 0; i < 0x55; i++, pos++) {
         f32 clothOpen = 1.0f - i_this->m2200;
@@ -395,8 +397,8 @@ void ho_move(daGrid_c* i_this) {
         f32 xRate = x_rate_tbl[row];
         s16 rowWaveAngle = 10922.0f * xRate;
 
-        f32 xWave = windDepth * cM_ssin(i_this->m1B44 + i * i_this->m1B4C);
-        f32 zWave = 0.5f * (windDepth * cM_scos(i_this->m1B44 + i * i_this->m1B4E));
+        xWave = windDepth * cM_ssin(i_this->m1B44 + i * i_this->m1B4C);
+        zWave = 0.5f * (windDepth * cM_scos(i_this->m1B44 + i * i_this->m1B4E));
 
         MtxPosition(&localIn, &localWind);
         f32 localWindX = localWind.x;

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -645,19 +645,23 @@ bool daGrid_c::_delete() {
 /* 800EAF28-800EB0EC       .text _execute__8daGrid_cFv */
 bool daGrid_c::_execute() {
     daGrid_c* i_this = this;
-    u8 targetAlpha;
     u8 alpha = i_this->mPacket.getAlpha();
+    u8 targetAlpha;
 
     if (!dComIfGp_event_runCheck()) {
+        u8 calcAlpha;
+
         cXyz eye = dComIfGp_getCamera(0)->mCamera.Eye();
         f32 dist = (i_this->current.pos - eye).abs();
 
         if (dist > l_HIO.mAlphaDist) {
-            targetAlpha = l_HIO.mFarAlpha;
+            calcAlpha = l_HIO.mFarAlpha;
         } else {
             f32 rate = dist / l_HIO.mAlphaDist;
-            targetAlpha = l_HIO.mFarAlpha * rate + l_HIO.mNearAlpha * (1.0f - rate);
+            calcAlpha = l_HIO.mFarAlpha * rate + l_HIO.mNearAlpha * (1.0f - rate);
         }
+
+        targetAlpha = calcAlpha;
     } else {
         targetAlpha = l_HIO.mFarAlpha;
     }

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -342,9 +342,10 @@ void ho_move(daGrid_c* i_this) {
     f32 windSide = std::fabsf(localWind.z) * (1.0f - i_this->m2200);
 
     f32 windWaveRate = 1.0f + (0.01f + REG6_F(15)) * (windSide * cM_ssin(i_this->m1B44));
-    s32 waveSpeed = 2500.0f + (9000.0f * (0.8f * windPow));
-    if (waveSpeed > 10000) {
-        waveSpeed = 10000;
+    s32 calcWaveSpeed = 2500.0f + (9000.0f * (0.8f * windPow));
+    s32 waveSpeed = 10000;
+    if (calcWaveSpeed <= 10000) {
+        waveSpeed = calcWaveSpeed;
     }
     i_this->m1B44 += waveSpeed;
 

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -208,7 +208,7 @@ void daHo_packet_c::draw() {
         GXSetChanCtrl(GX_COLOR0, 1, GX_SRC_REG, GX_SRC_REG, lightMask, GX_DF_CLAMP,
                       GX_AF_NONE);
         GXSetNumTexGens(2);
-        GXSetTexCoordGen(GX_TEXCOORD0, GX_TG_MTX3x4, GX_TG_TEX0, GX_IDENTITY);
+        GXSetTexCoordGen(GX_TEXCOORD0, GX_TG_MTX2x4, GX_TG_TEX0, GX_IDENTITY);
         GXSetTexCoordGen(GX_TEXCOORD1, GX_TG_SRTG, GX_TG_COLOR0, GX_IDENTITY);
         GXSetNumTevStages(numTevStages);
         GXSetTevSwapMode(GX_TEVSTAGE0, GX_TEV_SWAP0, GX_TEV_SWAP1);
@@ -241,7 +241,7 @@ void daHo_packet_c::draw() {
         GXSetChanCtrl(GX_COLOR0, 1, GX_SRC_REG, GX_SRC_REG, lightMask, GX_DF_CLAMP,
                       GX_AF_NONE);
         GXSetNumTexGens(1);
-        GXSetTexCoordGen(GX_TEXCOORD0, GX_TG_MTX3x4, GX_TG_TEX0, GX_IDENTITY);
+        GXSetTexCoordGen(GX_TEXCOORD0, GX_TG_MTX2x4, GX_TG_TEX0, GX_IDENTITY);
         GXSetNumTevStages(numTevStages);
         GXSetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD_NULL, GX_TEXMAP_NULL, GX_COLOR0A0);
         GXSetTevSwapMode(GX_TEVSTAGE0, GX_TEV_SWAP1, GX_TEV_SWAP0);

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -31,6 +31,13 @@ static daHo_HIO_c l_HIO;
 #include "assets/l_grid_DL.h"
 #include "assets/l_grid_matDL.h"
 
+static inline int daGrid_getWindRelAngle(daGrid_c* i_this, cXyz* windVec, s16 shipSailAngle) {
+    s16 windAngle = cM_atan2s(windVec->x, windVec->z);
+    int windRelAngle = (s16)(i_this->current.angle.y + shipSailAngle);
+    windRelAngle -= windAngle;
+    return windRelAngle;
+}
+
 /* 800E8CC0-800E8D48       .text setBackNrm__13daHo_packet_cFv */
 void daHo_packet_c::setBackNrm() {
     cXyz* nrm = getNrm();
@@ -312,9 +319,7 @@ void ho_move(daGrid_c* i_this) {
     i_this->m1B4E = 0x1C20;
 
     s16 shipSailAngle = l_ship->getSailAngle();
-    s16 windAngle = cM_atan2s(windVec->x, windVec->z);
-    int windRelAngle = (s16)(i_this->current.angle.y + shipSailAngle);
-    windRelAngle -= windAngle;
+    int windRelAngle = daGrid_getWindRelAngle(i_this, windVec, shipSailAngle);
     s16 targetWindAngle = windRelAngle + 0x8000;
     if (targetWindAngle > 0) {
         if (shipSailAngle > 0 && shipSailAngle < 0x4000) {

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -310,7 +310,7 @@ void ho_move(daGrid_c* i_this) {
 
     s16 shipSailAngle = l_ship->getSailAngle();
     s16 windAngle = cM_atan2s(windVec->x, windVec->z);
-    s16 windRelAngle = (s16)(i_this->current.angle.y + shipSailAngle) - windAngle;
+    s16 windRelAngle = i_this->current.angle.y + shipSailAngle - windAngle;
     s16 targetWindAngle = windRelAngle + 0x8000;
     if (targetWindAngle > 0) {
         if (shipSailAngle > 0 && shipSailAngle < 0x4000) {

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -595,14 +595,13 @@ cPhs_State daGrid_c::_create() {
         }
 
         f32 verticalAmplitude;
-        f32 verticalDistA;
-        f32 verticalDistB;
-        f32 verticalEdgeDist;
+        f32 verticalDist;
+        f32 verticalLimit;
         f32 verticalRate;
         if (gridPos[i].y < gridPos[columnTop].y) {
-            verticalDistA = std::fabsf(gridPos[0].y - gridPos[i].y);
-            verticalDistB = std::fabsf(gridPos[columnTop].y - gridPos[i].y);
-            verticalEdgeDist = std::fabsf(gridPos[columnTop].y - gridPos[0].y);
+            verticalDist = std::fabsf(gridPos[0].y - gridPos[i].y);
+            verticalLimit = std::fabsf(gridPos[columnTop].y - gridPos[i].y);
+            f32 verticalEdgeDist = std::fabsf(gridPos[columnTop].y - gridPos[0].y);
             verticalEdgeDist *= 0.5f;
             verticalRate = 1.05f * (1.5707964f / verticalEdgeDist);
             if (columnTop == 56) {
@@ -613,18 +612,18 @@ cPhs_State daGrid_c::_create() {
                 verticalAmplitude = 80.0f;
             }
         } else {
-            verticalDistA = std::fabsf(gridPos[columnTop].y - gridPos[i].y);
-            verticalDistB = std::fabsf(gridPos[84].y - gridPos[i].y);
-            verticalEdgeDist = std::fabsf(gridPos[columnTop].y - gridPos[84].y);
+            verticalDist = std::fabsf(gridPos[columnTop].y - gridPos[i].y);
+            verticalLimit = std::fabsf(gridPos[84].y - gridPos[i].y);
+            f32 verticalEdgeDist = std::fabsf(gridPos[columnTop].y - gridPos[84].y);
             verticalEdgeDist *= 0.5f;
             verticalRate = 1.15f * (1.5707964f / verticalEdgeDist);
             verticalAmplitude = 20.0f;
         }
 
-        if (verticalDistA > verticalDistB) {
-            verticalDistA = verticalDistB;
+        if (verticalDist > verticalLimit) {
+            verticalDist = verticalLimit;
         }
-        f32 verticalSin = sin(verticalDistA * verticalRate);
+        f32 verticalSin = sin(verticalDist * verticalRate);
         f32 verticalValue = verticalAmplitude * verticalSin;
 
         m1B54[i] = std::sqrtf(SQUARE(baseAmplitude) + SQUARE(verticalValue));

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -601,7 +601,7 @@ cPhs_State daGrid_c::_create() {
             verticalDist = std::fabsf(gridPos[0].y - currentY);
             verticalLimit = std::fabsf(topPos->y - currentY);
             f32 verticalEdgeDist = std::fabsf(topPos->y - gridPos[0].y);
-            verticalRate = 1.05f * ((1.5707964f / verticalEdgeDist) * 2.0f);
+            verticalRate = (1.05f * (1.5707964f / verticalEdgeDist)) * 2.0f;
             if (columnTop == 56) {
                 verticalAmplitude = 35.0f;
             } else if (columnTop == 57) {
@@ -613,7 +613,7 @@ cPhs_State daGrid_c::_create() {
             verticalDist = std::fabsf(topPos->y - currentY);
             verticalLimit = std::fabsf(gridPos[84].y - currentY);
             f32 verticalEdgeDist = std::fabsf(topPos->y - gridPos[84].y);
-            verticalRate = 1.15f * ((1.5707964f / verticalEdgeDist) * 2.0f);
+            verticalRate = (1.15f * (1.5707964f / verticalEdgeDist)) * 2.0f;
             verticalAmplitude = 20.0f;
         }
 

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -603,9 +603,9 @@ cPhs_State daGrid_c::_create() {
     Vec* gridPos = (Vec*)l_grid_pos;
     for (int i = 0; i < 0x55; i++) {
         f32 baseAmplitude;
-        if (i <= 6) {
+        if (i >= 0 && i <= 6) {
             baseAmplitude = 40.0f;
-        } else if (i <= 13) {
+        } else if (i >= 7 && i <= 13) {
             baseAmplitude = 70.0f;
         } else if ((i >= 49 && i <= 55) || (i >= 42 && i <= 48)) {
             baseAmplitude = 85.0f;
@@ -620,7 +620,8 @@ cPhs_State daGrid_c::_create() {
         if (edgeDistA > edgeDistB) {
             edgeDistA = edgeDistB;
         }
-        baseAmplitude *= sin(edgeDistA * edgeRate);
+        f32 edgeSin = sin(edgeDistA * edgeRate);
+        baseAmplitude *= edgeSin;
 
         int columnTop = 6;
         for (int j = 0; j < 7; j++) {
@@ -660,7 +661,8 @@ cPhs_State daGrid_c::_create() {
         if (verticalDistA > verticalDistB) {
             verticalDistA = verticalDistB;
         }
-        verticalAmplitude *= sin(verticalDistA * verticalRate);
+        f32 verticalSin = sin(verticalDistA * verticalRate);
+        verticalAmplitude *= verticalSin;
 
         m1B54[i] = std::sqrtf(SQUARE(baseAmplitude) + SQUARE(verticalAmplitude));
     }

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -434,7 +434,7 @@ void ho_move(daGrid_c* i_this) {
         } else {
             foldRate *= clothOpen + z_rate_tbl2[row] * i_this->m2200;
             depthRate = z_rate_tbl[row];
-            depthSwing *= depthRate * i_this->m2200;
+            depthSwing *= i_this->m2200 * depthRate;
             rowSwing = i_this->m2200 * (col * (5.0f * depthRate));
         }
 

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -595,14 +595,15 @@ cPhs_State daGrid_c::_create() {
         f32 currentY = gridPos[i].y;
         Vec* topPos = &gridPos[columnTop];
         f32 verticalAmplitude;
-        f32 verticalDist;
         f32 verticalLimit;
         f32 verticalRate;
+        f32 verticalDist;
         if (currentY < topPos->y) {
             verticalDist = std::fabsf(gridPos[0].y - currentY);
             verticalLimit = std::fabsf(topPos->y - currentY);
             f32 verticalEdgeDist = std::fabsf(topPos->y - gridPos[0].y);
-            verticalRate = (1.05f * (1.5707964f / verticalEdgeDist)) * 2.0f;
+            verticalEdgeDist *= 0.5f;
+            verticalRate = 1.05f * (1.5707964f / verticalEdgeDist);
             if (columnTop == 56) {
                 verticalAmplitude = 35.0f;
             } else if (columnTop == 57) {
@@ -614,7 +615,8 @@ cPhs_State daGrid_c::_create() {
             verticalDist = std::fabsf(topPos->y - currentY);
             verticalLimit = std::fabsf(gridPos[84].y - currentY);
             f32 verticalEdgeDist = std::fabsf(topPos->y - gridPos[84].y);
-            verticalRate = (1.15f * (1.5707964f / verticalEdgeDist)) * 2.0f;
+            verticalEdgeDist *= 0.5f;
+            verticalRate = 1.15f * (1.5707964f / verticalEdgeDist);
             verticalAmplitude = 20.0f;
         }
 

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -76,9 +76,9 @@ void daHo_packet_c::setNrmVtx(cXyz* i_nrm, int i_x, int i_y) {
     nrm.setall(0.0f);
 
     if (i_x != 0) {
-        leftRight = vtxPos[i_x + idx - 1] - pos;
+        leftRight = vtxPos[idx - 1 + i_x] - pos;
         if (i_y != 0 && i_y != 9) {
-            upDown = vtxPos[i_x + (i_y - 1) * 7] - pos;
+            upDown = vtxPos[(i_y - 1) * 7 + i_x] - pos;
             triNrm = leftRight.outprod(upDown);
             triNrm = triNrm.normZC();
             nrm += triNrm;
@@ -89,7 +89,7 @@ void daHo_packet_c::setNrmVtx(cXyz* i_nrm, int i_x, int i_y) {
             triNrm = triNrm.normZC();
             nrm += triNrm;
         } else if (i_y != 8) {
-            upDown = vtxPos[i_x + (i_y + 1) * 7] - pos;
+            upDown = vtxPos[(i_y + 1) * 7 + i_x] - pos;
             triNrm = upDown.outprod(leftRight);
             triNrm = triNrm.normZC();
             nrm += triNrm;
@@ -97,9 +97,9 @@ void daHo_packet_c::setNrmVtx(cXyz* i_nrm, int i_x, int i_y) {
     }
 
     if (i_x != 6) {
-        leftRight = vtxPos[i_x + idx + 1] - pos;
+        leftRight = vtxPos[i_x + 1 + idx] - pos;
         if (i_y != 0 && i_y != 9) {
-            upDown = vtxPos[i_x + (i_y - 1) * 7] - pos;
+            upDown = vtxPos[(i_y - 1) * 7 + i_x] - pos;
             triNrm = upDown.outprod(leftRight);
             triNrm = triNrm.normZC();
             nrm += triNrm;
@@ -110,7 +110,7 @@ void daHo_packet_c::setNrmVtx(cXyz* i_nrm, int i_x, int i_y) {
             triNrm = triNrm.normZC();
             nrm += triNrm;
         } else if (i_y != 8) {
-            upDown = vtxPos[i_x + (i_y + 1) * 7] - pos;
+            upDown = vtxPos[(i_y + 1) * 7 + i_x] - pos;
             triNrm = leftRight.outprod(upDown);
             triNrm = triNrm.normZC();
             nrm += triNrm;

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -464,7 +464,11 @@ void ho_move(daGrid_c* i_this) {
         zWave += i_this->m2204 * clothOpen * windSide * localWind.z;
 
         f32 waveLen = std::sqrtf(SQUARE(xWave) + SQUARE(zWave));
-        f32 yWave = 0.25f * waveLen * i_this->m1B54[i];
+        f32 yWave = 0.25f * waveLen;
+        f32 waveAmp = i_this->m1B54[i];
+        xWave *= waveAmp;
+        yWave *= waveAmp;
+        zWave *= waveAmp;
 
         f32 upperRow = rowCenter < 0.0f ? rowCenter : 0.0f;
         f32 foldRate = 1.0f - ((0.67f + 0.3f * (SQUARE(upperRow) * 0.25f)) * i_this->m2200);

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -450,7 +450,7 @@ void ho_move(daGrid_c* i_this) {
         depthSwing *= depthShape;
         rowSwing *= (i_this->m2200 * cM_scos(colWaveAngle) * col) / 6.0f;
 
-        f32 xAtten = 1.0f - 0.5f * xRate;
+        f32 xAtten = 1.0f - 0.5f * (SQUARE(upperRow) * 0.25f);
         depthSwing *= xAtten;
         rowSwing *= xAtten;
 

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -38,6 +38,10 @@ static inline int daGrid_getWindRelAngle(daGrid_c* i_this, cXyz* windVec, s16 sh
     return windRelAngle;
 }
 
+static inline f32 daGrid_mul(f32 lhs, f32 rhs) {
+    return lhs * rhs;
+}
+
 /* 800E8CC0-800E8D48       .text setBackNrm__13daHo_packet_cFv */
 void daHo_packet_c::setBackNrm() {
     cXyz* nrm = getNrm();
@@ -426,7 +430,7 @@ void ho_move(daGrid_c* i_this) {
         zWave *= waveAmp;
 
         f32 upperRow = rowCenter < 0.0f ? rowCenter : 0.0f;
-        f32 foldPoly = 0.67f + 0.3f * (SQUARE(upperRow) * 0.25f);
+        f32 foldPoly = 0.67f + 0.3f * daGrid_mul(SQUARE(upperRow), 0.25f);
         f32 foldRate = 1.0f - foldPoly * i_this->m2200;
         f32 depthRate;
         f32 depthSwing = 120.0f;
@@ -455,7 +459,7 @@ void ho_move(daGrid_c* i_this) {
         f32 colWaveCos = cM_scos(i_this->m2212 + rowWaveAngle * col);
         rowSwing *= (i_this->m2200 * colWaveCos * col) / 6.0f;
 
-        f32 xAtten = 1.0f - 0.5f * (SQUARE(upperRow) * 0.25f);
+        f32 xAtten = 1.0f - 0.5f * daGrid_mul(SQUARE(upperRow), 0.25f);
         rowSwing *= xAtten;
         depthSwing *= xAtten;
 
@@ -472,9 +476,9 @@ void ho_move(daGrid_c* i_this) {
             zSag *= i_this->m2200 * (6.0f * z_rate_tbl[row] * (col / 6.0f));
         }
 
-        pos->x += depthSwing + (0.35f * clothOpen + 0.65f) * (xWave * i_this->m2204);
-        pos->y += rowSwing + yWave * (0.35f * clothOpen + 0.65f);
-        pos->z += zSag + ((0.35f * clothOpen + 0.65f) * (zWave * i_this->m2204) - 13.75f);
+        pos->x += depthSwing + (0.65f * clothOpen + 0.35f) * (xWave * i_this->m2204);
+        pos->y += rowSwing + yWave * (0.65f * clothOpen + 0.35f);
+        pos->z += zSag + ((0.65f * clothOpen + 0.35f) * (zWave * i_this->m2204) - 13.75f);
 
         row = col < 6 ? row : row + 1;
         col = col < 6 ? col + 1 : 0;

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -426,16 +426,19 @@ void ho_move(daGrid_c* i_this) {
         f32 upperRow = rowCenter < 0.0f ? rowCenter : 0.0f;
         f32 foldRate = 1.0f - ((0.67f + 0.3f * (SQUARE(upperRow) * 0.25f)) * i_this->m2200);
         f32 depthRate;
+        f32 depthSwing;
+        f32 rowSwing;
         if (l_HIO.mUseHioRates != 0) {
             foldRate *= clothOpen + l_HIO.mWaveRate[row] * i_this->m2200;
             depthRate = l_HIO.mDepthRate[row];
+            depthSwing = 120.0f * (depthRate * i_this->m2200);
+            rowSwing = 5.0f * depthRate * row * i_this->m2200;
         } else {
             foldRate *= clothOpen + l_defaultWaveRate[row] * i_this->m2200;
             depthRate = l_defaultDepthRate[row];
+            depthSwing = 120.0f * (depthRate * i_this->m2200);
+            rowSwing = 5.0f * depthRate * row * i_this->m2200;
         }
-
-        f32 depthSwing = 120.0f * (depthRate * i_this->m2200);
-        f32 rowSwing = 5.0f * depthRate * row * i_this->m2200;
 
         pos->x = gridPos[i].x;
         pos->y = foldRate * gridPos[i].y + (1.0f - foldRate) * gridPos[row * 7].y;

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -472,14 +472,14 @@ void ho_move(daGrid_c* i_this) {
         }
     }
 
-    f32 topX = std::fabsf(i_this->mPacket.getPos()[59].x);
+    pos = i_this->mPacket.getPos();
+    f32 topX = std::fabsf(pos[59].x);
     f32 row8Rate = 1.0f - topX * (0.0015f + REG6_F(8));
     f32 row7Rate = 1.0f - topX * (0.00070000003f + REG6_F(9));
     f32 row6Rate = 1.0f - topX * (0.00020000007f + REG6_F(10));
     f32 row9Rate = 1.0f - topX * (0.0015f + REG6_F(11));
     f32 row10Rate = 1.0f - topX * (0.0012f + REG6_F(12));
 
-    pos = i_this->mPacket.getPos();
     for (int i = 0; i < 0x55; i++, pos++) {
         if (i >= 56 && i <= 62) {
             pos->z *= row8Rate;
@@ -494,10 +494,10 @@ void ho_move(daGrid_c* i_this) {
         }
     }
 
+    cXyz* nrm = i_this->mPacket.getNrm();
     cXyz windRel = i_this->tevStr.mLightPosWorld - i_this->current.pos;
     i_this->mPacket.setNrmMtx(windRel);
 
-    cXyz* nrm = i_this->mPacket.getNrm();
     for (int y = 0; y < 12; y++) {
         for (int x = 0; x < 7; x++, nrm++) {
             i_this->mPacket.setNrmVtx(nrm, x, y);

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -15,6 +15,7 @@
 #include "d/d_priority.h"
 #include "d/res/res_cloth.h"
 #include "d/res/res_ship.h"
+#include "d/d_s_play.h"
 #include "f_op/f_op_actor_iter.h"
 #include "f_op/f_op_actor_mng.h"
 #include "f_op/f_op_camera.h"
@@ -389,7 +390,7 @@ void ho_move(daGrid_c* i_this) {
     MtxPosition(&localIn, &localWind);
     f32 windSide = std::fabsf(localWind.z) * (1.0f - i_this->m2200);
 
-    f32 windWaveRate = 1.0f + 0.01f * windSide * cM_ssin(i_this->m1B44);
+    f32 windWaveRate = 1.0f + (0.01f + REG6_F(15)) * windSide * cM_ssin(i_this->m1B44);
     s32 waveSpeed = 2500.0f + (9000.0f * (0.8f * windPow));
     if (waveSpeed > 10000) {
         waveSpeed = 10000;
@@ -433,6 +434,8 @@ void ho_move(daGrid_c* i_this) {
     cXyz* pos = i_this->mPacket.getPos();
     int row = 0;
     int col = 0;
+    localIn.x = 0.0f;
+    localIn.z = 1.6f;
 
     for (int i = 0; i < 0x55; i++, pos++) {
         f32 clothOpen = 1.0f - i_this->m2200;
@@ -444,7 +447,6 @@ void ho_move(daGrid_c* i_this) {
         f32 xWave = windDepth * cM_ssin(i_this->m1B44 + i * i_this->m1B4C);
         f32 zWave = 0.5f * windDepth * cM_scos(i_this->m1B44 + i * i_this->m1B4E);
 
-        localIn.set(0.0f, 0.0f, 1.6f);
         MtxPosition(&localIn, &localWind);
         f32 xLimit = 0.25f + 0.75f * windPow;
         if (xLimit > 1.0f) {
@@ -520,11 +522,11 @@ void ho_move(daGrid_c* i_this) {
     }
 
     f32 topZ = std::fabsf(i_this->mPacket.getPos()[59].z);
-    f32 row8Rate = 1.0f - topZ * 0.0015f;
-    f32 row7Rate = 1.0f - topZ * 0.00070000003f;
-    f32 row6Rate = 1.0f - topZ * 0.00020000007f;
-    f32 row9Rate = 1.0f - topZ * 0.0015f;
-    f32 row10Rate = 1.0f - topZ * 0.0012f;
+    f32 row8Rate = 1.0f - topZ * (0.0015f + REG6_F(8));
+    f32 row7Rate = 1.0f - topZ * (0.00070000003f + REG6_F(9));
+    f32 row6Rate = 1.0f - topZ * (0.00020000007f + REG6_F(10));
+    f32 row9Rate = 1.0f - topZ * (0.0015f + REG6_F(11));
+    f32 row10Rate = 1.0f - topZ * (0.0012f + REG6_F(12));
 
     pos = i_this->mPacket.getPos();
     for (int i = 0; i < 0x55; i++, pos++) {

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -468,10 +468,9 @@ void ho_move(daGrid_c* i_this) {
             zSag *= i_this->m2200 * (6.0f * l_defaultDepthRate[row] * (col / 6.0f));
         }
 
-        f32 waveScale = 0.35f * clothOpen + 0.65f;
-        pos->x += depthSwing + waveScale * (i_this->m2204 * xWave);
-        pos->y += rowSwing + waveScale * yWave;
-        pos->z += zSag + waveScale * (i_this->m2204 * zWave) - 13.75f;
+        pos->x += depthSwing + (0.35f * clothOpen + 0.65f) * (i_this->m2204 * xWave);
+        pos->y += rowSwing + (0.35f * clothOpen + 0.65f) * yWave;
+        pos->z += zSag + (0.35f * clothOpen + 0.65f) * (i_this->m2204 * zWave) - 13.75f;
 
         row = col < 6 ? row : row + 1;
         col = col < 6 ? col + 1 : 0;

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -313,7 +313,8 @@ void ho_move(daGrid_c* i_this) {
 
     s16 shipSailAngle = l_ship->getSailAngle();
     s16 windAngle = cM_atan2s(windVec->x, windVec->z);
-    s16 windRelAngle = (s16)(i_this->current.angle.y + shipSailAngle) - windAngle;
+    int windRelAngle = (s16)(i_this->current.angle.y + shipSailAngle);
+    windRelAngle -= windAngle;
     s16 targetWindAngle = windRelAngle + 0x8000;
     if (targetWindAngle > 0) {
         if (shipSailAngle > 0 && shipSailAngle < 0x4000) {

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -421,7 +421,8 @@ void ho_move(daGrid_c* i_this) {
         zWave *= waveAmp;
 
         f32 upperRow = rowCenter < 0.0f ? rowCenter : 0.0f;
-        f32 foldRate = 1.0f - ((0.67f + 0.3f * (SQUARE(upperRow) * 0.25f)) * i_this->m2200);
+        f32 foldPoly = 0.67f + 0.3f * (SQUARE(upperRow) * 0.25f);
+        f32 foldRate = 1.0f - foldPoly * i_this->m2200;
         f32 depthRate;
         f32 depthSwing = 120.0f;
         f32 rowSwing;

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -452,8 +452,8 @@ void ho_move(daGrid_c* i_this) {
         rowSwing *= (i_this->m2200 * cM_scos(colWaveAngle) * col) / 6.0f;
 
         f32 xAtten = 1.0f - 0.5f * (SQUARE(upperRow) * 0.25f);
-        depthSwing *= xAtten;
         rowSwing *= xAtten;
+        depthSwing *= xAtten;
 
         f32 swingLen = std::sqrtf(SQUARE(depthSwing) + SQUARE(rowSwing));
         f32 zSag = 0.25f * -swingLen;

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -476,7 +476,7 @@ void ho_move(daGrid_c* i_this) {
         pos->y += rowSwing + waveScale * yWave;
         pos->z += zSag + waveScale * (i_this->m2204 * zWave) - 13.75f;
 
-        row = col >= 6 ? row + 1 : row;
+        row = col < 6 ? row : row + 1;
         col = col < 6 ? col + 1 : 0;
     }
 

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -692,19 +692,19 @@ bool daGrid_c::_execute() {
     u8 targetAlpha;
     int alpha = i_this->mPacket.mAlpha;
 
-    if (dComIfGp_event_runCheck()) {
-        targetAlpha = l_HIO.mFarAlpha;
-    } else {
+    if (!dComIfGp_event_runCheck()) {
         camera_class* camera = dComIfGp_getCamera(0);
         cXyz eye = camera->mCamera.Eye();
         f32 dist = (i_this->current.pos - eye).abs();
 
-        if (dist <= l_HIO.mAlphaDist) {
+        if (dist > l_HIO.mAlphaDist) {
+            targetAlpha = l_HIO.mFarAlpha;
+        } else {
             f32 rate = dist / l_HIO.mAlphaDist;
             targetAlpha = l_HIO.mFarAlpha * rate + l_HIO.mNearAlpha * (1.0f - rate);
-        } else {
-            targetAlpha = l_HIO.mFarAlpha;
         }
+    } else {
+        targetAlpha = l_HIO.mFarAlpha;
     }
 
     if (targetAlpha > alpha + 5) {
@@ -715,9 +715,11 @@ bool daGrid_c::_execute() {
         i_this->mPacket.mAlpha = targetAlpha;
     }
 
-    if (i_this->scale.y >= 0.06f) {
-        ho_move(i_this);
+    if (i_this->scale.y < 0.06f) {
+        return TRUE;
     }
+
+    ho_move(i_this);
 
     return TRUE;
 }

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -5,35 +5,337 @@
 
 #include "d/dolzel.h" // IWYU pragma: keep
 #include "d/actor/d_a_grid.h"
+#include "d/actor/d_a_ship.h"
 #include "JSystem/J3DGraphBase/J3DPacket.h"
+#include "SSystem/SComponent/c_lib.h"
+#include "SSystem/SComponent/c_math.h"
+#include "d/d_com_inf_game.h"
+#include "d/d_kankyo_wether.h"
 #include "d/d_procname.h"
 #include "d/d_priority.h"
+#include "d/res/res_cloth.h"
+#include "d/res/res_ship.h"
+#include "f_op/f_op_actor_iter.h"
+#include "f_op/f_op_actor_mng.h"
+#include "f_op/f_op_camera.h"
+#include "f_pc/f_pc_searcher.h"
+#include "m_Do/m_Do_graphic.h"
+#include "m_Do/m_Do_mtx.h"
 
+static daShip_c* l_ship;
 static daHo_HIO_c l_HIO;
+
+#include "assets/l_grid_pos.h"
+#include "assets/l_grid_texCoord.h"
+#include "assets/l_grid_DL.h"
+#include "assets/l_grid_matDL.h"
+
+static f32 l_defaultDepthRate[] = {
+    0.05f, 0.125f, 0.175f, 0.15f, 0.0625f, 0.15f, 0.2f,
+    0.15f, 0.075f, 0.175f, 0.175f, 0.1f, 0.0f,
+};
+
+static f32 l_defaultWaveRate[] = {
+    1.0f, 0.425f, 0.45f, 0.4f, 0.2f, 0.4f, 0.45f,
+    0.4f, 0.2f, 0.5f, 0.75f, 1.0f, 1.0f,
+};
+
+static f32 l_xRate[] = {
+    1.0f, 0.95f, 0.9f, 0.85f, 0.8f, 0.75f, 0.7f,
+    0.65f, 0.55f, 0.4f, 0.25f, 0.1f, 0.0f,
+};
+
+daHo_HIO_c::daHo_HIO_c() {
+    mNo = -1;
+    m05 = 1;
+    m06 = 0;
+    m07 = 0;
+    m08 = 0;
+    m0C = 0.1f;
+    m10 = 0.0f;
+    m14 = 40.0f;
+    m18 = 0.5f;
+    m1C = 0.1f;
+    m20 = 0.4f;
+    mScaleX = 1.0f;
+    mScaleY = 1.0f;
+    mScaleZ = 1.0f;
+    mFarAlpha = 0xFF;
+    mNearAlpha = 0x32;
+    mAlphaDist = 900.0f;
+    mStopMove = 0;
+    mUseHioRates = 0;
+
+    mDepthRate[0] = 0.05f;
+    mDepthRate[1] = 0.125f;
+    mDepthRate[2] = 0.175f;
+    mDepthRate[3] = 0.15f;
+    mDepthRate[4] = 0.0625f;
+    mDepthRate[5] = 0.15f;
+    mDepthRate[6] = 0.2f;
+    mDepthRate[7] = 0.15f;
+    mDepthRate[8] = 0.075f;
+    mDepthRate[9] = 0.175f;
+    mDepthRate[10] = 0.175f;
+    mDepthRate[11] = 0.1f;
+    mDepthRate[12] = 0.0f;
+
+    mWaveRate[0] = 1.0f;
+    mWaveRate[1] = 0.425f;
+    mWaveRate[2] = 0.45f;
+    mWaveRate[3] = 0.4f;
+    mWaveRate[4] = 0.2f;
+    mWaveRate[5] = 0.4f;
+    mWaveRate[6] = 0.45f;
+    mWaveRate[7] = 0.4f;
+    mWaveRate[8] = 0.2f;
+    mWaveRate[9] = 0.5f;
+    mWaveRate[10] = 0.75f;
+    mWaveRate[11] = 1.0f;
+    mWaveRate[12] = 1.0f;
+}
 
 /* 800E8CC0-800E8D48       .text setBackNrm__13daHo_packet_cFv */
 void daHo_packet_c::setBackNrm() {
-    /* Nonmatching */
+    cXyz* nrm = getNrm();
+    cXyz* backNrm = getBackNrm();
+
+    for (int i = 0; i < 0x55; i++, nrm++, backNrm++) {
+        backNrm->setall(0.0f);
+        *backNrm -= *nrm;
+    }
 }
 
 /* 800E8D48-800E8D74       .text setNrmMtx__13daHo_packet_cFR4cXyz */
 void daHo_packet_c::setNrmMtx(cXyz&) {
-    /* Nonmatching */
+    cMtx_YrotS(*calc_mtx, m189C);
 }
 
 /* 800E8D74-800E92AC       .text setNrmVtx__13daHo_packet_cFP4cXyzii */
-void daHo_packet_c::setNrmVtx(cXyz*, int, int) {
-    /* Nonmatching */
+void daHo_packet_c::setNrmVtx(cXyz* i_nrm, int i_x, int i_y) {
+    cXyz leftRight;
+    cXyz upDown;
+    cXyz triNrm;
+    cXyz pos;
+    cXyz nrm;
+    cXyz* vtxPos = getPos();
+    s32 idx = i_y * 7;
+
+    pos.set(vtxPos[i_x + idx]);
+    nrm.setall(0.0f);
+
+    if (i_x != 0) {
+        leftRight = vtxPos[i_x + idx - 1] - pos;
+        if (i_y != 0 && i_y != 9) {
+            upDown = vtxPos[i_x + (i_y - 1) * 7] - pos;
+            triNrm = leftRight.outprod(upDown);
+            triNrm = triNrm.normZC();
+            nrm += triNrm;
+        }
+        if (i_y == 11) {
+            upDown = vtxPos[84] - pos;
+            triNrm = upDown.outprod(leftRight);
+            triNrm = triNrm.normZC();
+            nrm += triNrm;
+        } else if (i_y != 8) {
+            upDown = vtxPos[i_x + (i_y + 1) * 7] - pos;
+            triNrm = upDown.outprod(leftRight);
+            triNrm = triNrm.normZC();
+            nrm += triNrm;
+        }
+    }
+
+    if (i_x != 6) {
+        leftRight = vtxPos[i_x + idx + 1] - pos;
+        if (i_y != 0 && i_y != 9) {
+            upDown = vtxPos[i_x + (i_y - 1) * 7] - pos;
+            triNrm = upDown.outprod(leftRight);
+            triNrm = triNrm.normZC();
+            nrm += triNrm;
+        }
+        if (i_y == 11) {
+            upDown = vtxPos[84] - pos;
+            triNrm = leftRight.outprod(upDown);
+            triNrm = triNrm.normZC();
+            nrm += triNrm;
+        } else if (i_y != 8) {
+            upDown = vtxPos[i_x + (i_y + 1) * 7] - pos;
+            triNrm = leftRight.outprod(upDown);
+            triNrm = triNrm.normZC();
+            nrm += triNrm;
+        }
+    }
+
+    if (i_y > 7) {
+        nrm.y = 0.0f;
+    }
+
+    if (!nrm.normalizeRS()) {
+        nrm.set(1.0f, 0.0f, 0.0f);
+    }
+
+    MtxPush();
+    cMtx_YrotM(*calc_mtx, cM_ssin((i_x + i_y) * -800) * 900.0f);
+    MtxPosition(&nrm, &triNrm);
+    *i_nrm = triNrm.normZC();
+    MtxPull();
 }
 
 /* 800E92AC-800E93B8       .text setTopNrmVtx__13daHo_packet_cFP4cXyz */
-void daHo_packet_c::setTopNrmVtx(cXyz*) {
-    /* Nonmatching */
+void daHo_packet_c::setTopNrmVtx(cXyz* i_nrm) {
+    cXyz sp18;
+    cXyz sp0C;
+    cXyz nrm;
+    cXyz* vtxPos = getPos();
+
+    sp18 = vtxPos[77] - vtxPos[84];
+    sp0C = vtxPos[83] - vtxPos[84];
+    nrm = sp18.outprod(sp0C);
+    nrm = nrm.normZC();
+    MtxPosition(&nrm, &sp18);
+    *i_nrm = sp18.normZC();
 }
 
 /* 800E93B8-800E9BE8       .text draw__13daHo_packet_cFv */
 void daHo_packet_c::draw() {
-    /* Nonmatching */
+    j3dSys.reinitGX();
+    GXSetNumIndStages(0);
+
+    dKy_GxFog_tevstr_set(mTevStr);
+
+    GXClearVtxDesc();
+    GXSetVtxDesc(GX_VA_POS, GX_INDEX8);
+    GXSetVtxDesc(GX_VA_NRM, GX_INDEX8);
+    GXSetVtxDesc(GX_VA_TEX0, GX_INDEX8);
+
+    GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_POS, GX_POS_XYZ, GX_F32, 0);
+    GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_NRM, GX_NRM_XYZ, GX_F32, 0);
+    GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_TEX0, GX_TEX_ST, GX_F32, 0);
+
+    GXSetArray(GX_VA_POS, getPos(), sizeof(cXyz));
+    GXSetArray(GX_VA_NRM, getNrm(), sizeof(cXyz));
+    GXSetArray(GX_VA_TEX0, l_grid_texCoord, sizeof(cXy));
+
+    GXTexObj texObj;
+    GXTlutObj tlutObj;
+
+    ResTIMG* ship = (ResTIMG*)dComIfG_getObjectRes("Ship", SHIP_BTI_NEW_HO1);
+    GXInitTlutObj(&tlutObj, (u8*)ship + ship->paletteOffset, GX_TL_RGB565, 0x100);
+    GXInitTexObjCI(&texObj, (u8*)ship + ship->imageOffset, ship->width, ship->height,
+                   (GXCITexFmt)ship->format, (GXTexWrapMode)ship->wrapS,
+                   (GXTexWrapMode)ship->wrapT, ship->mipmapCount > 1, GX_TLUT0);
+    GXInitTexObjLOD(&texObj, (GXTexFilter)ship->minFilter, (GXTexFilter)ship->magFilter,
+                    ship->minLOD * 0.125f, ship->maxLOD * 0.125f, ship->LODBias * 0.01f,
+                    ship->biasClamp, ship->doEdgeLOD, (GXAnisotropy)ship->maxAnisotropy);
+    GXLoadTlut(&tlutObj, GX_TLUT0);
+    GXLoadTexObj(&texObj, GX_TEXMAP0);
+
+    ResTIMG* cloth = (ResTIMG*)dComIfG_getObjectRes("Cloth", CLOTH_BTI_CLOTHTOON);
+    GXInitTexObj(&texObj, (u8*)cloth + cloth->imageOffset, cloth->width, cloth->height,
+                 (GXTexFmt)cloth->format, (GXTexWrapMode)cloth->wrapS,
+                 (GXTexWrapMode)cloth->wrapT, cloth->mipmapCount > 1);
+    GXInitTexObjLOD(&texObj, (GXTexFilter)cloth->minFilter, (GXTexFilter)cloth->magFilter,
+                    cloth->minLOD * 0.125f, cloth->maxLOD * 0.125f,
+                    cloth->LODBias * 0.01f, cloth->biasClamp, cloth->doEdgeLOD,
+                    (GXAnisotropy)cloth->maxAnisotropy);
+    GXLoadTexObj(&texObj, GX_TEXMAP1);
+
+    GXSetNumChans(1);
+
+    u8 numTevStages;
+    u8 lightMask;
+    if (mTevStr->mColorK1.a != 0) {
+        numTevStages = 3;
+        lightMask = GX_LIGHT0 | GX_LIGHT1;
+    } else {
+        numTevStages = 2;
+        lightMask = GX_LIGHT0;
+    }
+
+    if (l_HIO.m05 != 0) {
+        GXSetChanCtrl(GX_COLOR0, 1, GX_SRC_REG, GX_SRC_REG, lightMask, GX_DF_CLAMP,
+                      GX_AF_NONE);
+        GXSetNumTexGens(2);
+        GXSetTexCoordGen(GX_TEXCOORD0, GX_TG_MTX3x4, GX_TG_TEX0, GX_IDENTITY);
+        GXSetTexCoordGen(GX_TEXCOORD1, GX_TG_SRTG, GX_TG_COLOR0, GX_IDENTITY);
+        GXSetNumTevStages(numTevStages);
+        GXSetTevSwapMode(GX_TEVSTAGE0, GX_TEV_SWAP0, GX_TEV_SWAP1);
+        GXSetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD1, GX_TEXMAP1, GX_COLOR0A0);
+        GXSetTevColorIn(GX_TEVSTAGE0, GX_CC_C0, GX_CC_C1, GX_CC_TEXC, GX_CC_ZERO);
+        GXSetTevColorOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_TRUE,
+                        GX_TEVPREV);
+        GXSetTevAlphaIn(GX_TEVSTAGE0, GX_CA_ZERO, GX_CA_ZERO, GX_CA_ZERO, GX_CA_ZERO);
+        GXSetTevAlphaOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_TRUE,
+                        GX_TEVPREV);
+        GXSetTevSwapMode(GX_TEVSTAGE1, GX_TEV_SWAP0, GX_TEV_SWAP0);
+        GXSetTevOrder(GX_TEVSTAGE1, GX_TEXCOORD0, GX_TEXMAP0, GX_COLOR_NULL);
+        GXSetTevColorIn(GX_TEVSTAGE1, GX_CC_ZERO, GX_CC_TEXC, GX_CC_CPREV, GX_CC_ZERO);
+        GXSetTevColorOp(GX_TEVSTAGE1, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_TRUE,
+                        GX_TEVPREV);
+        GXSetTevAlphaIn(GX_TEVSTAGE1, GX_CA_ZERO, GX_CA_A0, GX_CA_TEXA, GX_CA_ZERO);
+        GXSetTevAlphaOp(GX_TEVSTAGE1, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_TRUE,
+                        GX_TEVPREV);
+        if (numTevStages == 3) {
+            GXSetTevSwapMode(GX_TEVSTAGE2, GX_TEV_SWAP0, GX_TEV_SWAP2);
+            GXSetTevOrder(GX_TEVSTAGE2, GX_TEXCOORD1, GX_TEXMAP1, GX_COLOR_NULL);
+            GXSetTevColorIn(GX_TEVSTAGE2, GX_CC_ZERO, GX_CC_C2, GX_CC_TEXC, GX_CC_CPREV);
+            GXSetTevColorOp(GX_TEVSTAGE2, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_TRUE,
+                            GX_TEVPREV);
+            GXSetTevAlphaIn(GX_TEVSTAGE2, GX_CA_ZERO, GX_CA_A0, GX_CA_TEXA, GX_CA_ZERO);
+            GXSetTevAlphaOp(GX_TEVSTAGE2, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_TRUE,
+                            GX_TEVPREV);
+        }
+    } else {
+        GXSetChanCtrl(GX_COLOR0, 1, GX_SRC_REG, GX_SRC_REG, lightMask, GX_DF_CLAMP,
+                      GX_AF_NONE);
+        GXSetNumTexGens(1);
+        GXSetTexCoordGen(GX_TEXCOORD0, GX_TG_MTX3x4, GX_TG_TEX0, GX_IDENTITY);
+        GXSetNumTevStages(numTevStages);
+        GXSetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD_NULL, GX_TEXMAP_NULL, GX_COLOR0A0);
+        GXSetTevSwapMode(GX_TEVSTAGE0, GX_TEV_SWAP1, GX_TEV_SWAP0);
+        GXSetTevColorIn(GX_TEVSTAGE0, GX_CC_C0, GX_CC_C1, GX_CC_RASC, GX_CC_ZERO);
+        GXSetTevColorOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_TRUE,
+                        GX_TEVPREV);
+        GXSetTevAlphaIn(GX_TEVSTAGE0, GX_CA_ZERO, GX_CA_ZERO, GX_CA_ZERO, GX_CA_ZERO);
+        GXSetTevAlphaOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_TRUE,
+                        GX_TEVPREV);
+        GXSetTevSwapMode(GX_TEVSTAGE1, GX_TEV_SWAP0, GX_TEV_SWAP0);
+        GXSetTevOrder(GX_TEVSTAGE1, GX_TEXCOORD0, GX_TEXMAP0, GX_COLOR_NULL);
+        GXSetTevColorIn(GX_TEVSTAGE1, GX_CC_ZERO, GX_CC_CPREV, GX_CC_TEXC, GX_CC_ZERO);
+        GXSetTevColorOp(GX_TEVSTAGE1, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_TRUE,
+                        GX_TEVPREV);
+        GXSetTevAlphaIn(GX_TEVSTAGE1, GX_CA_ZERO, GX_CA_ZERO, GX_CA_ZERO, GX_CA_TEXA);
+        GXSetTevAlphaOp(GX_TEVSTAGE1, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_TRUE,
+                        GX_TEVPREV);
+        if (numTevStages == 3) {
+            GXSetTevSwapMode(GX_TEVSTAGE2, GX_TEV_SWAP2, GX_TEV_SWAP0);
+            GXSetTevOrder(GX_TEVSTAGE2, GX_TEXCOORD_NULL, GX_TEXMAP_NULL, GX_COLOR_NULL);
+            GXSetTevColorIn(GX_TEVSTAGE2, GX_CC_ZERO, GX_CC_C2, GX_CC_RASC, GX_CC_CPREV);
+            GXSetTevColorOp(GX_TEVSTAGE2, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_TRUE,
+                            GX_TEVPREV);
+            GXSetTevAlphaIn(GX_TEVSTAGE2, GX_CA_ZERO, GX_CA_ZERO, GX_CA_ZERO, GX_CA_TEXA);
+            GXSetTevAlphaOp(GX_TEVSTAGE2, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_TRUE,
+                            GX_TEVPREV);
+        }
+    }
+
+    mTevStr->mColorC0.a = mAlpha;
+    GXSetTevColorS10(GX_TEVREG0, mTevStr->mColorC0);
+    GXSetTevColor(GX_TEVREG1, mTevStr->mColorK0);
+    GXSetTevColor(GX_TEVREG2, mTevStr->mColorK1);
+    GXCallDisplayList(l_grid_matDL, 0x20);
+
+    GXLoadPosMtxImm(*getMtx(), 0);
+    GXLoadNrmMtxImm(*getMtx(), 0);
+
+    GXSetCullMode(GX_CULL_BACK);
+    GXCallDisplayList(l_grid_DL, 0x220);
+
+    GXSetCullMode(GX_CULL_FRONT);
+    GXSetArray(GX_VA_NRM, getBackNrm(), sizeof(cXyz));
+    GXCallDisplayList(l_grid_DL, 0x220);
+
+    J3DShape::resetVcdVatCache();
 }
 
 /* 800E9BE8-800E9C0C       .text daGrid_Draw__FP8daGrid_c */
@@ -42,8 +344,218 @@ static BOOL daGrid_Draw(daGrid_c* i_this) {
 }
 
 /* 800E9C0C-800EA928       .text ho_move__FP8daGrid_c */
-void ho_move(daGrid_c*) {
-    /* Nonmatching */
+void ho_move(daGrid_c* i_this) {
+    if (l_HIO.mStopMove != 0) {
+        return;
+    }
+
+    cXyz* windVec = dKyw_get_wind_vec();
+    f32 windPow = dKyw_get_wind_pow();
+
+    i_this->mPacket.mActiveBuffer ^= 1;
+    i_this->m1B4C = 0x1D4C;
+    i_this->m1B4E = 0x1C20;
+
+    s16 shipSailAngle = l_ship->mSailAngle;
+    s16 windAngle = cM_atan2s(windVec->x, windVec->z);
+    s16 windRelAngle = (s16)(i_this->current.angle.y + shipSailAngle) - windAngle;
+    s16 targetWindAngle = windRelAngle + 0x8000;
+    if (targetWindAngle > 0) {
+        if (shipSailAngle > 0 && shipSailAngle < 0x4000) {
+            targetWindAngle = 0;
+        }
+    } else if (shipSailAngle < 0 && shipSailAngle > -0x4000) {
+        targetWindAngle = 0;
+    }
+
+    s16 targetAngle = 0.6f * targetWindAngle;
+    if (i_this->mForceWindRelAngleFlag == 0) {
+        cLib_addCalcAngleS2(&i_this->m2210, targetAngle, 4, 0x1000);
+    } else {
+        s16 forceTarget = i_this->mForceWindRelAngle - l_ship->mSailAngle + 0x8000;
+        cLib_addCalcAngleS2(&i_this->m2210, forceTarget, 2, 0x1400);
+    }
+    i_this->mForceWindRelAngleFlag = 0;
+
+    cMtx_YrotS(*calc_mtx, i_this->m2210);
+
+    cXyz localIn(0.0f, 0.0f, 0.064f);
+    cXyz localWind;
+    MtxPosition(&localIn, &localWind);
+    f32 windDepth = std::fabsf(localWind.z) + 0.02f;
+
+    localIn.x = 1.0f;
+    localIn.z = 0.0f;
+    MtxPosition(&localIn, &localWind);
+    f32 windSide = std::fabsf(localWind.z) * (1.0f - i_this->m2200);
+
+    f32 windWaveRate = 1.0f + 0.01f * windSide * cM_ssin(i_this->m1B44);
+    s32 waveSpeed = 2500.0f + (9000.0f * (0.8f * windPow));
+    if (waveSpeed > 10000) {
+        waveSpeed = 10000;
+    }
+    i_this->m1B44 += waveSpeed;
+
+    i_this->m2212 += (s16)(3000.0f * cM_scos(windRelAngle));
+    if (i_this->m2212 > 0) {
+        i_this->m2212 += 300;
+    } else {
+        i_this->m2212 -= 300;
+    }
+
+    f32 windBend = 0.5f * cM_ssin(windRelAngle);
+
+    if (l_HIO.m08 == 0) {
+        if (l_ship->mStateFlag & 0x200) {
+            if (i_this->m2208 == 0.0f) {
+                if (i_this->m2200 <= 0.0001f + l_HIO.m0C) {
+                    i_this->m2208 = 1.0f;
+                    i_this->m1B4A = 15;
+                }
+            } else if (i_this->m1B4A > 0) {
+                cLib_addCalc2(&i_this->m2204, 1.414f, 0.25f, l_HIO.m20);
+                i_this->m1B4A--;
+            } else {
+                cLib_addCalc2(&i_this->m2204, 1.0f, 0.1f, 0.05f);
+            }
+        } else {
+            if (i_this->m2200 > 0.7f) {
+                i_this->m2208 = 0.0f;
+                i_this->m1B4A = 0;
+            }
+            cLib_addCalc2(&i_this->m2204, 1.0f - 0.65f * i_this->m2200, 0.1f, 0.05f);
+        }
+    } else {
+        i_this->m2200 = l_HIO.m10;
+    }
+
+    Vec* gridPos = (Vec*)l_grid_pos;
+    cXyz* pos = i_this->mPacket.getPos();
+    int row = 0;
+    int col = 0;
+
+    for (int i = 0; i < 0x55; i++, pos++) {
+        f32 clothOpen = 1.0f - i_this->m2200;
+        f32 colCenter = 3 - col;
+        f32 rowCenter = row - 2;
+        f32 xRate = l_xRate[row];
+        s16 rowWaveAngle = 10922.0f * xRate;
+
+        f32 xWave = windDepth * cM_ssin(i_this->m1B44 + i * i_this->m1B4C);
+        f32 zWave = 0.5f * windDepth * cM_scos(i_this->m1B44 + i * i_this->m1B4E);
+
+        localIn.set(0.0f, 0.0f, 1.6f);
+        MtxPosition(&localIn, &localWind);
+        f32 xLimit = 0.25f + 0.75f * windPow;
+        if (xLimit > 1.0f) {
+            xLimit = 1.0f;
+        }
+        localWind.x *= xLimit;
+
+        f32 zLimit = 0.5f + 0.25f * windPow;
+        if (zLimit > 1.0f) {
+            zLimit = 1.0f;
+        }
+        localWind.z *= zLimit;
+
+        xWave += i_this->m2204 * clothOpen * windWaveRate * localWind.x;
+        zWave += i_this->m2204 * clothOpen * windSide * localWind.z;
+
+        f32 waveLen = std::sqrtf(SQUARE(xWave) + SQUARE(zWave));
+        f32 yWave = 0.25f * waveLen * i_this->m1B54[i];
+
+        f32 upperRow = rowCenter < 0.0f ? rowCenter : 0.0f;
+        f32 foldRate = 1.0f - ((0.67f + 0.3f * (SQUARE(upperRow) * 0.25f)) * i_this->m2200);
+        if (l_HIO.mUseHioRates != 0) {
+            foldRate *= clothOpen + l_HIO.mWaveRate[row] * i_this->m2200;
+        } else {
+            foldRate *= clothOpen + l_defaultWaveRate[row] * i_this->m2200;
+        }
+
+        f32 depthRate;
+        if (l_HIO.mUseHioRates != 0) {
+            depthRate = l_HIO.mDepthRate[row];
+        } else {
+            depthRate = l_defaultDepthRate[row];
+        }
+
+        f32 depthSwing = 120.0f * (depthRate * i_this->m2200);
+        f32 rowSwing = 5.0f * depthRate * row * i_this->m2200;
+
+        pos->x = gridPos[i].x;
+        pos->y = foldRate * gridPos[i].y + (1.0f - foldRate) * gridPos[row * 7].y;
+        pos->z = foldRate * gridPos[i].z;
+
+        s16 colWaveAngle = i_this->m2212 + rowWaveAngle * col;
+        f32 rowShape = 9.0f - SQUARE(colCenter);
+        f32 depthShape = ((i_this->m2200 * cM_ssin(colWaveAngle) * rowShape) / 9.0f) -
+                         ((windBend * rowShape) / 9.0f);
+        depthSwing *= depthShape;
+        rowSwing *= (i_this->m2200 * cM_scos(colWaveAngle) * col) / 6.0f;
+
+        f32 xAtten = 1.0f - 0.5f * xRate;
+        depthSwing *= xAtten;
+        rowSwing *= xAtten;
+
+        f32 swingLen = std::sqrtf(SQUARE(depthSwing) + SQUARE(rowSwing));
+        f32 zSag = -0.25f * swingLen;
+        if (col > 4) {
+            f32 edgeWave = std::fabsf(cM_ssin(i_this->m2212 + rowWaveAngle * col * 2));
+            zSag += 4.25f * (col - 4) * edgeWave;
+        }
+
+        zSag *= i_this->m2200 * (6.0f * depthRate * (col / 6.0f));
+
+        f32 waveScale = 0.35f * clothOpen + 0.65f;
+        pos->x += depthSwing + waveScale * i_this->m2204 * xWave;
+        pos->y += rowSwing + waveScale * yWave;
+        pos->z += zSag + waveScale * i_this->m2204 * zWave - 13.75f;
+
+        if (col >= 6) {
+            col = 0;
+            row++;
+        } else {
+            col++;
+        }
+    }
+
+    f32 topZ = std::fabsf(i_this->mPacket.getPos()[59].z);
+    f32 row8Rate = 1.0f - topZ * 0.0015f;
+    f32 row7Rate = 1.0f - topZ * 0.00070000003f;
+    f32 row6Rate = 1.0f - topZ * 0.00020000007f;
+    f32 row9Rate = 1.0f - topZ * 0.0015f;
+    f32 row10Rate = 1.0f - topZ * 0.0012f;
+
+    pos = i_this->mPacket.getPos();
+    for (int i = 0; i < 0x55; i++, pos++) {
+        if (i >= 56 && i <= 62) {
+            pos->z *= row8Rate;
+        } else if (i >= 49 && i <= 55) {
+            pos->z *= row7Rate;
+        } else if (i >= 42 && i <= 48) {
+            pos->z *= row6Rate;
+        } else if (i >= 63 && i <= 69) {
+            pos->z *= row9Rate;
+        } else if (i >= 70 && i <= 77) {
+            pos->z *= row10Rate;
+        }
+    }
+
+    cXyz windRel = i_this->tevStr.mLightPosWorld - i_this->current.pos;
+    i_this->mPacket.setNrmMtx(windRel);
+
+    cXyz* nrm = i_this->mPacket.getNrm();
+    for (int y = 0; y < 12; y++) {
+        for (int x = 0; x < 7; x++, nrm++) {
+            i_this->mPacket.setNrmVtx(nrm, x, y);
+        }
+    }
+    i_this->mPacket.setTopNrmVtx(nrm);
+    i_this->mPacket.setBackNrm();
+
+    DCStoreRangeNoSync(i_this->mPacket.getPos(), sizeof(i_this->mPacket.mPos[0]));
+    DCStoreRangeNoSync(i_this->mPacket.getNrm(), sizeof(i_this->mPacket.mNrm[0]));
+    DCStoreRangeNoSync(i_this->mPacket.getBackNrm(), sizeof(i_this->mPacket.mBackNrm[0]));
 }
 
 /* 800EA928-800EA94C       .text daGrid_Execute__FP8daGrid_c */
@@ -68,22 +580,168 @@ static cPhs_State daGrid_Create(fopAc_ac_c* i_this) {
 
 /* 800EA998-800EAEAC       .text _create__8daGrid_cFv */
 cPhs_State daGrid_c::_create() {
-    /* Nonmatching */
+    fopAcM_ct(this, daGrid_c);
+
+    mRoomNo = fopAcM_GetParam(this);
+
+    cPhs_State phase = dComIfG_resLoad(&mClothPhase, "Cloth");
+    if (phase != cPhs_COMPLEATE_e) {
+        return phase;
+    }
+
+    phase = dComIfG_resLoad(&mShipPhase, "Ship");
+    if (phase != cPhs_COMPLEATE_e) {
+        return phase;
+    }
+
+    if (l_HIO.mNo < 0) {
+        l_HIO.mNo = mDoHIO_root.m_subroot.createChild("\221D\202\314\224\277", &l_HIO);
+    }
+
+    Vec* gridPos = (Vec*)l_grid_pos;
+    for (int i = 0; i < 0x55; i++) {
+        f32 baseAmplitude;
+        if (i <= 6) {
+            baseAmplitude = 40.0f;
+        } else if (i <= 13) {
+            baseAmplitude = 70.0f;
+        } else if ((i >= 49 && i <= 55) || (i >= 42 && i <= 48)) {
+            baseAmplitude = 85.0f;
+        } else {
+            baseAmplitude = 80.0f;
+        }
+
+        f32 edgeDistA = std::fabsf(gridPos[0].z - gridPos[i].z);
+        f32 edgeDistB = std::fabsf(gridPos[6].z - gridPos[i].z);
+        f32 edgeDist = std::fabsf(gridPos[0].z - gridPos[6].z);
+        f32 edgeRate = 1.05f * (1.5707964f / (edgeDist * 0.5f));
+        if (edgeDistA > edgeDistB) {
+            edgeDistA = edgeDistB;
+        }
+        baseAmplitude *= sin(edgeDistA * edgeRate);
+
+        int columnTop = 6;
+        for (int j = 0; j < 7; j++) {
+            if (i == j || i == j + 7 || i == j + 14 || i == j + 21 || i == j + 28 ||
+                i == j + 35 || i == j + 42 || i == j + 49 || i == j + 56 || i == j + 63 ||
+                i == j + 70 || i == j + 77)
+            {
+                columnTop = j + 56;
+            }
+        }
+
+        f32 verticalAmplitude;
+        f32 verticalDistA;
+        f32 verticalDistB;
+        f32 verticalEdgeDist;
+        f32 verticalRate;
+        if (gridPos[i].y < gridPos[columnTop].y) {
+            verticalDistA = std::fabsf(gridPos[0].y - gridPos[i].y);
+            verticalDistB = std::fabsf(gridPos[columnTop].y - gridPos[i].y);
+            verticalEdgeDist = std::fabsf(gridPos[columnTop].y - gridPos[0].y);
+            verticalRate = 1.05f * (1.5707964f / (verticalEdgeDist * 0.5f));
+            if (columnTop == 56) {
+                verticalAmplitude = 35.0f;
+            } else if (columnTop == 57) {
+                verticalAmplitude = 70.0f;
+            } else {
+                verticalAmplitude = 80.0f;
+            }
+        } else {
+            verticalDistA = std::fabsf(gridPos[columnTop].y - gridPos[i].y);
+            verticalDistB = std::fabsf(gridPos[84].y - gridPos[i].y);
+            verticalEdgeDist = std::fabsf(gridPos[columnTop].y - gridPos[84].y);
+            verticalRate = 1.15f * (1.5707964f / (verticalEdgeDist * 0.5f));
+            verticalAmplitude = 20.0f;
+        }
+
+        if (verticalDistA > verticalDistB) {
+            verticalDistA = verticalDistB;
+        }
+        verticalAmplitude *= sin(verticalDistA * verticalRate);
+
+        m1B54[i] = std::sqrtf(SQUARE(baseAmplitude) + SQUARE(verticalAmplitude));
+    }
+
+    s16 procName = PROC_SHIP;
+    l_ship = (daShip_c*)fopAcIt_Judge((fopAcIt_JudgeFunc)fpcSch_JudgeForPName, &procName);
+    ho_move(this);
+    return cPhs_COMPLEATE_e;
 }
 
 /* 800EAEAC-800EAF28       .text _delete__8daGrid_cFv */
 bool daGrid_c::_delete() {
-    /* Nonmatching */
+    dComIfG_resDelete(&mClothPhase, "Cloth");
+    dComIfG_resDelete(&mShipPhase, "Ship");
+
+    if (l_HIO.mNo >= 0) {
+        mDoHIO_root.m_subroot.deleteChild(l_HIO.mNo);
+        l_HIO.mNo = -1;
+    }
+
+    return TRUE;
 }
 
 /* 800EAF28-800EB0EC       .text _execute__8daGrid_cFv */
 bool daGrid_c::_execute() {
-    /* Nonmatching */
+    daGrid_c* i_this = this;
+    u8 targetAlpha;
+    int alpha = i_this->mPacket.mAlpha;
+
+    if (dComIfGp_event_runCheck()) {
+        targetAlpha = l_HIO.mFarAlpha;
+    } else {
+        camera_class* camera = dComIfGp_getCamera(0);
+        cXyz eye = camera->mCamera.Eye();
+        f32 dist = (i_this->current.pos - eye).abs();
+
+        if (dist <= l_HIO.mAlphaDist) {
+            f32 rate = dist / l_HIO.mAlphaDist;
+            targetAlpha = l_HIO.mFarAlpha * rate + l_HIO.mNearAlpha * (1.0f - rate);
+        } else {
+            targetAlpha = l_HIO.mFarAlpha;
+        }
+    }
+
+    if (targetAlpha > alpha + 5) {
+        i_this->mPacket.mAlpha = alpha + 5;
+    } else if (targetAlpha < alpha - 5) {
+        i_this->mPacket.mAlpha = alpha - 5;
+    } else {
+        i_this->mPacket.mAlpha = targetAlpha;
+    }
+
+    if (i_this->scale.y >= 0.06f) {
+        ho_move(i_this);
+    }
+
+    return TRUE;
 }
 
 /* 800EB0EC-800EB328       .text _draw__8daGrid_cFv */
 bool daGrid_c::_draw() {
-    /* Nonmatching */
+    if (scale.y < 0.06f) {
+        return TRUE;
+    }
+
+    tevStr = l_ship->tevStr;
+
+    MtxTrans(current.pos.x, current.pos.y, current.pos.z, false);
+    cMtx_YrotM(*calc_mtx, current.angle.y);
+    cMtx_XrotM(*calc_mtx, current.angle.x);
+    cMtx_ZrotM(*calc_mtx, current.angle.z);
+    s16 shipSailAngle = l_ship->mSailAngle;
+    cMtx_YrotM(*calc_mtx, shipSailAngle);
+    MtxScale(1.0f, scale.y, 1.0f, true);
+    MtxScale(l_HIO.mScaleX, l_HIO.mScaleY, l_HIO.mScaleZ, true);
+    cMtx_concat(j3dSys.getViewMtx(), *calc_mtx, *mPacket.getMtx());
+    mPacket.setTevStr(&tevStr);
+
+    J3DDrawBuffer* buffer = mDoGph_gInf_c::isMonotone() ? dComIfGd_getXluListP1() : dComIfGd_getXluList();
+    buffer->setZMtx(*calc_mtx);
+    buffer->entryZSort(&mPacket);
+
+    return TRUE;
 }
 
 static actor_method_class l_daGrid_Method = {

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -313,7 +313,7 @@ void ho_move(daGrid_c* i_this) {
 
     s16 shipSailAngle = l_ship->getSailAngle();
     s16 windAngle = cM_atan2s(windVec->x, windVec->z);
-    s16 windRelAngle = i_this->current.angle.y + shipSailAngle - windAngle;
+    s16 windRelAngle = (s16)(i_this->current.angle.y + shipSailAngle) - windAngle;
     s16 targetWindAngle = windRelAngle + 0x8000;
     if (targetWindAngle > 0) {
         if (shipSailAngle > 0 && shipSailAngle < 0x4000) {
@@ -359,7 +359,6 @@ void ho_move(daGrid_c* i_this) {
     i_this->m2212 += windAngleStep;
 
     f32 windBend = 0.5f * cM_ssin(windRelAngle);
-    Vec* gridPos = (Vec*)l_pos;
     localIn.x = 0.0f;
     localIn.z = 1.6f;
     cXyz* pos = i_this->mPacket.getPos();
@@ -438,17 +437,16 @@ void ho_move(daGrid_c* i_this) {
             rowSwing = i_this->m2200 * (col * (5.0f * depthRate));
         }
 
-        pos->x = gridPos[i].x;
-        pos->y = foldRate * gridPos[i].y + (1.0f - foldRate) * gridPos[row * 7].y;
-        pos->z = foldRate * gridPos[i].z;
+        pos->x = ((Vec*)l_pos)[i].x;
+        pos->y = foldRate * ((Vec*)l_pos)[i].y + (1.0f - foldRate) * ((Vec*)l_pos)[row * 7].y;
+        pos->z = foldRate * ((Vec*)l_pos)[i].z;
 
-        s16 colWaveAngle = i_this->m2212 + rowWaveAngle * col;
-        f32 colWaveSin = cM_ssin(colWaveAngle);
+        f32 colWaveSin = cM_ssin(i_this->m2212 + rowWaveAngle * col);
         f32 rowShape = 9.0f - SQUARE(colCenter);
         f32 depthShape = ((i_this->m2200 * colWaveSin * rowShape) / 9.0f) -
                          ((windBend * rowShape) / 9.0f);
         depthSwing *= depthShape;
-        f32 colWaveCos = cM_scos(colWaveAngle);
+        f32 colWaveCos = cM_scos(i_this->m2212 + rowWaveAngle * col);
         rowSwing *= (i_this->m2200 * colWaveCos * col) / 6.0f;
 
         f32 xAtten = 1.0f - 0.5f * (SQUARE(upperRow) * 0.25f);

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -430,12 +430,12 @@ void ho_move(daGrid_c* i_this) {
             foldRate *= clothOpen + l_HIO.mWaveRate[row] * i_this->m2200;
             depthRate = l_HIO.mDepthRate[row];
             depthSwing *= depthRate * i_this->m2200;
-            rowSwing = 5.0f * depthRate * col * i_this->m2200;
+            rowSwing = i_this->m2200 * (5.0f * depthRate * col);
         } else {
             foldRate *= clothOpen + z_rate_tbl2[row] * i_this->m2200;
             depthRate = z_rate_tbl[row];
             depthSwing *= depthRate * i_this->m2200;
-            rowSwing = 5.0f * depthRate * col * i_this->m2200;
+            rowSwing = i_this->m2200 * (col * (5.0f * depthRate));
         }
 
         pos->x = gridPos[i].x;

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -564,6 +564,8 @@ cPhs_State daGrid_c::_create() {
             baseAmplitude = 80.0f;
         }
 
+        int columnTop = 6;
+
         f32 edgeDistA = std::fabsf(gridPos[0].z - gridPos[i].z);
         f32 edgeDistB = std::fabsf(gridPos[6].z - gridPos[i].z);
         f32 edgeDist = std::fabsf(gridPos[0].z - gridPos[6].z);
@@ -574,7 +576,6 @@ cPhs_State daGrid_c::_create() {
         f32 edgeSin = sin(edgeDistA * edgeRate);
         baseAmplitude *= edgeSin;
 
-        int columnTop = 6;
         for (int j = 0; j < 7; j++) {
             if (i == j || i == j + 7 || i == j + 14 || i == j + 21 || i == j + 28 ||
                 i == j + 35 || i == j + 42 || i == j + 49 || i == j + 56 || i == j + 63 ||
@@ -613,9 +614,9 @@ cPhs_State daGrid_c::_create() {
             verticalDistA = verticalDistB;
         }
         f32 verticalSin = sin(verticalDistA * verticalRate);
-        verticalAmplitude *= verticalSin;
+        f32 verticalValue = verticalAmplitude * verticalSin;
 
-        m1B54[i] = std::sqrtf(SQUARE(baseAmplitude) + SQUARE(verticalAmplitude));
+        m1B54[i] = std::sqrtf(SQUARE(baseAmplitude) + SQUARE(verticalValue));
     }
 
     s16 procName = PROC_SHIP;

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -339,7 +339,8 @@ void ho_move(daGrid_c* i_this) {
     localIn.x = 1.0f;
     localIn.z = 0.0f;
     MtxPosition(&localIn, &localWind);
-    f32 windSide = std::fabsf(localWind.z) * (1.0f - i_this->m2200);
+    f32 windSide = std::fabsf(localWind.z);
+    windSide *= 1.0f - i_this->m2200;
 
     f32 windWaveRate = 1.0f + (0.01f + REG6_F(15)) * (windSide * cM_ssin(i_this->m1B44));
     s32 calcWaveSpeed = 2500.0f + (9000.0f * (0.8f * windPow));

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -404,11 +404,13 @@ void ho_move(daGrid_c* i_this) {
         f32 zWave = 0.5f * (windDepth * cM_scos(i_this->m1B44 + i * i_this->m1B4E));
 
         MtxPosition(&localIn, &localWind);
+        f32 localWindX = localWind.x;
         f32 xLimit = 0.25f + 0.75f * windPow;
-        localWind.x *= xLimit > 1.0f ? 1.0f : xLimit;
+        localWind.x = localWindX * (xLimit > 1.0f ? 1.0f : xLimit);
 
+        f32 localWindZ = localWind.z;
         f32 zLimit = 0.5f + 0.25f * windPow;
-        localWind.z *= zLimit > 1.0f ? 1.0f : zLimit;
+        localWind.z = localWindZ * (zLimit > 1.0f ? 1.0f : zLimit);
 
         xWave += i_this->m2204 * (clothOpen * (windWaveRate * localWind.x));
         zWave += i_this->m2204 * (clothOpen * (windSide * localWind.z));

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -46,56 +46,6 @@ static f32 l_xRate[] = {
     0.65f, 0.55f, 0.4f, 0.25f, 0.1f, 0.0f,
 };
 
-daHo_HIO_c::daHo_HIO_c() {
-    mNo = -1;
-    m05 = 1;
-    m06 = 0;
-    m07 = 0;
-    m08 = 0;
-    m0C = 0.1f;
-    m10 = 0.0f;
-    m14 = 40.0f;
-    m18 = 0.5f;
-    m1C = 0.1f;
-    m20 = 0.4f;
-    mScaleX = 1.0f;
-    mScaleY = 1.0f;
-    mScaleZ = 1.0f;
-    mFarAlpha = 0xFF;
-    mNearAlpha = 0x32;
-    mAlphaDist = 900.0f;
-    mStopMove = 0;
-    mUseHioRates = 0;
-
-    mDepthRate[0] = 0.05f;
-    mDepthRate[1] = 0.125f;
-    mDepthRate[2] = 0.175f;
-    mDepthRate[3] = 0.15f;
-    mDepthRate[4] = 0.0625f;
-    mDepthRate[5] = 0.15f;
-    mDepthRate[6] = 0.2f;
-    mDepthRate[7] = 0.15f;
-    mDepthRate[8] = 0.075f;
-    mDepthRate[9] = 0.175f;
-    mDepthRate[10] = 0.175f;
-    mDepthRate[11] = 0.1f;
-    mDepthRate[12] = 0.0f;
-
-    mWaveRate[0] = 1.0f;
-    mWaveRate[1] = 0.425f;
-    mWaveRate[2] = 0.45f;
-    mWaveRate[3] = 0.4f;
-    mWaveRate[4] = 0.2f;
-    mWaveRate[5] = 0.4f;
-    mWaveRate[6] = 0.45f;
-    mWaveRate[7] = 0.4f;
-    mWaveRate[8] = 0.2f;
-    mWaveRate[9] = 0.5f;
-    mWaveRate[10] = 0.75f;
-    mWaveRate[11] = 1.0f;
-    mWaveRate[12] = 1.0f;
-}
-
 /* 800E8CC0-800E8D48       .text setBackNrm__13daHo_packet_cFv */
 void daHo_packet_c::setBackNrm() {
     cXyz* nrm = getNrm();

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -67,8 +67,8 @@ void daHo_packet_c::setNrmVtx(cXyz* i_nrm, int i_x, int i_y) {
     cXyz leftRight;
     cXyz upDown;
     cXyz triNrm;
-    cXyz pos;
     cXyz nrm;
+    cXyz pos;
     cXyz* vtxPos = getPos();
     s32 idx = i_y * 7;
 
@@ -136,6 +136,7 @@ void daHo_packet_c::setNrmVtx(cXyz* i_nrm, int i_x, int i_y) {
 void daHo_packet_c::setTopNrmVtx(cXyz* i_nrm) {
     cXyz sp18;
     cXyz sp0C;
+    cXyz sp24;
     cXyz nrm;
     cXyz* vtxPos = getPos();
 
@@ -143,8 +144,8 @@ void daHo_packet_c::setTopNrmVtx(cXyz* i_nrm) {
     sp0C = vtxPos[83] - vtxPos[84];
     nrm = sp18.outprod(sp0C);
     nrm = nrm.normZC();
-    MtxPosition(&nrm, &sp18);
-    *i_nrm = sp18.normZC();
+    MtxPosition(&nrm, &sp24);
+    *i_nrm = sp24.normZC();
 }
 
 /* 800E93B8-800E9BE8       .text draw__13daHo_packet_cFv */

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -650,8 +650,7 @@ bool daGrid_c::_execute() {
     int alpha = i_this->mPacket.mAlpha;
 
     if (!dComIfGp_event_runCheck()) {
-        camera_class* camera = dComIfGp_getCamera(0);
-        cXyz eye = camera->mCamera.Eye();
+        cXyz eye = dComIfGp_getCamera(0)->mCamera.Eye();
         f32 dist = (i_this->current.pos - eye).abs();
 
         if (dist > l_HIO.mAlphaDist) {

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -343,8 +343,10 @@ void ho_move(daGrid_c* i_this) {
 
     f32 windWaveRate = 1.0f + (0.01f + REG6_F(15)) * (windSide * cM_ssin(i_this->m1B44));
     s32 calcWaveSpeed = 2500.0f + (9000.0f * (0.8f * windPow));
-    s32 waveSpeed = 10000;
-    if (calcWaveSpeed <= 10000) {
+    s32 waveSpeed;
+    if (calcWaveSpeed > 10000) {
+        waveSpeed = 10000;
+    } else {
         waveSpeed = calcWaveSpeed;
     }
     i_this->m1B44 += waveSpeed;

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -301,6 +301,9 @@ void ho_move(daGrid_c* i_this) {
         return;
     }
 
+    f32 xWave;
+    f32 zWave;
+
     cXyz* windVec = dKyw_get_wind_vec();
     f32 windPow = dKyw_get_wind_pow();
 
@@ -387,8 +390,6 @@ void ho_move(daGrid_c* i_this) {
 
     int col = 0;
     int row = 0;
-    f32 xWave;
-    f32 zWave;
 
     for (int i = 0; i < 0x55; i++, pos++) {
         f32 clothOpen = 1.0f - i_this->m2200;

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -472,7 +472,7 @@ void ho_move(daGrid_c* i_this) {
 
         pos->x += depthSwing + (0.35f * clothOpen + 0.65f) * (i_this->m2204 * xWave);
         pos->y += rowSwing + (0.35f * clothOpen + 0.65f) * yWave;
-        pos->z += zSag + (0.35f * clothOpen + 0.65f) * (i_this->m2204 * zWave) - 13.75f;
+        pos->z += zSag + ((0.35f * clothOpen + 0.65f) * (i_this->m2204 * zWave) - 13.75f);
 
         row = col < 6 ? row : row + 1;
         col = col < 6 ? col + 1 : 0;

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -432,12 +432,12 @@ void ho_move(daGrid_c* i_this) {
             foldRate *= clothOpen + l_HIO.mWaveRate[row] * i_this->m2200;
             depthRate = l_HIO.mDepthRate[row];
             depthSwing *= depthRate * i_this->m2200;
-            rowSwing = 5.0f * depthRate * row * i_this->m2200;
+            rowSwing = 5.0f * depthRate * col * i_this->m2200;
         } else {
             foldRate *= clothOpen + l_defaultWaveRate[row] * i_this->m2200;
             depthRate = l_defaultDepthRate[row];
             depthSwing *= depthRate * i_this->m2200;
-            rowSwing = 5.0f * depthRate * row * i_this->m2200;
+            rowSwing = 5.0f * depthRate * col * i_this->m2200;
         }
 
         pos->x = gridPos[i].x;

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -591,18 +591,17 @@ cPhs_State daGrid_c::_create() {
             }
         }
 
+        f32 currentY = gridPos[i].y;
+        Vec* topPos = &gridPos[columnTop];
         f32 verticalAmplitude;
         f32 verticalDist;
         f32 verticalLimit;
         f32 verticalRate;
-        f32 currentY = gridPos[i].y;
-        Vec* topPos = &gridPos[columnTop];
         if (currentY < topPos->y) {
-            verticalDist = std::fabsf(currentY - gridPos[0].y);
+            verticalDist = std::fabsf(gridPos[0].y - currentY);
             verticalLimit = std::fabsf(topPos->y - currentY);
-            f32 verticalEdgeDist = std::fabsf(gridPos[0].y - topPos->y);
-            verticalEdgeDist *= 0.5f;
-            verticalRate = 1.05f * (1.5707964f / verticalEdgeDist);
+            f32 verticalEdgeDist = std::fabsf(topPos->y - gridPos[0].y);
+            verticalRate = 1.05f * ((1.5707964f / verticalEdgeDist) * 2.0f);
             if (columnTop == 56) {
                 verticalAmplitude = 35.0f;
             } else if (columnTop == 57) {
@@ -612,10 +611,9 @@ cPhs_State daGrid_c::_create() {
             }
         } else {
             verticalDist = std::fabsf(topPos->y - currentY);
-            verticalLimit = std::fabsf(currentY - gridPos[84].y);
-            f32 verticalEdgeDist = std::fabsf(gridPos[84].y - topPos->y);
-            verticalEdgeDist *= 0.5f;
-            verticalRate = 1.15f * (1.5707964f / verticalEdgeDist);
+            verticalLimit = std::fabsf(gridPos[84].y - currentY);
+            f32 verticalEdgeDist = std::fabsf(topPos->y - gridPos[84].y);
+            verticalRate = 1.15f * ((1.5707964f / verticalEdgeDist) * 2.0f);
             verticalAmplitude = 20.0f;
         }
 

--- a/src/d/actor/d_a_grid.cpp
+++ b/src/d/actor/d_a_grid.cpp
@@ -476,9 +476,7 @@ void ho_move(daGrid_c* i_this) {
         pos->y += rowSwing + waveScale * yWave;
         pos->z += zSag + waveScale * (i_this->m2204 * zWave) - 13.75f;
 
-        if (col >= 6) {
-            row++;
-        }
+        row = col >= 6 ? row + 1 : row;
         col = col < 6 ? col + 1 : 0;
     }
 


### PR DESCRIPTION
## Summary

Decompiles `d/actor/d_a_grid.cpp` and adds the actor/header structure for `daGrid_c`, `daHo_packet_c`, and `daHo_HIO_c`.

This is marked `Equivalent` because the TU is function/data complete locally, but the linked DOL still differs by weak destructor ordering.

## Status

Local matching status for `d_a_grid`:

```text
matched_functions: 20 / 20
matched_code:      10572 / 10572
matched_data:      3100 / 3100
```

The remaining linked-DOL difference is weak function order only:

```text
target:
__sinit_d_a_grid_cpp
__dt__10daHo_HIO_cFv
__dt__13daHo_packet_cFv
Eye__9dCamera_cFv

current:
__sinit_d_a_grid_cpp
__dt__13daHo_packet_cFv
__dt__10daHo_HIO_cFv
Eye__9dCamera_cFv
```

The packet and HIO destructors themselves match; only their weak emission/link order differs.

## Notes

I avoided fakematching and inline asm here. Most of the final work was source-shape cleanup around `create` and `ho_move`, with local scripted variant testing to narrow down lifetime/expression-order issues instead of adding artificial code.

I also tried the non-fakematch destructor-order fixes I could think of, including explicit/implicit packet destructor changes, out-of-class inline destructor definitions, moving destructor definitions between header/cpp, and class-order variants. Those did not solve the weak order.

ref #578
