### PR TITLE
d_a_himo2: improve match to 57/59 functions

### DIFF
--- a/include/d/actor/d_a_himo2.h
+++ b/include/d/actor/d_a_himo2.h
@@ -64,8 +64,7 @@ struct himo2_class {
     /* 0x2180 */ fpc_ProcID m2180;
     /* 0x2184 */ f32 m2184;
     /* 0x2188 */ f32 m2188;
-    /* 0x218C */ fopAc_ac_c* m218C;
-    /* 0x2190 */ u8 m2190[0x24AC - 0x2190];
+    /* 0x218C */ fopAc_ac_c* m218C[200];
     /* 0x24AC */ u8 m24AC;
     /* 0x24AD */ u8 m24AD[0x24B0 - 0x24AD];
     /* 0x24B0 */ J3DModel* m24B0;

--- a/include/d/actor/d_a_himo2.h
+++ b/include/d/actor/d_a_himo2.h
@@ -49,8 +49,7 @@ struct himo2_class {
     /* 0x1120 */ himo2_s m1120[100];
     /* 0x1F30 */ mDoExt_3DlineMat1_c m1F30;
     /* 0x1F6C */ s32 m1F6C;
-    /* 0x1F70 */ f32 m1F70;
-    /* 0x1F74 */ u8 m1F74[0x1F84 - 0x1F74];
+    /* 0x1F70 */ f32 m1F70[5];
     /* 0x1F84 */ cXyz m1F84;
     /* 0x1F90 */ s16 m1F90;
     /* 0x1F92 */ s16 m1F92;

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -1684,12 +1684,12 @@ void new_himo2_move(himo2_class* i_this) {
 BOOL daHimo2_Execute(himo2_class* i_this) {
     /* Nonmatching - last for loop, regalloc */
     fopAc_ac_c* actor = &i_this->actor;
+    daPy_py_c* apdVar1 = (daPy_py_c*)dComIfGp_getPlayer(0);
     himo2_s* phVar3;
     int iVar4;
     int iVar5;
     cXyz local_c8;
 
-    daPy_py_c* apdVar1 = daPy_getPlayerActorClass();
 #if VERSION > VERSION_DEMO
     if (btd == NULL) {
         btd = (btd_class*)fpcM_Search(b_a_sub, i_this);

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -368,7 +368,6 @@ static BOOL daHimo2_Draw(himo2_class* i_this) {
     f32 dVar14;
     cXyz local_a4c;
     cXyz local_a40;
-    cXyz local_a34;
     cXyz local_a28;
     cXyz local_a1c;
     f32 local_b0;
@@ -490,16 +489,16 @@ static BOOL daHimo2_Draw(himo2_class* i_this) {
             local_a1c.y = (REG0_F(7) + -10.0f - i_this->m1FD4) * i_this->m1F70;
             local_a1c.z = (REG0_F(8) + 10.0f + i_this->m1FD4) * i_this->m1F70;
             MtxPosition(&local_a1c, &local_a28);
-            local_a34.x = local_a34.x * 0.06666667f;
-            local_a34.y = local_a34.y * 0.06666667f;
-            local_a34.z = local_a34.z * 0.06666667f;
+            local_a4c.x = local_a4c.x * 0.06666667f;
+            local_a4c.y = local_a4c.y * 0.06666667f;
+            local_a4c.z = local_a4c.z * 0.06666667f;
             int uVar6 = 0;
             int uVar4 = 0;
             for (int i = 0; i < 16; i++) {
                 f32 fVar1 = cM_ssin(uVar4);
-                pcVar7->x = i_this->m02EC[0].x + local_a34.x * uVar6 + local_a28.x * fVar1;
-                pcVar7->y = i_this->m02EC[0].y + local_a34.y * uVar6 + local_a28.y * fVar1;
-                pcVar7->z = i_this->m02EC[0].z + local_a34.z * uVar6 + local_a28.z * fVar1;
+                pcVar7->x = i_this->m02EC[0].x + local_a4c.x * uVar6 + local_a28.x * fVar1;
+                pcVar7->y = i_this->m02EC[0].y + local_a4c.y * uVar6 + local_a28.y * fVar1;
+                pcVar7->z = i_this->m02EC[0].z + local_a4c.z * uVar6 + local_a28.z * fVar1;
                 pcVar7++;
                 uVar6 += 1;
                 uVar4 += 0x888;

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -117,7 +117,7 @@ void spin_draw(himo2_class* i_this) {
     sVar8 = -0x30d4;
     pcVar7 = i_this->m1F30.getPos(0) + i_this->m1F6C;
     cXyz local_4f8[100];
-    for (iVar11 = 0, iVar6 = 0; iVar11 < 100; iVar11++, iVar6 += 12) {
+    for (iVar11 = 0, iVar6 = 0; iVar11 < 100; iVar11++, iVar6++) {
         local_4f8[iVar6].y = -200000.0f;
         if (iVar11 < 50) {
             sVar3 = sVar8;

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -487,8 +487,10 @@ static BOOL daHimo2_Draw(himo2_class* i_this) {
             local_a4c.x *= 0.06666667f;
             local_a4c.y *= 0.06666667f;
             local_a4c.z *= 0.06666667f;
-            int uVar4 = 0;
-            int uVar6 = 0;
+            int uVar4;
+            int uVar6;
+            uVar6 = 0;
+            uVar4 = 0;
             for (int i = 0; i < 16; i++) {
                 f32 fVar1 = cM_ssin(uVar4);
                 pcVar7->x = i_this->m02EC[1].x + local_a4c.x * uVar6 + local_a28.x * fVar1;

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -766,7 +766,6 @@ void new_himo2_move(himo2_class* i_this) {
     fopAc_ac_c* r24;
     dAttention_c* attention; // r23
     u32 r30;
-    int r23;
     s16 r22;
     f32 f31;
     f32 f30;
@@ -871,7 +870,7 @@ void new_himo2_move(himo2_class* i_this) {
                 fopAcM_seStart(actor, JA_SE_LK_ROPE_COIL_1, 0);
             }
         } else {
-            r23 = (i_this->m2188 * (REG0_F(3) + 0.060000002f));
+            int r23 = (i_this->m2188 * (REG0_F(3) + 0.060000002f));
             i_this->m02CC = 97 - r23;
             cLib_addCalc2(&actor->current.pos.x, sp100.x, 1.0f, i_this->m2500 * 200.0f);
             cLib_addCalc2(&actor->current.pos.y, sp100.y, 1.0f, i_this->m2500 * 200.0f);
@@ -995,7 +994,7 @@ void new_himo2_move(himo2_class* i_this) {
         f27 = (dVar25 * dVar25);
         f32 f26 = std::sqrtf(f31 + (f27 + (f30 * f30)));
         f27 = std::sqrtf(f27 + f31);
-        r23 = (s16)(f26 * (REG0_F(3) + -5.0f));
+        int r23 = (s16)(f26 * (REG0_F(3) + -5.0f));
         if (r23 < (s16)(REG0_S(2) + -3000)) {
             r23 = REG0_S(2) + -3000;
         }
@@ -1076,7 +1075,7 @@ void new_himo2_move(himo2_class* i_this) {
         MtxPosition(&sp130, &actor->speed);
         actor->current.pos += actor->speed;
         pl_pos_add(i_this);
-        r23 = himo2_bg_check(i_this);
+        int r23 = himo2_bg_check(i_this);
         if (r23 != 0) {
             r26 = true;
             i_this->m2500 = 0.1f;
@@ -1109,7 +1108,7 @@ void new_himo2_move(himo2_class* i_this) {
             if (i_this->m2184 < 0.1f) {
                 fopAcM_SetParam(actor, 0);
             }
-            r23 = (i_this->m2188 * (REG0_F(5) + 0.060000002f));
+            int r23 = (i_this->m2188 * (REG0_F(5) + 0.060000002f));
             r23 = 97 - r23;
             if ((r23 < i_this->m02CC) || (i_this->m2184 < 0.1f)) {
                 i_this->m02CC = r23;
@@ -1134,7 +1133,7 @@ void new_himo2_move(himo2_class* i_this) {
         cLib_addCalc2(&i_this->m2500, 1.0f, 1.0f, 0.01f);
         pl_pos_add(i_this);
         sp130 = actor->current.pos - sp100;
-        r23 = -1;
+        int r23 = -1;
         if (sp130.abs() > 5.0f) {
             fopAcM_seStart(player, JA_SE_LK_ROPE_UNWIND, 0);
         } else {
@@ -1156,7 +1155,7 @@ void new_himo2_move(himo2_class* i_this) {
         cLib_addCalc2(&i_this->m2500, 1.0f, 1.0f, 0.01f);
         pl_pos_add(i_this);
         sp130 = actor->current.pos - sp100;
-        r23 = -1;
+        int r23 = -1;
         if (sp130.abs() > 5.0f) {
             fopAcM_seStart(player, JA_SE_LK_ROPE_UNWIND, 0);
         } else {
@@ -1169,7 +1168,7 @@ void new_himo2_move(himo2_class* i_this) {
         break;
     }
     case 10: {
-        r23 = (i_this->m2188 * (REG0_F(1) + 0.060000002f));
+        int r23 = (i_this->m2188 * (REG0_F(1) + 0.060000002f));
         i_this->m02CC = 100 - r23;
         actor->current.pos = i_this->m2504;
         cLib_addCalc2(&i_this->m02E4, -6.25f, 1.0f, 0.375f);
@@ -1186,7 +1185,7 @@ void new_himo2_move(himo2_class* i_this) {
     }
     case 11: {
         actor->current.pos = i_this->m2504;
-        r23 = (i_this->m2188 * (REG0_F(2) + 0.060000002f));
+        int r23 = (i_this->m2188 * (REG0_F(2) + 0.060000002f));
         i_this->m02CC = 100 - r23;
         i_this->m217C->health = 3;
     label_1260:

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -490,9 +490,9 @@ static BOOL daHimo2_Draw(himo2_class* i_this) {
             int uVar4 = 0;
             for (int i = 0; i < 16; i++) {
                 f32 fVar1 = cM_ssin(uVar4);
-                pcVar7->x = i_this->m02EC[0].x + local_a4c.x * uVar6 + local_a28.x * fVar1;
-                pcVar7->y = i_this->m02EC[0].y + local_a4c.y * uVar6 + local_a28.y * fVar1;
-                pcVar7->z = i_this->m02EC[0].z + local_a4c.z * uVar6 + local_a28.z * fVar1;
+                pcVar7->x = i_this->m02EC[1].x + local_a4c.x * uVar6 + local_a28.x * fVar1;
+                pcVar7->y = i_this->m02EC[1].y + local_a4c.y * uVar6 + local_a28.y * fVar1;
+                pcVar7->z = i_this->m02EC[1].z + local_a4c.z * uVar6 + local_a28.z * fVar1;
                 pcVar7++;
                 uVar6 += 1;
                 uVar4 += 0x888;

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -278,8 +278,8 @@ void himo2_draw(himo2_class* i_this, himo2_s* param_2) {
     /* Nonmatching - regalloc */
     fopAc_ac_c* actor = &i_this->actor;
     daPy_py_c* apdVar1 = (daPy_py_c*)dComIfGp_getPlayer(0);
-    himo2_s* phVar4;
     int iVar2;
+    himo2_s* phVar4;
     cXyz* pcVar6;
     pcVar6 = i_this->m1F30.getPos(0);
     pcVar6 += i_this->m1F6C;

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -372,8 +372,6 @@ static BOOL daHimo2_Draw(himo2_class* i_this) {
     cXyz local_a40;
     cXyz local_a28;
     cXyz local_a1c;
-    f32 local_b0;
-    f32 local_a8;
 
     if (((i_this->m24D9 >= 0) && (i_this->m029E == 0)) &&
         (i_this->m02DC != 0 || (!(daPy_getPlayerActorClass()->checkPlayerNoDraw()) && !(daPy_getPlayerActorClass()->checkPlayerGuard()))))
@@ -423,7 +421,6 @@ static BOOL daHimo2_Draw(himo2_class* i_this) {
             if (local_a28.z < -16384.0f) {
                 local_a28.z = -16384.0f;
             }
-            local_b0 = local_a28.z;
             cLib_addCalcAngleS2(&i_this->m1F90, local_a28.z, 2, REG0_S(2) + 0x800);
             local_a28.x *= REG0_F(6) + -200.0f;
             fVar1 = REG0_F(7) + 4000.0f;
@@ -433,7 +430,6 @@ static BOOL daHimo2_Draw(himo2_class* i_this) {
             if (local_a28.x < -fVar1) {
                 local_a28.x = -fVar1;
             }
-            local_a8 = local_a28.x;
             cLib_addCalcAngleS2(&i_this->m1F94, local_a28.x, 2, REG0_S(2) + 0x800);
             if (local_a28.y < REG0_F(8) + -20.0f) {
                 cLib_addCalcAngleS2(&i_this->m1F92, -0x8000, 2, 0x1000);
@@ -462,7 +458,6 @@ static BOOL daHimo2_Draw(himo2_class* i_this) {
                 local_a1c.y = (dVar10 * i_this->m1F70[iVar3]);
                 cMtx_YrotS(*calc_mtx, apdVar2->shape_angle.y);
                 iVar8 = ((dVar11 - i_this->m1F70[iVar3]) * (dVar12 + REG0_F(13)));
-                local_a8 = iVar8;
                 cMtx_ZrotM(*calc_mtx, i_this->m1F92 + iVar9 * (REG0_S(0) + i_this->m1F94 + -2000) + iVar8);
                 cMtx_XrotM(*calc_mtx, i_this->m1F90);
                 MtxTrans(0.0f, -local_a1c.y, 0.0f, true);
@@ -478,7 +473,6 @@ static BOOL daHimo2_Draw(himo2_class* i_this) {
             i_this->m1F98.update(0x20, rope_scale, local_a54, 0, &actor->tevStr);
             dComIfGd_set3DlineMat(&i_this->m1F98);
             pcVar7 = i_this->m1FD8.getPos(0);
-            local_a8 = i_this->m2188;
             if (((int)i_this->m2188 & REG0_S(4) + 64) != 0) {
                 fVar1 = REG0_F(14) + 15.0f;
             } else {

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -391,21 +391,17 @@ static BOOL daHimo2_Draw(himo2_class* i_this) {
         } else {
             pcVar7 = i_this->m1F30.getPos(0);
             cXyz local_a10[200];
-            iVar3 = 0;
-            for (iVar5 = 0; iVar5 < i_this->m1F6C; iVar5++) {
+            for (iVar5 = 0, iVar3 = 0; iVar5 < i_this->m1F6C; iVar5++, iVar3++) {
                 local_a10[iVar3].x = pcVar7->x;
                 local_a10[iVar3].y = pcVar7->y;
                 local_a10[iVar3].z = pcVar7->z;
                 pcVar7++;
-                iVar3++;
             }
-            iVar3 = 0;
-            for (iVar5 = 0; iVar5 < i_this->m1F6C; iVar5++) {
+            for (iVar5 = 0, iVar3 = 0; iVar5 < i_this->m1F6C; iVar5++, iVar3++) {
                 pcVar7--;
                 pcVar7->x = local_a10[iVar3].x;
                 pcVar7->y = local_a10[iVar3].y;
                 pcVar7->z = local_a10[iVar3].z;
-                iVar3++;
             }
             GXColor local_a50 = {200, 0x96, 50, 0xFF};
             i_this->m1F30.update((u16)i_this->m1F6C, rope_scale, local_a50, 0, &actor->tevStr);

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -817,9 +817,9 @@ void new_himo2_move(himo2_class* i_this) {
         i_this->m029E = 0;
     }
     r27 = false;
-    r26 = false;
     r25 = false;
     r24 = NULL;
+    r26 = false;
     if (attention->LockonTruth()) {
         r24 = attention->LockonTarget(0);
         if (r24) {

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -589,17 +589,15 @@ fopAc_ac_c* search_target(himo2_class* i_this, cXyz param_2) {
                             }
                             if ((sVar14 > (s16)-sVar15) && (sVar14 < sVar15)) {
                                 f32 target_dist = std::sqrtf(target_vec.x * target_vec.x + target_vec.z * target_vec.z);
-                                iVar16 = cM_atan2s(target_vec.y, target_dist);
+                                s16 negTarget = -cM_atan2s(target_vec.y, target_dist);
                                 f32 actor_dist_xz = std::sqrtf(actor_vec.x * actor_vec.x + actor_vec.z * actor_vec.z);
-                                int iVar19 = cM_atan2s(actor_vec.y, actor_dist_xz);
+                                int negActor = -cM_atan2s(actor_vec.y, actor_dist_xz);
                                 if (bVar1) {
                                     sVar14 = 2000;
                                 } else {
                                     sVar14 = l_himo2HIO.m0C;
                                 }
-                                int negTarget = -iVar16;
-                                int negActor = -iVar19;
-                                if ((negTarget < negActor + l_himo2HIO.m0E) && ((negActor + iVar16) < sVar14)) {
+                                if ((negTarget < negActor + l_himo2HIO.m0E) && ((s16)(negActor - negTarget) < sVar14)) {
                                     return pfVar18;
                                 }
                             }

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -444,24 +444,24 @@ static BOOL daHimo2_Draw(himo2_class* i_this) {
             local_a1c.z = 0.0f;
             local_a1c.x = 0.0f;
             dVar13 = ((REG0_F(10) + i_this->m2188 * (REG0_F(9) + 3.0f)) - 120.0f);
-            iVar5 = 0;
             iVar3 = 0;
+            iVar5 = 0;
             dVar14 = 300.0f;
             dVar10 = 15.0f;
             dVar11 = 1.0f;
             dVar12 = -20000.0f;
             for (int iVar9 = 0; iVar9 < 5; iVar9++) {
-                pcVar7 = i_this->m1F98.getPos(iVar3);
+                pcVar7 = i_this->m1F98.getPos(iVar5);
 
                 if (dVar13 > (dVar14 * (4 - iVar9))) {
-                    cLib_addCalc0(&i_this->m1F70[iVar9], dVar11, (REG0_F(11) + 0.2f));
+                    cLib_addCalc0(&i_this->m1F70[iVar3], dVar11, (REG0_F(11) + 0.2f));
                 } else {
-                    cLib_addCalc2(&i_this->m1F70[iVar9], 1.0f, 1.0f, REG0_F(12) + 0.1f);
+                    cLib_addCalc2(&i_this->m1F70[iVar3], 1.0f, 1.0f, REG0_F(12) + 0.1f);
                 }
 
-                local_a1c.y = (dVar10 * i_this->m1F70[iVar9]);
+                local_a1c.y = (dVar10 * i_this->m1F70[iVar3]);
                 cMtx_YrotS(*calc_mtx, apdVar2->shape_angle.y);
-                iVar8 = ((dVar11 - i_this->m1F70[iVar9]) * (dVar12 + REG0_F(13)));
+                iVar8 = ((dVar11 - i_this->m1F70[iVar3]) * (dVar12 + REG0_F(13)));
                 local_a8 = iVar8;
                 cMtx_ZrotM(*calc_mtx, i_this->m1F92 + iVar9 * (REG0_S(0) + i_this->m1F94 + -2000) + iVar8);
                 cMtx_XrotM(*calc_mtx, i_this->m1F90);
@@ -471,8 +471,8 @@ static BOOL daHimo2_Draw(himo2_class* i_this) {
                     MtxPosition(&local_a1c, pcVar7);
                     *pcVar7 += i_this->m02EC[1];
                 }
-                iVar5 += 4;
-                iVar3 += 24;
+                iVar3++;
+                iVar5++;
             }
             GXColor local_a54 = {200, 0x96, 50, 0xFF};
             i_this->m1F98.update(0x20, rope_scale, local_a54, 0, &actor->tevStr);

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -234,10 +234,10 @@ void himo2_control2(himo2_class* i_this, himo2_s* param_2) {
         local_a8.z = i_this->m2188 * 15.625f * (REG0_F(1) + 0.0007f);
     }
     f32 dVar9 = 0.0f;
+    f32 dVar10 = 0.0f;
     f32 dVar8 = (REG8_F(17) + 10.0f);
     int iVar4 = i_this->m02CC + 1;
     himo2_s* puVar6 = param_2 + 98;
-    f32 dVar10 = dVar9;
     for (; iVar4 < 100; iVar4++, puVar6--) {
         f32 dVar11 = (puVar6->m10.y - puVar6[1].m10.y);
         int iVar3 = i_this->m02DC;

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -122,7 +122,7 @@ void spin_draw(himo2_class* i_this) {
         if (iVar11 < 50) {
             sVar3 = sVar8;
             sVar8 += (s16)(REG0_S(2) + 100);
-        } else if ((iVar11 >= 50) && (i_this->m24BC + 49 <= iVar11)) {
+        } else if ((iVar11 >= 50) && (iVar11 <= i_this->m24BC + 49)) {
             sVar3 = sVar8;
             sVar8 = (s16)(sVar8 + i_this->m24C8);
             if (iVar11 >= 100 - (REG0_S(4) + 5)) {
@@ -155,7 +155,7 @@ void spin_draw(himo2_class* i_this) {
                 MtxTrans(local_51c.x, local_51c.y, local_51c.z, false);
                 cMtx_YrotM(*calc_mtx, sVar2);
                 cMtx_ZrotM(*calc_mtx, sVar4);
-                cMtx_XrotM(*calc_mtx, sVar8);
+                cMtx_XrotM(*calc_mtx, sVar3);
                 cMtx_YrotM(*calc_mtx, sVar9);
                 MtxTrans(0.0f, 0.0f, -3.0f, true);
                 cMtx_XrotM(*calc_mtx, i_this->m24CA);

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -403,11 +403,11 @@ static BOOL daHimo2_Draw(himo2_class* i_this) {
             }
             iVar3 = 0;
             for (iVar5 = 0; iVar5 < i_this->m1F6C; iVar5++) {
-                pcVar7[-1].x = local_a10[iVar3].x;
-                pcVar7[0].y = local_a10[iVar3].y;
-                pcVar7[0].z = local_a10[iVar3].z;
+                pcVar7--;
+                pcVar7->x = local_a10[iVar3].x;
+                pcVar7->y = local_a10[iVar3].y;
+                pcVar7->z = local_a10[iVar3].z;
                 iVar3++;
-                pcVar7 = pcVar7 + -1;
             }
             GXColor local_a50 = {200, 0x96, 50, 0xFF};
             i_this->m1F30.update((u16)i_this->m1F6C, rope_scale, local_a50, 0, &actor->tevStr);
@@ -454,14 +454,14 @@ static BOOL daHimo2_Draw(himo2_class* i_this) {
                 pcVar7 = i_this->m1F98.getPos(iVar3);
 
                 if (dVar13 > (dVar14 * (4 - iVar9))) {
-                    cLib_addCalc0(&i_this->m1F70, dVar11, (REG0_F(11) + 0.2f));
+                    cLib_addCalc0(&i_this->m1F70[iVar9], dVar11, (REG0_F(11) + 0.2f));
                 } else {
-                    cLib_addCalc2(&i_this->m1F70, 1.0f, 1.0f, REG0_F(12) + 0.1f);
+                    cLib_addCalc2(&i_this->m1F70[iVar9], 1.0f, 1.0f, REG0_F(12) + 0.1f);
                 }
 
-                local_a1c.y = (dVar10 * i_this->m1F70);
+                local_a1c.y = (dVar10 * i_this->m1F70[iVar9]);
                 cMtx_YrotS(*calc_mtx, apdVar2->shape_angle.y);
-                iVar8 = ((dVar11 - i_this->m1F70) * (dVar12 + REG0_F(13)));
+                iVar8 = ((dVar11 - i_this->m1F70[iVar9]) * (dVar12 + REG0_F(13)));
                 local_a8 = iVar8;
                 cMtx_ZrotM(*calc_mtx, i_this->m1F92 + iVar9 * (REG0_S(0) + i_this->m1F94 + -2000) + iVar8);
                 cMtx_XrotM(*calc_mtx, i_this->m1F90);
@@ -488,8 +488,8 @@ static BOOL daHimo2_Draw(himo2_class* i_this) {
             local_a4c = i_this->m02EC[0] - i_this->m02EC[1];
             cMtx_YrotS(*calc_mtx, (cM_atan2s(local_a4c.x, local_a4c.z) + REG0_S(0) + -0x4000));
             local_a1c.x = 0.0f;
-            local_a1c.y = (REG0_F(7) + -10.0f - i_this->m1FD4) * i_this->m1F70;
-            local_a1c.z = (REG0_F(8) + 10.0f + i_this->m1FD4) * i_this->m1F70;
+            local_a1c.y = (REG0_F(7) + -10.0f - i_this->m1FD4) * i_this->m1F70[0];
+            local_a1c.z = (REG0_F(8) + 10.0f + i_this->m1FD4) * i_this->m1F70[0];
             MtxPosition(&local_a1c, &local_a28);
             local_a4c.x = local_a4c.x * 0.06666667f;
             local_a4c.y = local_a4c.y * 0.06666667f;

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -278,7 +278,9 @@ void himo2_draw(himo2_class* i_this, himo2_s* param_2) {
     daPy_py_c* apdVar1 = (daPy_py_c*)dComIfGp_getPlayer(0);
     himo2_s* phVar4;
     int iVar2;
-    cXyz* pcVar6 = i_this->m1F30.getPos(0) + i_this->m1F6C;
+    cXyz* pcVar6;
+    pcVar6 = i_this->m1F30.getPos(0);
+    pcVar6 += i_this->m1F6C;
     pcVar6->x = i_this->m02B4.x;
     pcVar6->y = i_this->m02B4.y;
     pcVar6->z = i_this->m02B4.z;

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -82,10 +82,7 @@ void spin_draw(himo2_class* i_this) {
 
     sVar4 = 0;
     sVar2 = i_this->m2510;
-    fVar5 = 8.0f;
-    fVar1 = i_this->m217C->scale.y;
-    fVar10 = fVar1 - 1.0f;
-    fVar5 *= fVar10;
+    fVar5 = 8.0f * (fVar10 = (fVar1 = i_this->m217C->scale.y) - 1.0f);
     fVar10 = -7.0f * fVar10;
     #if VERSION > VERSION_DEMO
     if ((fopAcM_GetParam(i_this->m217C) & 0x0F) == 3) {

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -65,16 +65,16 @@ void spin_draw(himo2_class* i_this) {
     /* Nonmatching - regalloc, cXyz */
     fopAc_ac_c* actor = &i_this->actor;
     s16 sVar4;
+    int iVar6;
     s16 sVar3;
     s16 sVar2;
-    f32 fVar1;
-    cXyz* pcVar7;
-    s16 sVar9;
-    s16 sVar8;
     int iVar11;
-    int iVar6;
+    f32 fVar1;
     f32 fVar5;
+    s16 sVar9;
     f32 fVar10;
+    s16 sVar8;
+    cXyz* pcVar7;
     cXyz local_504;
     cXyz local_510;
     cXyz local_51c;

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -525,7 +525,7 @@ fopAc_ac_c* search_target(himo2_class* i_this, cXyz param_2) {
     s16 sVar14;
     s16 sVar15;
     int iVar16;
-    uint uVar17;
+    int uVar17;
     u8 bVar1;
     f32 dVar22;
     f32 search_limit;

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -288,7 +288,7 @@ void himo2_draw(himo2_class* i_this, himo2_s* param_2) {
     phVar4 = param_2 + (i_this->m02CC + 1);
     iVar2 = i_this->m02CC;
     pcVar6++;
-    for (; iVar2 < 98; iVar2++, phVar4++) {
+    for (; iVar2 < 98; iVar2++) {
         if (iVar2 == 97) {
             if ((i_this->m02DC == 0) && (i_this->m2188 < REG0_F(3) + 50.0f)) {
                 MTXCopy(apdVar1->getLeftHandMatrix(), *calc_mtx);
@@ -319,6 +319,7 @@ void himo2_draw(himo2_class* i_this, himo2_s* param_2) {
             i_this->m1F6C++;
             pcVar6++;
         }
+        phVar4++;
     }
 }
 

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -509,7 +509,7 @@ static BOOL daHimo2_Draw(himo2_class* i_this) {
 void* s_a_d_sub(void* param_1, void* param_2) {
     if ((fopAc_IsActor(param_1)) && (fopAcM_GetName(param_1) == PROC_KUI)) {
         himo2_class* rope = (himo2_class*)param_2;
-        (&rope->m218C)[rope->m24AC] = (fopAc_ac_c*)param_1;
+        rope->m218C[rope->m24AC] = (fopAc_ac_c*)param_1;
         rope->m24AC++;
     }
     return NULL;
@@ -537,7 +537,7 @@ fopAc_ac_c* search_target(himo2_class* i_this, cXyz param_2) {
     apdVar11 = daPy_getPlayerActorClass();
     i_this->m24AC = 0;
     for (int iVar16 = 0; iVar16 < 100; iVar16++) {
-        (&i_this->m218C)[iVar16] = NULL;
+        i_this->m218C[iVar16] = NULL;
     }
     fpcM_Search(s_a_d_sub, i_this);
     cMtx_YrotS(*calc_mtx, -apdVar11->shape_angle.y);
@@ -548,7 +548,7 @@ fopAc_ac_c* search_target(himo2_class* i_this, cXyz param_2) {
         uVar17 = 0;
         while (uVar17 < i_this->m24AC) {
                 bVar1 = 0;
-                pfVar18 = (&i_this->m218C)[uVar17];
+                pfVar18 = i_this->m218C[uVar17];
                 if ((fopAcM_GetParam(pfVar18) & 0xF0) != 0) {
                     bVar1 = 1;
                 }

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -592,9 +592,10 @@ fopAc_ac_c* search_target(himo2_class* i_this, cXyz param_2) {
                                 iVar16 = cM_atan2s(target_vec.y, target_dist);
                                 f32 actor_dist_xz = std::sqrtf(actor_vec.x * actor_vec.x + actor_vec.z * actor_vec.z);
                                 int iVar19 = cM_atan2s(actor_vec.y, actor_dist_xz);
-                                sVar14 = l_himo2HIO.m0C;
                                 if (bVar1) {
                                     sVar14 = 2000;
+                                } else {
+                                    sVar14 = l_himo2HIO.m0C;
                                 }
                                 int negTarget = -iVar16;
                                 int negActor = -iVar19;

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -436,13 +436,14 @@ static BOOL daHimo2_Draw(himo2_class* i_this) {
             local_a1c.z = 0.0f;
             local_a1c.x = 0.0f;
             dVar13 = ((REG0_F(10) + i_this->m2188 * (REG0_F(9) + 3.0f)) - 120.0f);
+            int iVar9 = 0;
             iVar3 = 0;
             iVar5 = 0;
             dVar14 = 300.0f;
             dVar10 = 15.0f;
             dVar11 = 1.0f;
             dVar12 = -20000.0f;
-            for (int iVar9 = 0; iVar9 < 5; iVar9++) {
+            for (; iVar9 < 5; iVar9++) {
                 pcVar7 = i_this->m1F98.getPos(iVar5);
 
                 if (dVar13 > (dVar14 * (4 - iVar9))) {
@@ -476,7 +477,7 @@ static BOOL daHimo2_Draw(himo2_class* i_this) {
             }
             cLib_addCalc2(&i_this->m1FD4, fVar1, 1.0f, REG0_F(15) + 4.0f);
             local_a4c = i_this->m02EC[0] - i_this->m02EC[1];
-            cMtx_YrotS(*calc_mtx, cM_atan2s(local_a4c.x, local_a4c.z) + (REG0_S(0) - 0x4000));
+            cMtx_YrotS(*calc_mtx, (cM_atan2s(local_a4c.x, local_a4c.z) - 0x4000) + REG0_S(0));
             local_a1c.x = 0.0f;
             local_a1c.y = REG0_F(7) + -10.0f - i_this->m1FD4;
             local_a1c.z = REG0_F(8) + 10.0f + i_this->m1FD4;

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -399,14 +399,14 @@ static BOOL daHimo2_Draw(himo2_class* i_this) {
                 local_a10[iVar3].y = pcVar7->y;
                 local_a10[iVar3].z = pcVar7->z;
                 pcVar7++;
-                iVar3 = iVar3 + 12;
+                iVar3++;
             }
             iVar3 = 0;
             for (iVar5 = 0; iVar5 < i_this->m1F6C; iVar5++) {
                 pcVar7[-1].x = local_a10[iVar3].x;
                 pcVar7[0].y = local_a10[iVar3].y;
                 pcVar7[0].z = local_a10[iVar3].z;
-                iVar3 = iVar3 + 12;
+                iVar3++;
                 pcVar7 = pcVar7 + -1;
             }
             GXColor local_a50 = {200, 0x96, 50, 0xFF};

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -478,8 +478,10 @@ static BOOL daHimo2_Draw(himo2_class* i_this) {
             local_a4c = i_this->m02EC[0] - i_this->m02EC[1];
             cMtx_YrotS(*calc_mtx, (cM_atan2s(local_a4c.x, local_a4c.z) + REG0_S(0) + -0x4000));
             local_a1c.x = 0.0f;
-            local_a1c.y = (REG0_F(7) + -10.0f - i_this->m1FD4) * i_this->m1F70[0];
-            local_a1c.z = (REG0_F(8) + 10.0f + i_this->m1FD4) * i_this->m1F70[0];
+            local_a1c.y = REG0_F(7) + -10.0f - i_this->m1FD4;
+            local_a1c.z = REG0_F(8) + 10.0f + i_this->m1FD4;
+            local_a1c.y *= i_this->m1F70[0];
+            local_a1c.z *= i_this->m1F70[0];
             MtxPosition(&local_a1c, &local_a28);
             local_a4c.x = local_a4c.x * 0.06666667f;
             local_a4c.y = local_a4c.y * 0.06666667f;

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -64,17 +64,17 @@ dr2_class* dr;
 void spin_draw(himo2_class* i_this) {
     /* Nonmatching - regalloc, cXyz */
     fopAc_ac_c* actor = &i_this->actor;
-    f32 fVar1;
-    s16 sVar2;
-    s16 sVar3;
     s16 sVar4;
-    f32 fVar5;
-    int iVar6;
+    s16 sVar3;
+    s16 sVar2;
+    f32 fVar1;
     cXyz* pcVar7;
     s16 sVar9;
     s16 sVar8;
-    f32 fVar10;
     int iVar11;
+    int iVar6;
+    f32 fVar5;
+    f32 fVar10;
     cXyz local_504;
     cXyz local_510;
     cXyz local_51c;

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -1012,7 +1012,7 @@ void new_himo2_move(himo2_class* i_this) {
         actor->current.pos += actor->speed;
         pl_pos_add(i_this);
         if (i_this->m217C != NULL) {
-            if ((f30 < (actor->speedF * 10.0f)) || (i_this->m0308 == 0)) {
+            if ((f26 < (actor->speedF * 10.0f)) || (i_this->m0308 == 0)) {
                 i_this->m02DC = 10;
                 i_this->m24D9 = 0xFF;
                 i_this->m24D8 = 1;

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -453,7 +453,7 @@ static BOOL daHimo2_Draw(himo2_class* i_this) {
                 local_a1c.y = (dVar10 * i_this->m1F70[iVar3]);
                 cMtx_YrotS(*calc_mtx, apdVar2->shape_angle.y);
                 iVar8 = ((dVar11 - i_this->m1F70[iVar3]) * (dVar12 + REG0_F(13)));
-                cMtx_ZrotM(*calc_mtx, i_this->m1F92 + iVar9 * (REG0_S(0) + i_this->m1F94 + -2000) + iVar8);
+                cMtx_ZrotM(*calc_mtx, i_this->m1F92 + iVar9 * (REG0_S(0) + (i_this->m1F94 - 2000)) + iVar8);
                 cMtx_XrotM(*calc_mtx, i_this->m1F90);
                 MtxTrans(0.0f, -local_a1c.y, 0.0f, true);
                 for (int j = 0; j < 32; j++, pcVar7++) {
@@ -475,7 +475,7 @@ static BOOL daHimo2_Draw(himo2_class* i_this) {
             }
             cLib_addCalc2(&i_this->m1FD4, fVar1, 1.0f, REG0_F(15) + 4.0f);
             local_a4c = i_this->m02EC[0] - i_this->m02EC[1];
-            cMtx_YrotS(*calc_mtx, (cM_atan2s(local_a4c.x, local_a4c.z) + REG0_S(0) + -0x4000));
+            cMtx_YrotS(*calc_mtx, cM_atan2s(local_a4c.x, local_a4c.z) + (REG0_S(0) - 0x4000));
             local_a1c.x = 0.0f;
             local_a1c.y = REG0_F(7) + -10.0f - i_this->m1FD4;
             local_a1c.z = REG0_F(8) + 10.0f + i_this->m1FD4;

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -486,8 +486,8 @@ static BOOL daHimo2_Draw(himo2_class* i_this) {
             local_a4c.x = local_a4c.x * 0.06666667f;
             local_a4c.y = local_a4c.y * 0.06666667f;
             local_a4c.z = local_a4c.z * 0.06666667f;
-            int uVar6 = 0;
             int uVar4 = 0;
+            int uVar6 = 0;
             for (int i = 0; i < 16; i++) {
                 f32 fVar1 = cM_ssin(uVar4);
                 pcVar7->x = i_this->m02EC[1].x + local_a4c.x * uVar6 + local_a28.x * fVar1;

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -1733,7 +1733,7 @@ static BOOL daHimo2_Execute(himo2_class* i_this) {
     }
     new_himo2_move(i_this);
     phVar3 = &i_this->m0310[0];
-    for (iVar5 = 0; iVar5 < i_this->m02CC + 1; iVar5++, phVar3++) {
+    for (iVar4 = 0; iVar4 < i_this->m02CC + 1; iVar4++, phVar3++) {
         phVar3->m10 = i_this->m02B4;
     }
     phVar3 = &i_this->m0310[0];

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -229,6 +229,7 @@ void himo2_control2(himo2_class* i_this, himo2_s* param_2) {
     /* Nonmatching - for loop, regalloc */
     cXyz local_a8;
     cXyz local_b4;
+    int iVar4;
 
     local_a8.x = 0.0f;
     local_a8.y = 0.0f;
@@ -244,7 +245,7 @@ void himo2_control2(himo2_class* i_this, himo2_s* param_2) {
     f32 dVar9;
     dVar10 = dVar9 = 0.0f;
     f32 dVar8 = (REG8_F(17) + 10.0f);
-    int iVar4 = i_this->m02CC + 1;
+    iVar4 = i_this->m02CC + 1;
     for (; iVar4 < 100; iVar4++, puVar6--) {
         dVar11 = (puVar6->m10.y - puVar6[1].m10.y);
         int iVar3 = i_this->m02DC;
@@ -279,6 +280,7 @@ void himo2_draw(himo2_class* i_this, himo2_s* param_2) {
     fopAc_ac_c* actor = &i_this->actor;
     daPy_py_c* apdVar1 = (daPy_py_c*)dComIfGp_getPlayer(0);
     int iVar2;
+    J3DModel* pJVar5;
     himo2_s* phVar4;
     cXyz* pcVar6;
     pcVar6 = i_this->m1F30.getPos(0);
@@ -310,7 +312,7 @@ void himo2_draw(himo2_class* i_this, himo2_s* param_2) {
             local_38.y = 0.0f;
             local_38.z = 15.0f;
             MtxPosition(&local_38, &i_this->m24CC);
-            J3DModel* pJVar5 = i_this->m24B0;
+            pJVar5 = i_this->m24B0;
             pJVar5->setBaseTRMtx(*calc_mtx);
             g_env_light.setLightTevColorType(pJVar5, &actor->tevStr);
             mDoExt_modelUpdateDL(pJVar5);

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -121,14 +121,14 @@ void spin_draw(himo2_class* i_this) {
         local_4f8[iVar6].y = -200000.0f;
         if (iVar11 < 50) {
             sVar3 = sVar8;
-            sVar8 += REG0_S(2) + 100;
+            sVar8 += (s16)(REG0_S(2) + 100);
         } else if ((iVar11 >= 50) && (i_this->m24BC + 49 <= iVar11)) {
             sVar3 = sVar8;
-            sVar8 += i_this->m24C8;
+            sVar8 = (s16)(sVar8 + i_this->m24C8);
             if (iVar11 >= 100 - (REG0_S(4) + 5)) {
                 sVar8 += REG0_S(5) + -1000;
             }
-            if ((i_this->m217C != NULL) && (fopAcM_GetParam(i_this->m217C) != 0)) {
+            if ((i_this->m217C != NULL) && ((fopAcM_GetParam(i_this->m217C) & 0xF0) != 0)) {
                 sVar4 = REG0_S(4) + sVar4 + -400;
             }
         } else {

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -583,7 +583,7 @@ fopAc_ac_c* search_target(himo2_class* i_this, cXyz param_2) {
                             }
                             f32 actor_dist =
                                 std::sqrtf(actor_vec.z * actor_vec.z + (actor_vec.x * actor_vec.x + actor_vec.y * actor_vec.y));
-                            sVar15 = cM_atan2s((pfVar18->scale).z * l_himo2HIO.m10, actor_dist);
+                            sVar15 = (s16)cM_atan2s((pfVar18->scale).z * l_himo2HIO.m10, actor_dist);
                             if (sVar15 < 0) {
                                 sVar15 = -sVar15;
                             }

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -276,13 +276,15 @@ void himo2_draw(himo2_class* i_this, himo2_s* param_2) {
     /* Nonmatching - regalloc */
     fopAc_ac_c* actor = &i_this->actor;
     daPy_py_c* apdVar1 = (daPy_py_c*)dComIfGp_getPlayer(0);
+    himo2_s* phVar4;
+    int iVar2;
     cXyz* pcVar6 = i_this->m1F30.getPos(0) + i_this->m1F6C;
     pcVar6->x = i_this->m02B4.x;
     pcVar6->y = i_this->m02B4.y;
     pcVar6->z = i_this->m02B4.z;
     i_this->m1F6C++;
-    himo2_s* phVar4 = param_2 + (i_this->m02CC + 1);
-    int iVar2 = i_this->m02CC;
+    phVar4 = param_2 + (i_this->m02CC + 1);
+    iVar2 = i_this->m02CC;
     pcVar6++;
     for (; iVar2 < 98; iVar2++, phVar4++) {
         if (iVar2 == 97) {

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -483,9 +483,9 @@ static BOOL daHimo2_Draw(himo2_class* i_this) {
             local_a1c.y *= i_this->m1F70[0];
             local_a1c.z *= i_this->m1F70[0];
             MtxPosition(&local_a1c, &local_a28);
-            local_a4c.x = local_a4c.x * 0.06666667f;
-            local_a4c.y = local_a4c.y * 0.06666667f;
-            local_a4c.z = local_a4c.z * 0.06666667f;
+            local_a4c.x *= 0.06666667f;
+            local_a4c.y *= 0.06666667f;
+            local_a4c.z *= 0.06666667f;
             int uVar4 = 0;
             int uVar6 = 0;
             for (int i = 0; i < 16; i++) {

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -368,10 +368,10 @@ static BOOL daHimo2_Draw(himo2_class* i_this) {
     f32 dVar12;
     f32 dVar13;
     f32 dVar14;
-    cXyz local_a4c;
     cXyz local_a40;
-    cXyz local_a28;
     cXyz local_a1c;
+    cXyz local_a28;
+    cXyz local_a4c;
 
     if (((i_this->m24D9 >= 0) && (i_this->m029E == 0)) &&
         (i_this->m02DC != 0 || (!(daPy_getPlayerActorClass()->checkPlayerNoDraw()) && !(daPy_getPlayerActorClass()->checkPlayerGuard()))))

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -262,7 +262,7 @@ void himo2_control2(himo2_class* i_this, himo2_s* param_2) {
         f32 dVar6 = fVar2;
         iVar3 = cM_atan2s(fVar1, fVar2);
         dVar6 = std::sqrtf((dVar7 * dVar7) + (dVar6 * dVar6));
-        s16 iVar5 = -cM_atan2s(dVar11, dVar6);
+        int iVar5 = (s16)-cM_atan2s(dVar11, dVar6);
         puVar6[1].m1E = iVar3;
         puVar6[1].m1C = iVar5;
         cMtx_YrotS(*calc_mtx, iVar3);

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -932,7 +932,7 @@ void new_himo2_move(himo2_class* i_this) {
         break;
     }
     case 1: {
-        mDoMtx_YrotS(*calc_mtx, actor->shape_angle.y);
+        mDoMtx_YrotS(*calc_mtx, player->shape_angle.y);
         mDoMtx_ZrotM(*calc_mtx, REG0_S(2) + -12000);
         mDoMtx_YrotM(*calc_mtx, i_this->m02D8 * (REG0_S(3) + 0x2000));
         sp130.x = 0.0f;

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -66,13 +66,14 @@ void spin_draw(himo2_class* i_this) {
     fopAc_ac_c* actor = &i_this->actor;
     int iVar11;
     s16 sVar3;
-    f32 fVar10;
+    f32 delta;
+    f32 fVar1;
     f32 fVar5;
+    f32 fVar10;
     int iVar6;
     s16 sVar2;
     s16 sVar4;
     s16 sVar9;
-    f32 fVar1;
     s16 sVar8;
     cXyz* pcVar7;
     cXyz local_504;
@@ -82,8 +83,8 @@ void spin_draw(himo2_class* i_this) {
 
     sVar4 = 0;
     sVar2 = i_this->m2510;
-    fVar5 = 8.0f * (fVar10 = (fVar1 = i_this->m217C->scale.y) - 1.0f);
-    fVar10 = -7.0f * fVar10;
+    fVar5 = 8.0f * (delta = (fVar1 = i_this->m217C->scale.y) - 1.0f);
+    fVar10 = -7.0f * delta;
     #if VERSION > VERSION_DEMO
     if ((fopAcM_GetParam(i_this->m217C) & 0x0F) == 3) {
         fVar5 += REG8_F(8) + -3.0f;

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -524,15 +524,6 @@ void* s_a_d_sub(void* param_1, void* param_2) {
 /* 800ECC54-800ED19C       .text search_target__FP11himo2_class4cXyz */
 fopAc_ac_c* search_target(himo2_class* i_this, cXyz param_2) {
     /* Nonmatching - cXyz, regalloc */
-    bool bVar1;
-    f32 fVar2;
-    f32 fVar3;
-    f32 fVar4;
-    f32 fVar5;
-    f32 fVar6;
-    f32 fVar7;
-    f32 fVar8;
-    f32 fVar9;
     daPy_py_c* apdVar11;
     s16 sVar12;
     s16 sVar13;
@@ -541,11 +532,13 @@ fopAc_ac_c* search_target(himo2_class* i_this, cXyz param_2) {
     int iVar16;
     uint uVar17;
     fopAc_ac_c* pfVar18;
-    int iVar19;
-    f32 dVar21;
+    u8 bVar1;
     f32 dVar22;
-    cXyz local_60;
+    f32 search_limit;
     cXyz local_54;
+    cXyz local_60;
+    cXyz target_vec;
+    cXyz actor_vec;
 
     apdVar11 = daPy_getPlayerActorClass();
     i_this->m24AC = 0;
@@ -559,13 +552,12 @@ fopAc_ac_c* search_target(himo2_class* i_this, cXyz param_2) {
     sVar13 = l_himo2HIO.m08 + 0x4000;
     if (i_this->m24AC != 0) {
         uVar17 = 0;
-        do {
-            do {
-                if ((uint)(s8)i_this->m24AC <= uVar17) {
-                    return NULL;
-                }
+        while (uVar17 < i_this->m24AC) {
                 pfVar18 = (&i_this->m218C)[uVar17];
-                bVar1 = fopAcM_GetParam(pfVar18) != 0;
+                bVar1 = 0;
+                if ((fopAcM_GetParam(pfVar18) & 0xF0) != 0) {
+                    bVar1 = 1;
+                }
                 local_54.x = apdVar11->current.pos.x - pfVar18->current.pos.x;
                 local_54.z = apdVar11->current.pos.z - pfVar18->current.pos.z;
                 iVar16 = cM_atan2s(local_54.x, local_54.z);
@@ -576,39 +568,37 @@ fopAc_ac_c* search_target(himo2_class* i_this, cXyz param_2) {
                 } else {
                     i_this->m251C = 0;
                 }
-                if ((bVar1) || (sVar12 > sVar14 && (sVar14 < sVar13))) {
+                if ((bVar1) || (sVar14 > sVar12 && (sVar14 < sVar13))) {
                     local_54.x = pfVar18->current.pos.x - apdVar11->current.pos.x;
                     local_54.y = pfVar18->current.pos.y - apdVar11->current.pos.y;
                     local_54.z = pfVar18->current.pos.z - apdVar11->current.pos.z;
                     MtxPosition(&local_54, &local_60);
                     if ((local_60.z > 100.0f) && (bVar1 || (std::fabsf(local_60.y) < l_himo2HIO.m14))) {
-                        dVar21 = std::sqrtf(local_60.x * local_60.x + local_60.z * local_60.z);
-                        if (dVar21 < dVar22) {
-                            fVar2 = dComIfGp_getCamera(0)->mLookat.mEye.x;
-                            fVar4 = dComIfGp_getCamera(0)->mLookat.mEye.y;
-                            fVar5 = dComIfGp_getCamera(0)->mLookat.mEye.z;
-                            fVar6 = param_2.x - fVar2;
-                            fVar3 = param_2.y;
-                            fVar8 = param_2.z - fVar5;
-                            fVar2 = pfVar18->current.pos.x - fVar2;
-                            fVar7 = pfVar18->current.pos.y - fVar4;
-                            fVar5 = pfVar18->current.pos.z - fVar5;
-                            iVar16 = cM_atan2s(fVar6, fVar8);
-                            iVar19 = cM_atan2s(fVar2, fVar5);
-                            sVar14 = iVar19 - iVar16;
+                        f32 dist = std::sqrtf(local_60.x * local_60.x + local_60.z * local_60.z);
+                        if (dist < dVar22) {
+                            camera_class* camera = dComIfGp_getCamera(0);
+                            target_vec.x = param_2.x - camera->mLookat.mEye.x;
+                            target_vec.y = param_2.y - camera->mLookat.mEye.y;
+                            target_vec.z = param_2.z - camera->mLookat.mEye.z;
+                            actor_vec.x = pfVar18->current.pos.x - camera->mLookat.mEye.x;
+                            actor_vec.y = pfVar18->current.pos.y - camera->mLookat.mEye.y;
+                            actor_vec.z = pfVar18->current.pos.z - camera->mLookat.mEye.z;
+                            iVar16 = cM_atan2s(target_vec.x, target_vec.z);
+                            sVar14 = cM_atan2s(actor_vec.x, actor_vec.z) - iVar16;
                             if (sVar14 < 0) {
                                 sVar14 = -sVar14;
                             }
-                            fVar9 = std::sqrtf(fVar5 * fVar5 + fVar2 * fVar2 + fVar7 * fVar7);
-                            sVar15 = cM_atan2s((pfVar18->scale).z * l_himo2HIO.m10, fVar9);
+                            f32 actor_dist =
+                                std::sqrtf(actor_vec.z * actor_vec.z + actor_vec.x * actor_vec.x + actor_vec.y * actor_vec.y);
+                            sVar15 = cM_atan2s((pfVar18->scale).z * l_himo2HIO.m10, actor_dist);
                             if (sVar15 < 0) {
                                 sVar15 = -sVar15;
                             }
                             if ((-sVar15 > sVar14) && (sVar14 < sVar15)) {
-                                fVar6 = std::sqrtf(fVar6 * fVar6 + fVar8 * fVar8);
-                                iVar16 = cM_atan2s(fVar3 - fVar4, fVar6);
-                                fVar2 = std::sqrtf(fVar2 * fVar2 + fVar5 * fVar5);
-                                iVar19 = cM_atan2s(fVar7, fVar2);
+                                f32 target_dist = std::sqrtf(target_vec.x * target_vec.x + target_vec.z * target_vec.z);
+                                iVar16 = cM_atan2s(target_vec.y, target_dist);
+                                f32 actor_dist_xz = std::sqrtf(actor_vec.x * actor_vec.x + actor_vec.z * actor_vec.z);
+                                int iVar19 = cM_atan2s(actor_vec.y, actor_dist_xz);
                                 sVar14 = l_himo2HIO.m0C;
                                 if (bVar1) {
                                     sVar14 = 2000;
@@ -621,15 +611,19 @@ fopAc_ac_c* search_target(himo2_class* i_this, cXyz param_2) {
                     }
                 }
                 uVar17++;
-            } while (uVar17 != (s8)i_this->m24AC);
-            uVar17 = 0;
-            dVar22 = (dVar22 + 100.0f);
-            if (bVar1) {
-                fVar2 = 2000.0f;
-            } else {
-                fVar2 = l_himo2HIO.m18;
+            if (uVar17 == i_this->m24AC) {
+                uVar17 = 0;
+                dVar22 = (dVar22 + 100.0f);
+                if (bVar1) {
+                    search_limit = 2000.0f;
+                } else {
+                    search_limit = l_himo2HIO.m18;
+                }
+                if (dVar22 > search_limit) {
+                    return NULL;
+                }
             }
-        } while (!(dVar22 > fVar2));
+        }
     }
     return NULL;
 }

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -277,7 +277,7 @@ void himo2_draw(himo2_class* i_this, himo2_s* param_2) {
     pcVar6->z = i_this->m02B4.z;
     i_this->m1F6C++;
     int iVar2 = i_this->m02CC;
-    himo2_s* phVar4 = param_2 + iVar2 + 1;
+    himo2_s* phVar4 = param_2 + (iVar2 + 1);
     pcVar6++;
     for (; iVar2 < 98; iVar2++, phVar4++) {
         if (iVar2 == 97) {

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -115,7 +115,8 @@ void spin_draw(himo2_class* i_this) {
     local_504.y = 0.0f;
     local_504.z = 3.90625f;
     sVar8 = -0x30d4;
-    pcVar7 = i_this->m1F30.getPos(0) + i_this->m1F6C;
+    pcVar7 = i_this->m1F30.getPos(0);
+    pcVar7 += i_this->m1F6C;
     cXyz local_4f8[100];
     for (iVar11 = 0, iVar6 = 0; iVar11 < 100; iVar11++, iVar6++) {
         local_4f8[iVar6].y = -200000.0f;

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -1630,16 +1630,15 @@ void new_himo2_move(himo2_class* i_this) {
     }
     
     if (i_this->m24D9 > 0) {
-        f32 f26 = cM_ssin(i_this->m02D8 * 0x3300);
-        f27 = (i_this->m2520 * f26);
-        f26 = cM_scos(i_this->m02D8 * 0x3000);
+        f26 = i_this->m2520 * cM_ssin(i_this->m02D8 * 0x3300);
+        f27 = cM_scos(i_this->m02D8 * 0x3000);
         cXyz spC4;
         cXyz spB8;
-        f32 f1 = (i_this->m2520 * f26);
-        spC4.x = (i_this->m24DC.x + f27);
+        f32 f1 = (i_this->m2520 * f27);
+        spC4.x = (i_this->m24DC.x + f26);
         spC4.y = i_this->m24DC.y + f1;
         spC4.z = i_this->m24DC.z;
-        spB8.x = (i_this->m24E8.x + f27);
+        spB8.x = (i_this->m24E8.x + f26);
         spB8.y = i_this->m24E8.y + f1;
         spB8.z = i_this->m24E8.z;
         f32 f1_3 = cM_scos(i_this->m02D8 * 0x1C00);

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -280,8 +280,8 @@ void himo2_draw(himo2_class* i_this, himo2_s* param_2) {
     pcVar6->y = i_this->m02B4.y;
     pcVar6->z = i_this->m02B4.z;
     i_this->m1F6C++;
+    himo2_s* phVar4 = param_2 + (i_this->m02CC + 1);
     int iVar2 = i_this->m02CC;
-    himo2_s* phVar4 = param_2 + (iVar2 + 1);
     pcVar6++;
     for (; iVar2 < 98; iVar2++, phVar4++) {
         if (iVar2 == 97) {

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -64,15 +64,15 @@ dr2_class* dr;
 void spin_draw(himo2_class* i_this) {
     /* Nonmatching - regalloc, cXyz */
     fopAc_ac_c* actor = &i_this->actor;
-    s16 sVar4;
-    int iVar6;
-    s16 sVar3;
-    s16 sVar2;
     int iVar11;
-    f32 fVar1;
-    f32 fVar5;
-    s16 sVar9;
+    s16 sVar3;
     f32 fVar10;
+    f32 fVar5;
+    int iVar6;
+    s16 sVar4;
+    s16 sVar9;
+    s16 sVar2;
+    f32 fVar1;
     s16 sVar8;
     cXyz* pcVar7;
     cXyz local_504;

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -1686,6 +1686,7 @@ void new_himo2_move(himo2_class* i_this) {
 static BOOL daHimo2_Execute(himo2_class* i_this) {
     /* Nonmatching - last for loop, regalloc */
     fopAc_ac_c* actor = &i_this->actor;
+    himo2_s* phVar3;
     int iVar4;
     int iVar5;
     cXyz local_c8;
@@ -1721,7 +1722,7 @@ static BOOL daHimo2_Execute(himo2_class* i_this) {
         iVar5 = 3;
     }
     dBgS_GndChk local_bc;
-    himo2_s* phVar3 = &i_this->m1120[0];
+    phVar3 = &i_this->m1120[0];
     for (iVar4 = 0; iVar4 < iVar5; iVar4++, phVar3++) {
         if (i_this->m02DC != 2) {
             local_bc.GetPointP()->set(phVar3->m10.x, phVar3->m10.y + 60.0f, phVar3->m10.z);
@@ -1732,9 +1733,10 @@ static BOOL daHimo2_Execute(himo2_class* i_this) {
     }
     new_himo2_move(i_this);
     phVar3 = &i_this->m0310[0];
-    for (iVar5 = 0; iVar5 < i_this->m02CC++; iVar5++, phVar3++) {
+    for (iVar5 = 0; iVar5 < i_this->m02CC + 1; iVar5++, phVar3++) {
         phVar3->m10 = i_this->m02B4;
     }
+    phVar3 = &i_this->m0310[0];
     himo2_control(i_this, phVar3);
     i_this->m0310[99].m10 = actor->current.pos;
     himo2_control2(i_this, phVar3);

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -587,7 +587,7 @@ fopAc_ac_c* search_target(himo2_class* i_this, cXyz param_2) {
                             if (sVar15 < 0) {
                                 sVar15 = -sVar15;
                             }
-                            if ((-sVar15 < sVar14) && (sVar14 < sVar15)) {
+                            if ((sVar14 > (s16)-sVar15) && (sVar14 < sVar15)) {
                                 f32 target_dist = std::sqrtf(target_vec.x * target_vec.x + target_vec.z * target_vec.z);
                                 iVar16 = cM_atan2s(target_vec.y, target_dist);
                                 f32 actor_dist_xz = std::sqrtf(actor_vec.x * actor_vec.x + actor_vec.z * actor_vec.z);
@@ -596,7 +596,9 @@ fopAc_ac_c* search_target(himo2_class* i_this, cXyz param_2) {
                                 if (bVar1) {
                                     sVar14 = 2000;
                                 }
-                                if ((-iVar16 < -iVar19 + l_himo2HIO.m0E) && ((-iVar19 + iVar16) < sVar14)) {
+                                int negTarget = -iVar16;
+                                int negActor = -iVar19;
+                                if ((negTarget < negActor + l_himo2HIO.m0E) && ((negActor + iVar16) < sVar14)) {
                                     return pfVar18;
                                 }
                             }

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -368,7 +368,6 @@ static BOOL daHimo2_Draw(himo2_class* i_this) {
     f32 dVar12;
     f32 dVar13;
     f32 dVar14;
-    cXyz local_a40;
     cXyz local_a1c;
     cXyz local_a28;
     cXyz local_a4c;
@@ -408,8 +407,8 @@ static BOOL daHimo2_Draw(himo2_class* i_this) {
             dComIfGd_set3DlineMat(&i_this->m1F30);
             daPy_py_c* apdVar2 = (daPy_py_c*)dComIfGp_getPlayer(0);
             cMtx_YrotS(*calc_mtx, -apdVar2->shape_angle.y);
-            local_a40 = i_this->m02EC[1] - i_this->m1F84;
-            MtxPosition(&local_a40, &local_a28);
+            local_a1c = i_this->m02EC[1] - i_this->m1F84;
+            MtxPosition(&local_a1c, &local_a28);
             local_a28.z = local_a28.z * (REG0_F(5) + 500.0f);
             if (local_a28.z > 16384.0f) {
                 local_a28.z = 16384.0f;

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -455,7 +455,7 @@ static BOOL daHimo2_Draw(himo2_class* i_this) {
                 local_a1c.y = (dVar10 * i_this->m1F70[iVar3]);
                 cMtx_YrotS(*calc_mtx, apdVar2->shape_angle.y);
                 iVar8 = ((dVar11 - i_this->m1F70[iVar3]) * (dVar12 + REG0_F(13)));
-                cMtx_ZrotM(*calc_mtx, i_this->m1F92 + iVar9 * (REG0_S(0) + (i_this->m1F94 - 2000)) + iVar8);
+                cMtx_ZrotM(*calc_mtx, i_this->m1F92 + iVar9 * ((REG0_S(0) - 2000) + i_this->m1F94) + iVar8);
                 cMtx_XrotM(*calc_mtx, i_this->m1F90);
                 MtxTrans(0.0f, -local_a1c.y, 0.0f, true);
                 for (int j = 0; j < 32; j++, pcVar7++) {

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -237,13 +237,14 @@ void himo2_control2(himo2_class* i_this, himo2_s* param_2) {
     } else {
         local_a8.z = i_this->m2188 * 15.625f * (REG0_F(1) + 0.0007f);
     }
+    f32 dVar11;
     f32 dVar9 = 0.0f;
     f32 dVar10 = 0.0f;
     f32 dVar8 = (REG8_F(17) + 10.0f);
     int iVar4 = i_this->m02CC + 1;
     himo2_s* puVar6 = param_2 + 98;
     for (; iVar4 < 100; iVar4++, puVar6--) {
-        f32 dVar11 = (puVar6->m10.y - puVar6[1].m10.y);
+        dVar11 = (puVar6->m10.y - puVar6[1].m10.y);
         int iVar3 = i_this->m02DC;
         if ((iVar3 >= 0) && (iVar3 <= 3)) {
             if (iVar3 != 0) {

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -236,7 +236,7 @@ void himo2_control2(himo2_class* i_this, himo2_s* param_2) {
     }
     f32 dVar9 = 0.0f;
     f32 dVar8 = (REG8_F(17) + 10.0f);
-    int iVar4 = i_this->m02CC;
+    int iVar4 = i_this->m02CC + 1;
     f32 dVar10 = dVar9;
     for (; iVar4 < 100; iVar4++, puVar6--) {
         f32 dVar11 = (puVar6->m10.y - puVar6[1].m10.y);

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -82,10 +82,12 @@ void spin_draw(himo2_class* i_this) {
 
     sVar4 = 0;
     sVar2 = i_this->m2510;
-    fVar5 = (i_this->m217C->scale.y - 1.0f) * 8.0f;
-    fVar10 *= -7.0f;
-    #if VERSION > VERSION_DEMO
+    fVar5 = 8.0f;
     fVar1 = i_this->m217C->scale.y;
+    f32 scale_delta = fVar1 - 1.0f;
+    fVar5 *= scale_delta;
+    fVar10 = -7.0f * scale_delta;
+    #if VERSION > VERSION_DEMO
     if ((fopAcM_GetParam(i_this->m217C) & 0x0F) == 3) {
         fVar5 += REG8_F(8) + -3.0f;
         fVar10 += REG8_F(9) + 1.5f;

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -994,9 +994,9 @@ void new_himo2_move(himo2_class* i_this) {
         f27 = (dVar25 * dVar25);
         f32 f26 = std::sqrtf(f31 + (f27 + (f30 * f30)));
         f27 = std::sqrtf(f27 + f31);
-        int r23 = (s16)(f26 * (REG0_F(3) + -5.0f));
-        if (r23 < (s16)(REG0_S(2) + -3000)) {
-            r23 = REG0_S(2) + -3000;
+        int r23 = f26 * (REG0_F(3) + -5.0f);
+        if ((s16)r23 < (s16)(REG0_S(2) + -3000)) {
+            r23 = (s16)(REG0_S(2) + -3000);
         }
         if ((i_this->m217C != NULL) || (f26 > (actor->speedF * 10.0f))) {
             actor->current.angle.y = cM_atan2s(dVar25, f28);

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -765,12 +765,12 @@ void new_himo2_move(himo2_class* i_this) {
     dAttention_c* attention; // r23
     u32 r30;
     s16 r22;
+    f32 f29;
+    f32 f27;
+    f32 f28;
     f32 f31;
     f32 f30;
-    f32 f28;
-    f32 f27;
     f32 f26;
-    f32 dVar25;
     f32 fVar26;
     cXyz sp130;
     cXyz sp124;
@@ -985,20 +985,20 @@ void new_himo2_move(himo2_class* i_this) {
         } else {
             sp10C = i_this->m2524;
         }
-        dVar25 = (sp10C.x - actor->current.pos.x);
-        f30 = (sp10C.y - actor->current.pos.y);
-        f28 = (sp10C.z - actor->current.pos.z);
-        f31 = (f28 * f28);
-        f27 = (dVar25 * dVar25);
-        f32 f26 = std::sqrtf(f31 + (f27 + (f30 * f30)));
-        f27 = std::sqrtf(f27 + f31);
-        int r23 = f26 * (REG0_F(3) + -5.0f);
+        f31 = (sp10C.x - actor->current.pos.x);
+        f27 = (sp10C.y - actor->current.pos.y);
+        f26 = (sp10C.z - actor->current.pos.z);
+        f29 = (f26 * f26);
+        f28 = (f31 * f31);
+        f30 = std::sqrtf(f29 + (f28 + (f27 * f27)));
+        f28 = std::sqrtf(f28 + f29);
+        int r23 = f30 * (REG0_F(3) + -5.0f);
         if ((s16)r23 < (s16)(REG0_S(2) + -3000)) {
             r23 = (s16)(REG0_S(2) + -3000);
         }
-        if ((i_this->m217C != NULL) || (f26 > (actor->speedF * 10.0f))) {
-            actor->current.angle.y = cM_atan2s(dVar25, f28);
-            actor->current.angle.x = -cM_atan2s(f30, f27);
+        if ((i_this->m217C != NULL) || (f30 > (actor->speedF * 10.0f))) {
+            actor->current.angle.y = cM_atan2s(f31, f26);
+            actor->current.angle.x = -cM_atan2s(f27, f28);
         }
         actor->speedF = 20.0f;
         mDoMtx_YrotS(*calc_mtx, actor->current.angle.y);
@@ -1010,7 +1010,7 @@ void new_himo2_move(himo2_class* i_this) {
         actor->current.pos += actor->speed;
         pl_pos_add(i_this);
         if (i_this->m217C != NULL) {
-            if ((f26 < (actor->speedF * 10.0f)) || (i_this->m0308 == 0)) {
+            if ((f30 < (actor->speedF * 10.0f)) || (i_this->m0308 == 0)) {
                 i_this->m02DC = 10;
                 i_this->m24D9 = 0xFF;
                 i_this->m24D8 = 1;
@@ -1639,9 +1639,7 @@ void new_himo2_move(himo2_class* i_this) {
         spB8.x = (i_this->m24E8.x + f26);
         spB8.y = i_this->m24E8.y + f1;
         spB8.z = i_this->m24E8.z;
-        f32 f1_3 = cM_scos(i_this->m02D8 * 0x1C00);
-        f32 f1_2 = (i_this->m2520 * f1_3);
-        s16 r23 = 7.5f * f1_2;
+        s16 r23 = (i_this->m2520 * cM_scos(i_this->m02D8 * 0x1C00)) * 7.5f;
         camera->mCamera.Set(spB8, spC4, r23, i_this->m24F4);
         cLib_addCalc0(&i_this->m2520, 1.0f, (REG0_F(16) + 2.0f));
         s16 r23_2 = 0;

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -71,8 +71,8 @@ void spin_draw(himo2_class* i_this) {
     f32 fVar5;
     int iVar6;
     cXyz* pcVar7;
-    s16 sVar8;
     s16 sVar9;
+    s16 sVar8;
     f32 fVar10;
     int iVar11;
     cXyz local_504;
@@ -120,25 +120,28 @@ void spin_draw(himo2_class* i_this) {
     for (iVar11 = 0, iVar6 = 0; iVar11 < 100; iVar11++, iVar6 += 12) {
         local_4f8[iVar6].y = -200000.0f;
         if (iVar11 < 50) {
-            sVar3 = sVar8 + REG0_S(2) + 100;
+            sVar3 = sVar8;
+            sVar8 += REG0_S(2) + 100;
         } else if ((iVar11 >= 50) && (i_this->m24BC + 49 <= iVar11)) {
-            sVar3 = sVar8 + i_this->m24C8;
+            sVar3 = sVar8;
+            sVar8 += i_this->m24C8;
             if (iVar11 >= 100 - (REG0_S(4) + 5)) {
-                sVar3 = REG0_S(5) + sVar3 + -1000;
+                sVar8 += REG0_S(5) + -1000;
             }
             if ((i_this->m217C != NULL) && (fopAcM_GetParam(i_this->m217C) != 0)) {
                 sVar4 = REG0_S(4) + sVar4 + -400;
             }
         } else {
+            sVar3 = sVar8;
             if (i_this->m24BC == 0) {
-                sVar3 = sVar8 + (s16)(REG0_S(2) + 70);
+                sVar8 += (s16)(REG0_S(2) + 70);
             } else {
-                sVar3 = sVar8 + 50;
+                sVar8 += 50;
             }
         }
         cMtx_YrotS(*calc_mtx, sVar2);
         cMtx_ZrotM(*calc_mtx, sVar4);
-        cMtx_XrotM(*calc_mtx, sVar8);
+        cMtx_XrotM(*calc_mtx, sVar3);
         cMtx_YrotM(*calc_mtx, sVar9);
         MtxPosition(&local_504, &local_510);
         local_51c.x = local_51c.x + local_510.x;
@@ -169,7 +172,6 @@ void spin_draw(himo2_class* i_this) {
                 local_4f8[iVar6] = local_51c;
             }
         }
-        sVar8 = sVar3;
     }
     iVar6 = 99;
     for (iVar11 = 0; iVar11 < 100; iVar11++, iVar6--) {

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -1046,10 +1046,7 @@ void new_himo2_move(himo2_class* i_this) {
     }
     case 3: {
         i_this->m02CC = REG0_S(0);
-        // fakematch - why is this not getting inlined?
-        // r24 = fopAcM_SearchByID(i_this->m2180);
-        fpc_ProcID sp08 = i_this->m2180;
-        r24 = (fopAc_ac_c*)fopAcIt_Judge((fopAcIt_JudgeFunc)fpcSch_JudgeByID, &sp08);
+        r24 = fopAcM_SearchByID(i_this->m2180);
         if (r24 != NULL) {
             sp130 = r24->eyePos - actor->current.pos;
             cLib_addCalcAngleS2(&actor->current.angle.y, cM_atan2s(sp130.x, sp130.z), 2, REG0_S(1) + 0x800);
@@ -1087,10 +1084,7 @@ void new_himo2_move(himo2_class* i_this) {
         break;
     }
     case 4: {
-        // fakematch - why is this not getting inlined?
-        // r24 = fopAcM_SearchByID(i_this->m2180);
-        fpc_ProcID sp08 = i_this->m2180;
-        r24 = (fopAc_ac_c*)fopAcIt_Judge((fopAcIt_JudgeFunc)fpcSch_JudgeByID, &sp08);
+        r24 = fopAcM_SearchByID(i_this->m2180);
         if (r24 == NULL) {
             i_this->m02DC = 5;
         } else {

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -525,13 +525,13 @@ void* s_a_d_sub(void* param_1, void* param_2) {
 fopAc_ac_c* search_target(himo2_class* i_this, cXyz param_2) {
     /* Nonmatching - cXyz, regalloc */
     daPy_py_c* apdVar11;
+    fopAc_ac_c* pfVar18;
     s16 sVar12;
     s16 sVar13;
     s16 sVar14;
     s16 sVar15;
     int iVar16;
     uint uVar17;
-    fopAc_ac_c* pfVar18;
     u8 bVar1;
     f32 dVar22;
     f32 search_limit;
@@ -553,15 +553,14 @@ fopAc_ac_c* search_target(himo2_class* i_this, cXyz param_2) {
     if (i_this->m24AC != 0) {
         uVar17 = 0;
         while (uVar17 < i_this->m24AC) {
-                pfVar18 = (&i_this->m218C)[uVar17];
                 bVar1 = 0;
+                pfVar18 = (&i_this->m218C)[uVar17];
                 if ((fopAcM_GetParam(pfVar18) & 0xF0) != 0) {
                     bVar1 = 1;
                 }
                 local_54.x = apdVar11->current.pos.x - pfVar18->current.pos.x;
                 local_54.z = apdVar11->current.pos.z - pfVar18->current.pos.z;
-                iVar16 = cM_atan2s(local_54.x, local_54.z);
-                sVar14 = pfVar18->current.angle.y - iVar16;
+                sVar14 = pfVar18->current.angle.y - cM_atan2s(local_54.x, local_54.z);
                 if (sVar14 < 0 && !bVar1) {
                     sVar14 = -sVar14;
                     i_this->m251C = 1;
@@ -584,17 +583,17 @@ fopAc_ac_c* search_target(himo2_class* i_this, cXyz param_2) {
                             actor_vec.y = pfVar18->current.pos.y - camera->mLookat.mEye.y;
                             actor_vec.z = pfVar18->current.pos.z - camera->mLookat.mEye.z;
                             iVar16 = cM_atan2s(target_vec.x, target_vec.z);
-                            sVar14 = cM_atan2s(actor_vec.x, actor_vec.z) - iVar16;
+                            sVar14 = (s16)cM_atan2s(actor_vec.x, actor_vec.z) - iVar16;
                             if (sVar14 < 0) {
                                 sVar14 = -sVar14;
                             }
                             f32 actor_dist =
-                                std::sqrtf(actor_vec.z * actor_vec.z + actor_vec.x * actor_vec.x + actor_vec.y * actor_vec.y);
+                                std::sqrtf(actor_vec.z * actor_vec.z + (actor_vec.x * actor_vec.x + actor_vec.y * actor_vec.y));
                             sVar15 = cM_atan2s((pfVar18->scale).z * l_himo2HIO.m10, actor_dist);
                             if (sVar15 < 0) {
                                 sVar15 = -sVar15;
                             }
-                            if ((-sVar15 > sVar14) && (sVar14 < sVar15)) {
+                            if ((-sVar15 < sVar14) && (sVar14 < sVar15)) {
                                 f32 target_dist = std::sqrtf(target_vec.x * target_vec.x + target_vec.z * target_vec.z);
                                 iVar16 = cM_atan2s(target_vec.y, target_dist);
                                 f32 actor_dist_xz = std::sqrtf(actor_vec.x * actor_vec.x + actor_vec.z * actor_vec.z);

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -591,7 +591,7 @@ fopAc_ac_c* search_target(himo2_class* i_this, cXyz param_2) {
                                 f32 target_dist = std::sqrtf(target_vec.x * target_vec.x + target_vec.z * target_vec.z);
                                 s16 negTarget = -cM_atan2s(target_vec.y, target_dist);
                                 f32 actor_dist_xz = std::sqrtf(actor_vec.x * actor_vec.x + actor_vec.z * actor_vec.z);
-                                int negActor = -cM_atan2s(actor_vec.y, actor_dist_xz);
+                                s16 negActor = -cM_atan2s(actor_vec.y, actor_dist_xz);
                                 if (bVar1) {
                                     sVar14 = 2000;
                                 } else {

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -292,7 +292,7 @@ void himo2_draw(himo2_class* i_this, himo2_s* param_2) {
     phVar4 = param_2 + (i_this->m02CC + 1);
     iVar2 = i_this->m02CC;
     pcVar6++;
-    for (; iVar2 < 98; iVar2++) {
+    for (; iVar2 < 98; iVar2++, phVar4++) {
         if (iVar2 == 97) {
             if ((i_this->m02DC == 0) && (i_this->m2188 < REG0_F(3) + 50.0f)) {
                 MTXCopy(apdVar1->getLeftHandMatrix(), *calc_mtx);
@@ -323,7 +323,6 @@ void himo2_draw(himo2_class* i_this, himo2_s* param_2) {
             i_this->m1F6C++;
             pcVar6++;
         }
-        phVar4++;
     }
 }
 

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -84,9 +84,9 @@ void spin_draw(himo2_class* i_this) {
     sVar2 = i_this->m2510;
     fVar5 = 8.0f;
     fVar1 = i_this->m217C->scale.y;
-    f32 scale_delta = fVar1 - 1.0f;
-    fVar5 *= scale_delta;
-    fVar10 = -7.0f * scale_delta;
+    fVar10 = fVar1 - 1.0f;
+    fVar5 *= fVar10;
+    fVar10 = -7.0f * fVar10;
     #if VERSION > VERSION_DEMO
     if ((fopAcM_GetParam(i_this->m217C) & 0x0F) == 3) {
         fVar5 += REG8_F(8) + -3.0f;

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -633,9 +633,8 @@ BOOL himo2_class::setTargetPos(cXyz* param_1, float* param_2, float* param_3) {
     *param_2 = -1.0f;
     *param_3 = -1.0f;
     m2524 = *param_1;
-    fopAc_ac_c* pfVar1 = search_target(this, m2524);
-    m217C = pfVar1;
-    if (pfVar1 != NULL) {
+    fopAc_ac_c* pfVar1;
+    if ((m217C = (pfVar1 = search_target(this, m2524))) != NULL) {
         if ((fopAcM_GetParam(m217C) & 0xF0) != 0) {
             *param_2 = 700.0f;
             *param_3 = 100.0f;

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -228,7 +228,6 @@ void himo2_control2(himo2_class* i_this, himo2_s* param_2) {
 
     local_a8.x = 0.0f;
     local_a8.y = 0.0f;
-    himo2_s* puVar6 = param_2 + 98;
     if (i_this->m02DC == 0) {
         local_a8.z = i_this->m2188 * 15.625f * (REG8_F(18) + 0.002f);
     } else {
@@ -237,6 +236,7 @@ void himo2_control2(himo2_class* i_this, himo2_s* param_2) {
     f32 dVar9 = 0.0f;
     f32 dVar8 = (REG8_F(17) + 10.0f);
     int iVar4 = i_this->m02CC + 1;
+    himo2_s* puVar6 = param_2 + 98;
     f32 dVar10 = dVar9;
     for (; iVar4 < 100; iVar4++, puVar6--) {
         f32 dVar11 = (puVar6->m10.y - puVar6[1].m10.y);

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -69,9 +69,9 @@ void spin_draw(himo2_class* i_this) {
     f32 fVar10;
     f32 fVar5;
     int iVar6;
+    s16 sVar2;
     s16 sVar4;
     s16 sVar9;
-    s16 sVar2;
     f32 fVar1;
     s16 sVar8;
     cXyz* pcVar7;

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -850,9 +850,9 @@ void new_himo2_move(himo2_class* i_this) {
     case 0: {
         actor->speedF = 0.0f;
         if ((r30 == 0) && player->checkRopeReadyAnime()) {
-            cMtx_YrotS(*calc_mtx, player->shape_angle.y);
-            cMtx_ZrotM(*calc_mtx, REG0_S(2) + -12000);
-            cMtx_YrotM(*calc_mtx, i_this->m02D8 * (REG0_S(3) + 0x2000));
+            mDoMtx_YrotS(*calc_mtx, player->shape_angle.y);
+            mDoMtx_ZrotM(*calc_mtx, REG0_S(2) + -12000);
+            mDoMtx_YrotM(*calc_mtx, i_this->m02D8 * (REG0_S(3) + 0x2000));
             sp130.x = 0.0f;
             sp130.y = 0.0f;
             sp130.z = REG0_F(11) + 70.0f;
@@ -891,8 +891,8 @@ void new_himo2_move(himo2_class* i_this) {
             if (std::sqrtf(f31 + SQUARE(f27) + f30) > sp130.z) {
                 int r24 = cM_atan2s(f28, f26);
                 r22 = -cM_atan2s(f27, std::sqrtf(f31 + f30));
-                cMtx_YrotS(*calc_mtx, r24);
-                cMtx_XrotM(*calc_mtx, r22);
+                mDoMtx_YrotS(*calc_mtx, r24);
+                mDoMtx_XrotM(*calc_mtx, r22);
                 sp130.x = 0.0f;
                 sp130.y = 0.0f;
                 MtxPosition(&sp130, &sp124);
@@ -925,9 +925,9 @@ void new_himo2_move(himo2_class* i_this) {
         break;
     }
     case 1: {
-        cMtx_YrotS(*calc_mtx, actor->shape_angle.y);
-        cMtx_ZrotM(*calc_mtx, REG0_S(2) + -12000);
-        cMtx_YrotM(*calc_mtx, i_this->m02D8 * (REG0_S(3) + 0x2000));
+        mDoMtx_YrotS(*calc_mtx, actor->shape_angle.y);
+        mDoMtx_ZrotM(*calc_mtx, REG0_S(2) + -12000);
+        mDoMtx_YrotM(*calc_mtx, i_this->m02D8 * (REG0_S(3) + 0x2000));
         sp130.x = 0.0f;
         sp130.y = 0.0f;
         sp130.z = REG0_F(11) + 70.0f;
@@ -968,8 +968,8 @@ void new_himo2_move(himo2_class* i_this) {
             } else {
                 sp10C = i_this->m2524;
             }
-            cMtx_YrotS(*calc_mtx, actor->current.angle.y);
-            cMtx_XrotM(*calc_mtx, actor->current.angle.x);
+            mDoMtx_YrotS(*calc_mtx, actor->current.angle.y);
+            mDoMtx_XrotM(*calc_mtx, actor->current.angle.x);
             sp130.y = 0.0f;
             sp130.x = 0.0f;
             sp130.z = REG0_F(14) * 100.0f + 100.0f;
@@ -996,8 +996,8 @@ void new_himo2_move(himo2_class* i_this) {
             actor->current.angle.x = -cM_atan2s(f30, f27);
         }
         actor->speedF = 20.0f;
-        cMtx_YrotS(*calc_mtx, actor->current.angle.y);
-        cMtx_XrotM(*calc_mtx, actor->current.angle.x + r23);
+        mDoMtx_YrotS(*calc_mtx, actor->current.angle.y);
+        mDoMtx_XrotM(*calc_mtx, actor->current.angle.x + r23);
         sp130.y = 0.0f;
         sp130.x = 0.0f;
         sp130.z = actor->speedF;
@@ -1063,8 +1063,8 @@ void new_himo2_move(himo2_class* i_this) {
             }
         }
         actor->speedF = REG0_F(14) + 30.0f;
-        cMtx_YrotS(*calc_mtx, actor->current.angle.y);
-        cMtx_XrotM(*calc_mtx, actor->current.angle.x);
+        mDoMtx_YrotS(*calc_mtx, actor->current.angle.y);
+        mDoMtx_XrotM(*calc_mtx, actor->current.angle.x);
         sp130.y = 0.0f;
         sp130.x = 0.0f;
         sp130.z = actor->speedF;
@@ -1097,7 +1097,7 @@ void new_himo2_move(himo2_class* i_this) {
         if (r24 == NULL) {
             i_this->m02DC = 5;
         } else {
-            cMtx_YrotS(*calc_mtx, (i_this->m02D8 << 13));
+            mDoMtx_YrotS(*calc_mtx, (i_this->m02D8 << 13));
             sp130.x = 0.0f;
             sp130.y = 0.0f;
             sp130.z = i_this->m2184;
@@ -1327,7 +1327,7 @@ void new_himo2_move(himo2_class* i_this) {
         cLib_addCalc2(&i_this->m24E8.y, i_this->m217C->current.pos.y, 0.3f, 100.0f);
         cLib_addCalc2(&i_this->m24E8.z, i_this->m217C->current.pos.z, 0.3f, 100.0f);
         i_this->m24DC = i_this->m217C->current.pos;
-        cMtx_YrotS(*calc_mtx, i_this->m2510);
+        mDoMtx_YrotS(*calc_mtx, i_this->m2510);
         sp130.x = (REG0_F(5) * 10.0f + 50.0f) * i_this->m2514;
         sp130.y = (REG0_F(4) * 10.0f - 200.0f) + 140.0f;
         sp130.z = ((REG0_F(3) * 10.0f + 200.f) - 80.0f) * i_this->m2518;
@@ -1344,7 +1344,7 @@ void new_himo2_move(himo2_class* i_this) {
     }
     case 3: {
         i_this->m217C->health = 2;
-        cMtx_YrotS(*calc_mtx, i_this->m217C->current.angle.y);
+        mDoMtx_YrotS(*calc_mtx, i_this->m217C->current.angle.y);
         sp130.x = ((REG0_F(11) + 2000.0f) - 800.0f) - 300.0f;
         sp130.y = i_this->m217C->home.pos.y + REG0_F(12) + 2000.0f;
         sp130.z = REG0_F(13) + 1000.0f;
@@ -1415,7 +1415,7 @@ void new_himo2_move(himo2_class* i_this) {
             i_this->m2512 = i_this->m2510;
             i_this->m24F4 = 65.0f;
             i_this->m24F8 = 65.0f;
-            cMtx_YrotS(*calc_mtx, i_this->m2510);
+            mDoMtx_YrotS(*calc_mtx, i_this->m2510);
             sp130.x = REG0_F(7) + 100.0f + 200.0f;
             sp130.y = player->current.pos.y + 700.0f + REG0_F(8);
             sp130.z = REG0_F(9) + -500.0f;
@@ -1461,7 +1461,7 @@ void new_himo2_move(himo2_class* i_this) {
             cLib_addCalc2(&i_this->m24F8, REG0_F(8) + 20.0f, 1.0f, std::fabsf(f26) * 3.0f);
         }
         cLib_addCalc2(&i_this->m24F4, i_this->m24F8, 0.1f, 10.0f);
-        cMtx_YrotS(*calc_mtx, i_this->m2510);
+        mDoMtx_YrotS(*calc_mtx, i_this->m2510);
         sp130.x = REG0_F(7) + 100.0f + 200.0f;
         sp130.y = player->current.pos.y + 700.0f + REG0_F(8);
         sp130.z = REG0_F(9) + -500.0f;
@@ -1518,7 +1518,7 @@ void new_himo2_move(himo2_class* i_this) {
         i_this->m24E8.x = 0.0f;
         i_this->m24E8.y = REG0_F(5) * 0.1f + 3000.0f;
         i_this->m24E8.z = REG0_F(6) * 0.1f;
-        cMtx_YrotS(*calc_mtx, btd->actor.current.angle.y);
+        mDoMtx_YrotS(*calc_mtx, btd->actor.current.angle.y);
         sp130.x = REG0_F(7) * 0.1f;
         sp130.y = REG0_F(8) * 0.1f + 1000.0f;
         sp130.z = REG0_F(9) * 0.1f + 1400.0f;
@@ -1590,7 +1590,7 @@ void new_himo2_move(himo2_class* i_this) {
     case 9: {
         cLib_addCalc2(&i_this->m24F4, REG0_F(4) + 50.0f, 0.5f, 3.0f);
         cLib_addCalc2(&i_this->m24E8.y, btd->actor.eyePos.y + REG0_F(5) * 0.1f + 200.0f, 0.2f, 1000.0f);
-        cMtx_YrotS(*calc_mtx, btd->actor.current.angle.y);
+        mDoMtx_YrotS(*calc_mtx, btd->actor.current.angle.y);
         sp130.x = REG0_F(7) * 0.1f + -300.0f;
         sp130.y = REG0_F(8) * 0.1f + 100.0f;
         sp130.z = REG0_F(9) * 0.1f + 2000.0f;

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -365,7 +365,7 @@ void himo2_disp(himo2_class* i_this) {
 }
 
 /* 800EC338-800ECBE8       .text daHimo2_Draw__FP11himo2_class */
-static BOOL daHimo2_Draw(himo2_class* i_this) {
+BOOL daHimo2_Draw(himo2_class* i_this) {
     /* Nonmatching - cXyz */
     fopAc_ac_c* actor = &i_this->actor;
     f32 fVar1;
@@ -674,7 +674,7 @@ void* dr_a_sub(void* param_1, void* param_2) {
 }
 
 /* 800ED32C-800ED378       .text b_a_sub__FPvPv */
-void* b_a_sub(void* param_1, void* param_2) {
+static void* b_a_sub(void* param_1, void* param_2) {
     if ((fopAc_IsActor(param_1)) && (fopAcM_GetName(param_1) == PROC_BTD)) {
         return param_1;
     } else {
@@ -1685,7 +1685,7 @@ void new_himo2_move(himo2_class* i_this) {
 }
 
 /* 800F01BC-800F062C       .text daHimo2_Execute__FP11himo2_class */
-static BOOL daHimo2_Execute(himo2_class* i_this) {
+BOOL daHimo2_Execute(himo2_class* i_this) {
     /* Nonmatching - last for loop, regalloc */
     fopAc_ac_c* actor = &i_this->actor;
     himo2_s* phVar3;
@@ -1754,18 +1754,18 @@ static BOOL daHimo2_Execute(himo2_class* i_this) {
 }
 
 /* 800F062C-800F0634       .text daHimo2_IsDelete__FP11himo2_class */
-static BOOL daHimo2_IsDelete(himo2_class*) {
+BOOL daHimo2_IsDelete(himo2_class*) {
     return TRUE;
 }
 
 /* 800F0634-800F0670       .text daHimo2_Delete__FP11himo2_class */
-static BOOL daHimo2_Delete(himo2_class*) {
+BOOL daHimo2_Delete(himo2_class*) {
     mDoHIO_deleteChild(l_himo2HIO.mNo);
     return TRUE;
 }
 
 /* 800F0670-800F07F4       .text CallbackCreateHeap__FP10fopAc_ac_c */
-static int CallbackCreateHeap(fopAc_ac_c* i_this) {
+int CallbackCreateHeap(fopAc_ac_c* i_this) {
     ResTIMG* pRVar1;
     J3DModelData* modelData;
     himo2_class* a_this = (himo2_class*)i_this;
@@ -1792,7 +1792,7 @@ static int CallbackCreateHeap(fopAc_ac_c* i_this) {
 }
 
 /* 800F07F4-800F0B08       .text daHimo2_Create__FP10fopAc_ac_c */
-static cPhs_State daHimo2_Create(fopAc_ac_c* i_this) {
+cPhs_State daHimo2_Create(fopAc_ac_c* i_this) {
     himo2_class* a_this = (himo2_class*)i_this;
     daPy_py_c* player = (daPy_py_c*)dComIfGp_getPlayer(0);
 

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -549,7 +549,7 @@ fopAc_ac_c* search_target(himo2_class* i_this, cXyz param_2) {
 
     apdVar11 = daPy_getPlayerActorClass();
     i_this->m24AC = 0;
-    for (int iVar16 = 0, iVar19 = 100; iVar19 != 0; iVar16 += 4, iVar19--) {
+    for (int iVar16 = 0; iVar16 < 100; iVar16++) {
         (&i_this->m218C)[iVar16] = NULL;
     }
     fpcM_Search(s_a_d_sub, i_this);
@@ -570,7 +570,7 @@ fopAc_ac_c* search_target(himo2_class* i_this, cXyz param_2) {
                 local_54.z = apdVar11->current.pos.z - pfVar18->current.pos.z;
                 iVar16 = cM_atan2s(local_54.x, local_54.z);
                 sVar14 = pfVar18->current.angle.y - iVar16;
-                if ((sVar14 >= -1) || (!bVar1)) {
+                if (sVar14 < 0 && !bVar1) {
                     sVar14 = -sVar14;
                     i_this->m251C = 1;
                 } else {

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -232,17 +232,19 @@ void himo2_control2(himo2_class* i_this, himo2_s* param_2) {
 
     local_a8.x = 0.0f;
     local_a8.y = 0.0f;
+    himo2_s* puVar6 = param_2;
+    puVar6 += 98;
     if (i_this->m02DC == 0) {
         local_a8.z = i_this->m2188 * 15.625f * (REG8_F(18) + 0.002f);
     } else {
         local_a8.z = i_this->m2188 * 15.625f * (REG0_F(1) + 0.0007f);
     }
     f32 dVar11;
-    f32 dVar10 = 0.0f;
-    f32 dVar9 = 0.0f;
+    f32 dVar10;
+    f32 dVar9;
+    dVar10 = dVar9 = 0.0f;
     f32 dVar8 = (REG8_F(17) + 10.0f);
     int iVar4 = i_this->m02CC + 1;
-    himo2_s* puVar6 = param_2 + 98;
     for (; iVar4 < 100; iVar4++, puVar6--) {
         dVar11 = (puVar6->m10.y - puVar6[1].m10.y);
         int iVar3 = i_this->m02DC;

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -1725,7 +1725,11 @@ BOOL daHimo2_Execute(himo2_class* i_this) {
     phVar3 = &i_this->m1120[0];
     for (iVar4 = 0; iVar4 < iVar5; iVar4++, phVar3++) {
         if (i_this->m02DC != 2) {
-            local_bc.GetPointP()->set(phVar3->m10.x, phVar3->m10.y + 60.0f, phVar3->m10.z);
+            f32 gy = phVar3->m10.y;
+            f32 gz = phVar3->m10.z;
+            gy += 60.0f;
+            f32 gx = phVar3->m10.x;
+            local_bc.GetPointP()->set(gx, gy, gz);
             phVar3->m0C = (5.0f + dComIfG_Bgsp()->GroundCross(&local_bc));
         } else {
             phVar3->m0C = -100000.0f;

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -238,8 +238,8 @@ void himo2_control2(himo2_class* i_this, himo2_s* param_2) {
         local_a8.z = i_this->m2188 * 15.625f * (REG0_F(1) + 0.0007f);
     }
     f32 dVar11;
-    f32 dVar9 = 0.0f;
     f32 dVar10 = 0.0f;
+    f32 dVar9 = 0.0f;
     f32 dVar8 = (REG8_F(17) + 10.0f);
     int iVar4 = i_this->m02CC + 1;
     himo2_s* puVar6 = param_2 + 98;

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -325,8 +325,8 @@ void himo_e_draw(himo2_class* i_this, himo2_s*) {
 
 /* 800EC1E4-800EC300       .text himo_hang_draw__FP11himo2_class */
 void himo_hang_draw(himo2_class* i_this) {
-    /* Nonmatching - regalloc */
-    cXyz* pcVar3 = i_this->m1F30.getPos(0) + i_this->m1F6C;
+    cXyz* pcVar3 = i_this->m1F30.getPos(0);
+    pcVar3 += i_this->m1F6C;
     cXyz local_38 = i_this->m02EC[0] - i_this->m2504;
     local_38.x *= 0.25f;
     local_38.y *= 0.25f;

--- a/src/d/actor/d_a_himo2.cpp
+++ b/src/d/actor/d_a_himo2.cpp
@@ -607,7 +607,7 @@ fopAc_ac_c* search_target(himo2_class* i_this, cXyz param_2) {
                 uVar17++;
             if (uVar17 == i_this->m24AC) {
                 uVar17 = 0;
-                dVar22 = (dVar22 + 100.0f);
+                dVar22 += 100.0f;
                 if (bVar1) {
                     search_limit = 2000.0f;
                 } else {
@@ -618,6 +618,8 @@ fopAc_ac_c* search_target(himo2_class* i_this, cXyz param_2) {
                 }
             }
         }
+    } else {
+        return NULL;
     }
     return NULL;
 }


### PR DESCRIPTION
## Summary

Improves `d/actor/d_a_himo2.cpp` and tightens the `himo2_class` actor layout.

This gets the TU very close locally: all data is matched, 57 / 59 functions are matched, and the remaining two functions are narrow register-allocation issues.

## Status

Local matching status for `d_a_himo2`:

```text
unit fuzzy:       99.929016
matched_functions: 57 / 59
matched_data:      836 / 836
```

Remaining nonmatching functions:

```text
daHimo2_Draw      99.89209
new_himo2_move    99.86748
```

The remaining diffs are allocator-shape only:

- `new_himo2_move`: early callee-saved GPR ownership around `dComIfGp_getAttention()`
- `daHimo2_Draw`: final 16-point loop volatile register choice

## Notes

I avoided fakematching, inline asm, and artificial no-op code. Most of the final work was source-shape cleanup around rope movement, draw/update loops, spin draw, and camera/target math.

I also ran targeted scripted probes for the remaining allocator issues, including declaration/lifetime variants, `Lockon()` result spelling, bool/full-width no-lockon forms, final-loop type/init/order variants, manual sine lookup spellings, and count-controlled loop forms. Those either stayed neutral or regressed.

ref #579
