### PR TITLE
d_a_obj_Itnak: 8/9 functions matching, _create/_draw equivalent

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1678,7 +1678,7 @@ config.libs = [
     ActorRel(NonMatching, "d_a_npc_zk1"),
     ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"), "d_a_npc_zl1"),
     ActorRel(NonMatching, "d_a_nz"),
-    ActorRel(NonMatching, "d_a_obj_Itnak"),
+    ActorRel(Equivalent, "d_a_obj_Itnak"), # _create/_draw minor regalloc/inline nonmatching
     ActorRel(NonMatching, "d_a_obj_Vds"),
     ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d_a_obj_Vteng"),
     ActorRel(NonMatching, "d_a_obj_YLzou"),

--- a/include/d/actor/d_a_obj_Itnak.h
+++ b/include/d/actor/d_a_obj_Itnak.h
@@ -2,28 +2,66 @@
 #define D_A_OBJ_ITNAK_H
 
 #include "f_op/f_op_actor.h"
+#include "m_Do/m_Do_ext.h"
 #include "d/d_cc_d.h"
+#include "d/d_a_obj.h"
+#include "d/d_bg_s_gnd_chk.h"
 
 namespace daObjItnak {
     class Act_c : public fopAc_ac_c {
     public:
-        void is_switch() const {}
+        struct Attr_c {
+            /* 0x00 */ f32 m00;
+            /* 0x04 */ f32 m04;
+            /* 0x08 */ f32 m08;
+            /* 0x0C */ f32 m0C;
+            /* 0x10 */ f32 m10;
+            /* 0x14 */ f32 m14;
+            /* 0x18 */ f32 m18;
+            /* 0x1C */ f32 m1C;
+            /* 0x20 */ f32 m20;
+            /* 0x24 */ f32 m24;
+            /* 0x28 */ f32 m28;
+            /* 0x2C */ f32 m2C;
+        }; // size = 0x30 (12 f32, verified from orig .rodata)
+
+        bool is_switch() const {
+            return fopAcM_isSwitch(const_cast<Act_c*>(this), param_get_swbit());
+        }
         void param_get_arg0() const {}
-        void param_get_swbit() const {}
-    
-        void solidHeapCB(fopAc_ac_c*);
-        void create_heap();
+        s32 param_get_swbit() const {
+            return daObj::PrmAbstract(this, 8, 8);
+        }
+
+        static BOOL solidHeapCB(fopAc_ac_c*);
+        bool create_heap();
         cPhs_State _create();
         bool _delete();
         void set_mtx();
-        void set_co_se(dCcD_Cyl*);
+        int set_co_se(dCcD_Cyl*);
         void manage_draw_flag();
         void set_collision();
         bool _execute();
         bool _draw();
-    
+
+        static const char M_arcname[];
+
     public:
-        /* Place member variables here */
+        /* 0x290 */ u8 field_0x290[0x294 - 0x290];
+        /* 0x294 */ request_of_phase_process_class mPhase;
+        /* 0x29C */ J3DModel* mpModel;
+        /* 0x2A0 */ Mtx mMtx;
+        /* 0x2D0 */ u32 mShadowId;
+        /* 0x2D4 */ dBgS_ObjGndChk mGndChk;
+        /* 0x328 */ f32 mGroundY;
+        /* 0x32C */ dCcD_Stts mStts1;
+        /* 0x368 */ dCcD_Cyl mCyl1;
+        /* 0x498 */ dCcD_Stts mStts2;
+        /* 0x4D4 */ dCcD_Cyl mCyl2;
+        /* 0x604 */ dCcD_Stts mStts3;
+        /* 0x640 */ dCcD_Cyl mCyl3;
+        /* 0x770 */ s32 mType;
+        /* 0x774 */ s32 mDrawFlag;
     };
 };
 

--- a/src/d/actor/d_a_obj_Itnak.cpp
+++ b/src/d/actor/d_a_obj_Itnak.cpp
@@ -7,55 +7,215 @@
 #include "d/actor/d_a_obj_Itnak.h"
 #include "d/d_procname.h"
 #include "d/d_priority.h"
+#include "d/d_a_obj.h"
+#include "d/d_kankyo.h"
+#include "d/res/res_itnak.h"
+
+namespace daObjItnak {
+namespace {
+static const Act_c::Attr_c L_attr = {
+    68.0f, 230.0f, 62.0f, 121.0f, 41.0f, 44.0f,
+    84.0f, 47.0f, 205.0f, -88.0f, 83.0f, 86.0f,
+};
+static inline const Act_c::Attr_c& attr() {
+    return L_attr;
+}
+} // namespace
+} // namespace daObjItnak
+
+namespace daObjItnak {
+const dCcD_SrcCyl M_cyl_src = {
+    // dCcD_SrcGObjInf
+    {
+        /* Flags             */ 0,
+        /* SrcObjAt  Type    */ 0,
+        /* SrcObjAt  Atp     */ 0,
+        /* SrcObjAt  SPrm    */ 0,
+        /* SrcObjTg  Type    */ AT_TYPE_ALL,
+        /* SrcObjTg  SPrm    */ cCcD_TgSPrm_Set_e | cCcD_TgSPrm_IsOther_e,
+        /* SrcObjCo  SPrm    */ 0,
+        /* SrcGObjAt Se      */ 0,
+        /* SrcGObjAt HitMark */ 0,
+        /* SrcGObjAt Spl     */ 0,
+        /* SrcGObjAt Mtrl    */ 0,
+        /* SrcGObjAt SPrm    */ 0,
+        /* SrcGObjTg Se      */ 0,
+        /* SrcGObjTg HitMark */ 0,
+        /* SrcGObjTg Spl     */ 0,
+        /* SrcGObjTg Mtrl    */ 0,
+        /* SrcGObjTg SPrm    */ dCcG_TgSPrm_NoHitMark_e,
+        /* SrcGObjCo SPrm    */ 0,
+    },
+    // cM3dGCylS
+    {{
+        /* Center */ {0.0f, 0.0f, 0.0f},
+        /* Radius */ 100.0f,
+        /* Height */ 200.0f,
+    }},
+};
+} // namespace daObjItnak
+
+const char daObjItnak::Act_c::M_arcname[] = "Itnak";
 
 /* 00000078-0000009C       .text solidHeapCB__Q210daObjItnak5Act_cFP10fopAc_ac_c */
-void daObjItnak::Act_c::solidHeapCB(fopAc_ac_c*) {
-    /* Nonmatching */
+BOOL daObjItnak::Act_c::solidHeapCB(fopAc_ac_c* i_this) {
+    return ((Act_c*)i_this)->create_heap();
 }
 
 /* 0000009C-0000016C       .text create_heap__Q210daObjItnak5Act_cFv */
-void daObjItnak::Act_c::create_heap() {
-    /* Nonmatching */
+bool daObjItnak::Act_c::create_heap() {
+    J3DModelData* mdl_data = static_cast<J3DModelData*>(dComIfG_getObjectRes(M_arcname, ITNAK_BDL_ITNAK));
+    JUT_ASSERT(321, mdl_data != NULL);
+
+    if (mdl_data != NULL) {
+        mpModel = mDoExt_J3DModel__create(mdl_data, 0, 0x11000002);
+    }
+
+    set_mtx();
+    return mdl_data != NULL && mpModel != NULL;
 }
 
 /* 0000016C-000003A0       .text _create__Q210daObjItnak5Act_cFv */
 cPhs_State daObjItnak::Act_c::_create() {
-    /* Nonmatching */
+    fopAcM_ct_Retail(this, Act_c);
+
+    cPhs_State phase = dComIfG_resLoad(&mPhase, M_arcname);
+    mType = daObj::PrmAbstract(this, 8, 0);
+
+    if (phase == cPhs_COMPLEATE_e) {
+        if (fopAcM_entrySolidHeap(this, solidHeapCB, 0)) {
+            mDrawFlag = mType;
+
+            fopAcM_SetMtx(this, mpModel->getBaseTRMtx());
+            fopAcM_setCullSizeBox(this, -120.0f, 0.0f, -100.0f, 120.0f, 280.0f, 150.0f);
+
+            cXyz gnd_pos(current.pos.x, 100.0f + current.pos.y, current.pos.z);
+            mGndChk.SetPos(&gnd_pos);
+            mGndChk.SetActorPid(fopAcM_GetID(this));
+            mGroundY = dComIfG_Bgsp()->GroundCross(&mGndChk);
+
+            mStts1.Init(0xFF, 0xFF, this);
+            mCyl1.Set(M_cyl_src);
+            mCyl1.SetStts(&mStts1);
+            mCyl1.SetC(cXyz::Zero);
+            mCyl1.OnTgNoHitMark();
+
+            mStts2.Init(0xFF, 0xFF, this);
+            mCyl2.Set(M_cyl_src);
+            mCyl2.SetStts(&mStts2);
+            mCyl2.SetC(cXyz::Zero);
+            mCyl2.OnTgNoHitMark();
+
+            mStts3.Init(0xFF, 0xFF, this);
+            mCyl3.Set(M_cyl_src);
+            mCyl3.SetStts(&mStts3);
+            mCyl3.SetC(cXyz::Zero);
+            mCyl3.OnTgNoHitMark();
+        } else {
+            phase = cPhs_ERROR_e;
+        }
+    }
+    return phase;
 }
 
 /* 00000D10-00000D40       .text _delete__Q210daObjItnak5Act_cFv */
 bool daObjItnak::Act_c::_delete() {
-    /* Nonmatching */
+    dComIfG_resDelete(&mPhase, M_arcname);
+    return true;
 }
 
 /* 00000D40-00000DEC       .text set_mtx__Q210daObjItnak5Act_cFv */
 void daObjItnak::Act_c::set_mtx() {
-    /* Nonmatching */
+    mpModel->setBaseScale(scale);
+    mDoMtx_stack_c::transS(current.pos);
+    mDoMtx_stack_c::ZXYrotM(shape_angle);
+    mpModel->setBaseTRMtx(mDoMtx_stack_c::get());
+    cMtx_copy(mDoMtx_stack_c::get(), mMtx);
+    mpModel->calc();
 }
 
 /* 00000DEC-00000EB0       .text set_co_se__Q210daObjItnak5Act_cFP8dCcD_Cyl */
-void daObjItnak::Act_c::set_co_se(dCcD_Cyl*) {
-    /* Nonmatching */
+int daObjItnak::Act_c::set_co_se(dCcD_Cyl* i_cyl) {
+    if (i_cyl->ChkTgHit()) {
+        daObj::HitSeStart(&current.pos, fopAcM_GetRoomNo(this), i_cyl, 0xD);
+        dKy_Sound_set(current.pos, 4, fopAcM_GetID(this), 0x64);
+        daObj::HitEff_hibana(this, i_cyl);
+        i_cyl->ClrTgHit();
+        return 1;
+    }
+    return 0;
 }
 
 /* 00000EB0-00000F94       .text manage_draw_flag__Q210daObjItnak5Act_cFv */
 void daObjItnak::Act_c::manage_draw_flag() {
-    /* Nonmatching */
+    if (mType == 1) {
+        if (mDrawFlag == 1) {
+            if (is_switch() == 1) {
+                mDrawFlag = 0;
+            }
+        }
+    } else if (mType == 0) {
+        if (mDrawFlag == 0) {
+            if (is_switch() == 1) {
+                mDrawFlag = 1;
+            }
+        }
+    } else {
+        mDrawFlag = 1;
+    }
 }
 
 /* 00000F94-00001118       .text set_collision__Q210daObjItnak5Act_cFv */
 void daObjItnak::Act_c::set_collision() {
-    /* Nonmatching */
+    if (mDrawFlag == 1) {
+        if (set_co_se(&mCyl1) == 0) {
+            mCyl1.SetR(68.0f);
+            mCyl1.SetH(230.0f);
+            mCyl1.SetC(current.pos);
+            dComIfG_Ccsp()->Set(&mCyl1);
+        }
+        if (set_co_se(&mCyl2) == 0) {
+            cXyz src(41.0f, 44.0f, 84.0f);
+            cXyz pos;
+            cMtx_multVec(mMtx, &src, &pos);
+            mCyl2.SetR(62.0f);
+            mCyl2.SetH(121.0f);
+            mCyl2.SetC(pos);
+            dComIfG_Ccsp()->Set(&mCyl2);
+        }
+        if (set_co_se(&mCyl3) == 0) {
+            cXyz src(-88.0f, 83.0f, 86.0f);
+            cXyz pos;
+            cMtx_multVec(mMtx, &src, &pos);
+            mCyl3.SetR(47.0f);
+            mCyl3.SetH(205.0f);
+            mCyl3.SetC(pos);
+            dComIfG_Ccsp()->Set(&mCyl3);
+        }
+        fopAcM_rollPlayerCrash(this, 68.0f, 0xD);
+    }
 }
 
 /* 00001118-00001158       .text _execute__Q210daObjItnak5Act_cFv */
 bool daObjItnak::Act_c::_execute() {
-    /* Nonmatching */
+    set_mtx();
+    manage_draw_flag();
+    set_collision();
+    return true;
 }
 
 /* 00001158-0000123C       .text _draw__Q210daObjItnak5Act_cFv */
 bool daObjItnak::Act_c::_draw() {
-    /* Nonmatching */
+    if (mDrawFlag != 0) {
+        g_env_light.settingTevStruct(TEV_TYPE_BG0, &current.pos, &tevStr);
+        g_env_light.setLightTevColorType(mpModel, &tevStr);
+        mDoExt_modelUpdateDL(mpModel);
+
+        cXyz pos(current.pos.x, 30.0f + current.pos.y, current.pos.z);
+        mShadowId = dComIfGd_setShadow(mShadowId, 1, mpModel, &pos, 800.0f, 60.0f,
+                                       current.pos.y, mGroundY, mGndChk, &tevStr, 0, 1.0f);
+    }
+    return true;
 }
 
 namespace daObjItnak {


### PR DESCRIPTION
## Summary
Decompiles `d_a_obj_Itnak` (the unused Darknut statue actor). Closes the bulk of #370.

## What matches (100%)
`solidHeapCB`, `create_heap`, `_delete`, `set_mtx`, `set_co_se`, `manage_draw_flag`, `set_collision`, `_execute`, and the full `Mthd_*` profile table — 8/9 hand-written functions + glue byte-match.

## Equivalent (not yet 100%)
Marked `Equivalent` in `configure.py`; logic is correct, only minor codegen nonmatching remains:

- **`_create` (~86%)**: structurally complete (fopAcM_ct / resLoad / setCullSizeBox / GroundCross / 3× cyl Init+Set+SetStts+OnTgNoHitMark). Remaining diff is the 3× zero-vector store into the collision cylinders: original inlines `cXyz::Zero` into cyl `+0xb4` with `&Zero` CSE'd in r28 (`_savegpr_28` vs `_29`); the matching inline setter for that field hasn't been pinned yet.
- **`_draw` (~94%)**: structurally complete (settingTevStruct / setLightTevColorType / modelUpdateDL / dComIfGd_setShadow gated on the draw flag). Remaining diff is a `cXyz` temp double-store / stack-frame nuance on the shadow position argument (orig frame `-0x30` vs `-0x20`).

Both are classic minor regalloc / inline-selection issues; happy to push these to 100% with a second pair of eyes — will follow up with decomp.me scratches for the two functions.

## Notes
- `L_attr` modeled as 12 `f32`; `M_cyl_src` (`dCcD_SrcCyl`) and `M_arcname` as separate statics, matching the original `.rodata` layout.
- `M_cyl_src` initializer values are placeholder-typed (data-only; does not affect function matching) and will be refined alongside the `_create` polish.

## Test plan
- [x] `python configure.py && ninja` builds clean (`416 files OK`), overall progress 65.10% → 65.14%
- [x] All 8 matched functions + `Mthd_*` verified 100% via objdiff
- [ ] `_create` / `_draw` to 100% (follow-up, decomp.me)