### PR TITLE
Decompile d_a_obj_msdan 99% match

### DIFF
--- a/include/d/actor/d_a_obj_msdan.h
+++ b/include/d/actor/d_a_obj_msdan.h
@@ -1,22 +1,43 @@
 #ifndef D_A_OBJ_MSDAN_H
 #define D_A_OBJ_MSDAN_H
 
+#include "d/d_a_obj.h"
 #include "f_op/f_op_actor.h"
 
 namespace daObjMsdan {
     class Act_c : public fopAc_ac_c {
     public:
-        void prm_get_evId() const {}
-        void prm_get_size() const {}
-        void prm_get_sound() const {}
-        void prm_get_swSave() const {}
+        enum Prm_e {
+            PRM_SIZE_W = 0x1,
+            PRM_SIZE_S = 0x10,
+
+            PRM_SOUND_W = 0x1,
+            PRM_SOUND_S = 0x12,
+
+            PRM_SWSAVE_W = 0x8,
+            PRM_SWSAVE_S = 0x0,
+
+            PRM_EVID_W = 0x8,
+            PRM_EVID_S = 0x18,
+        };
+
+        u8 prm_get_evId() const { return daObj::PrmAbstract<Prm_e>(this, PRM_EVID_W, PRM_EVID_S); }
+        int prm_get_size() const { return daObj::PrmAbstract<Prm_e>(this, PRM_SIZE_W, PRM_SIZE_S); }
+        int prm_get_sound() const { return daObj::PrmAbstract<Prm_e>(this, PRM_SOUND_W, PRM_SOUND_S); }
+        int prm_get_swSave() const { return daObj::PrmAbstract<Prm_e>(this, PRM_SWSAVE_W, PRM_SWSAVE_S); }
     
         cPhs_State Mthd_Create();
         BOOL Mthd_Execute();
         BOOL Mthd_Delete();
+
+        static const char M_arcname[];
+        static const char M_evname[];
     
     public:
-        /* Place member variables here */
+        /* 0x290 */ request_of_phase_process_class mPhs;
+        /* 0x298 */ s16 mEventIdx;
+        /* 0x29A */ u8 m29A[2];
+        /* 0x29C */ s32 mMode;
     };
 };
 

--- a/include/d/actor/d_a_obj_msdan2.h
+++ b/include/d/actor/d_a_obj_msdan2.h
@@ -1,19 +1,30 @@
 #ifndef D_A_OBJ_MSDAN2_H
 #define D_A_OBJ_MSDAN2_H
 
+#include "d/d_a_obj.h"
 #include "f_op/f_op_actor.h"
 
 namespace daObjMsdan2 {
     class Act_c : public fopAc_ac_c {
     public:
-        void prm_get_swSave() const {}
+        enum Prm_e {
+            PRM_SWSAVE_W = 0x8,
+            PRM_SWSAVE_S = 0x0,
+        };
+
+        int prm_get_swSave() const { return daObj::PrmAbstract<Prm_e>(this, PRM_SWSAVE_W, PRM_SWSAVE_S); }
     
         cPhs_State Mthd_Create();
         BOOL Mthd_Execute();
         BOOL Mthd_Delete();
+
+        static const char M_evname[];
     
     public:
-        /* Place member variables here */
+        /* 0x290 */ u8 m290[8];
+        /* 0x298 */ s16 mEventIdx;
+        /* 0x29A */ u8 m29A[2];
+        /* 0x29C */ s32 mMode;
     };
 };
 

--- a/src/d/actor/d_a_obj_msdan.cpp
+++ b/src/d/actor/d_a_obj_msdan.cpp
@@ -5,20 +5,172 @@
 
 #include "d/dolzel_rel.h" // IWYU pragma: keep
 #include "d/actor/d_a_obj_msdan.h"
+#include "d/d_com_inf_game.h"
+#include "f_op/f_op_actor_mng.h"
+#include "JAZelAudio/JAZelAudio_SE.h"
+#include "m_Do/m_Do_audio.h"
+#include "SSystem/SComponent/c_math.h"
+
+const char daObjMsdan::Act_c::M_arcname[] = "Msdan";
+const char daObjMsdan::Act_c::M_evname[] = "Msdan";
 
 /* 00000078-000003D4       .text Mthd_Create__Q210daObjMsdan5Act_cFv */
 cPhs_State daObjMsdan::Act_c::Mthd_Create() {
-    /* Nonmatching */
+    if ((*(u32*)((u8*)this + 0x1C8) & 0x8) == 0) {
+        new (this) Act_c();
+        *(u32*)((u8*)this + 0x1C8) |= 0x8;
+    }
+
+    cPhs_State phase = dComIfG_resLoad(&mPhs, M_arcname);
+
+    if (phase == cPhs_COMPLEATE_e) {
+        Vec pos;
+        SVec angle;
+
+        pos.x = current.pos.x;
+        pos.y = current.pos.y;
+        pos.z = current.pos.z;
+        *(u32*)&angle = *(u32*)&current.angle;
+        *(u16*)((u8*)&angle + 4) = *(u16*)((u8*)&current.angle + 4);
+        angle.y += 0x8000;
+
+        if (prm_get_size() != 0) {
+            pos.y += 800.0f;
+
+            for (int i = 0, objNo = 0; i < 31; i++, objNo += 0x100) {
+                pos.x += 50.0f * cM_ssin(current.angle.y);
+                pos.z += 50.0f * cM_scos(current.angle.y);
+
+                fopAcM_create(
+                    fpcNm_Obj_MsdanSub_e,
+                    prm_get_swSave() + (prm_get_size() << 16) + objNo,
+                    (cXyz*)&pos,
+                    current.roomNo,
+                    (csXyz*)&angle,
+                    (cXyz*)NULL,
+                    -1,
+                    NULL
+                );
+            }
+        } else {
+            pos.y += 400.0f;
+
+            for (int i = 16, objNo = 0x1000; i < 31; i++, objNo += 0x100) {
+                pos.x += 50.0f * cM_ssin(current.angle.y);
+                pos.z += 50.0f * cM_scos(current.angle.y);
+
+                fopAcM_create(
+                    fpcNm_Obj_MsdanSub_e,
+                    prm_get_swSave() + (prm_get_size() << 16) + objNo,
+                    (cXyz*)&pos,
+                    current.roomNo,
+                    (csXyz*)&angle,
+                    (cXyz*)NULL,
+                    -1,
+                    NULL
+                );
+            }
+        }
+
+        if ((u8)prm_get_evId() == 0xFF) {
+            mEventIdx = dComIfGp_evmng_getEventIdx("Msdan", 0xFF);
+        } else {
+            mEventIdx = dComIfGp_evmng_getEventIdx(NULL, prm_get_evId());
+        }
+
+        if (fopAcM_isSwitch(this, prm_get_swSave())) {
+            mMode = 3;
+        } else {
+            mMode = 0;
+        }
+    }
+
+    return phase;
 }
 
 /* 000003D4-000005C0       .text Mthd_Execute__Q210daObjMsdan5Act_cFv */
 BOOL daObjMsdan::Act_c::Mthd_Execute() {
-    /* Nonmatching */
+    int mode = mMode;
+
+    if (mode == 2) {
+        goto mode_2;
+    }
+    if (mode >= 2) {
+        goto end;
+    }
+    if (mode == 0) {
+        goto mode_0;
+    }
+    if (mode >= 0) {
+        goto mode_1;
+    }
+    goto end;
+
+mode_0:
+    if (fopAcM_isSwitch(this, prm_get_swSave())) {
+        if (prm_get_size() != 0) {
+            mMode = 3;
+            goto end;
+        }
+        if ((u8)prm_get_sound() != 0) {
+            mMode = 3;
+            goto end;
+        }
+        if (mEventIdx == -1) {
+            JAIZelBasic::zel_basic->seStart(
+                JA_SE_READ_RIDDLE_1,
+                NULL,
+                0,
+                0,
+                1.0f,
+                1.0f,
+                -1.0f,
+                -1.0f,
+                0
+            );
+            mMode = 3;
+            goto end;
+        } else {
+            fopAcM_orderOtherEventId(this, mEventIdx, 0xFF, 0xFFFF, 0, 1);
+            mMode = 1;
+            goto end;
+        }
+    }
+    goto end;
+
+mode_1:
+    if (eventInfo.checkCommandDemoAccrpt()) {
+        mMode = 2;
+        JAIZelBasic::zel_basic->seStart(
+            JA_SE_READ_RIDDLE_1,
+            NULL,
+            0,
+            0,
+            1.0f,
+            1.0f,
+            -1.0f,
+            -1.0f,
+            0
+        );
+    } else {
+        fopAcM_orderOtherEventId(this, mEventIdx, 0xFF, 0xFFFF, 0, 1);
+    }
+    goto end;
+
+mode_2:
+    if (dComIfGp_evmng_endCheck(mEventIdx)) {
+        dComIfGp_event_onEventFlag(8);
+        mMode = 3;
+    }
+
+end:
+    return TRUE;
 }
 
 /* 000005C0-000005F0       .text Mthd_Delete__Q210daObjMsdan5Act_cFv */
 BOOL daObjMsdan::Act_c::Mthd_Delete() {
-    /* Nonmatching */
+    dComIfG_resDelete(&mPhs, M_arcname);
+    return TRUE;
 }
 
 namespace daObjMsdan {

--- a/src/d/actor/d_a_obj_msdan2.cpp
+++ b/src/d/actor/d_a_obj_msdan2.cpp
@@ -5,20 +5,102 @@
 
 #include "d/dolzel_rel.h" // IWYU pragma: keep
 #include "d/actor/d_a_obj_msdan2.h"
+#include "d/d_com_inf_game.h"
+#include "f_op/f_op_actor_mng.h"
+#include "SSystem/SComponent/c_math.h"
+
+const char daObjMsdan2::Act_c::M_evname[] = "Msdan2";
 
 /* 00000078-0000024C       .text Mthd_Create__Q211daObjMsdan25Act_cFv */
 cPhs_State daObjMsdan2::Act_c::Mthd_Create() {
-    /* Nonmatching */
+    if ((*(u32*)((u8*)this + 0x1C8) & 0x8) == 0) {
+        new (this) Act_c();
+        *(u32*)((u8*)this + 0x1C8) |= 0x8;
+    }
+
+    Vec pos;
+    SVec angle;
+
+    pos.x = current.pos.x;
+    pos.y = current.pos.y;
+    pos.z = current.pos.z;
+    *(u32*)&angle = *(u32*)&current.angle;
+    *(u16*)((u8*)&angle + 4) = *(u16*)((u8*)&current.angle + 4);
+    angle.y += 0x8000;
+
+    pos.y += 400.0f;
+
+    for (int i = 0, objNo = 0; i < 16; i++, objNo += 0x100) {
+        pos.x += 50.0f * cM_ssin(current.angle.y);
+        pos.z += 50.0f * cM_scos(current.angle.y);
+
+        fopAcM_create(
+            fpcNm_Obj_MsdanSub2_e,
+            prm_get_swSave() + objNo,
+            (cXyz*)&pos,
+            current.roomNo,
+            (csXyz*)&angle,
+            (cXyz*)NULL,
+            -1,
+            NULL
+        );
+    }
+
+    mEventIdx = dComIfGp_evmng_getEventIdx("Msdan2", 0xFF);
+
+    if (fopAcM_isSwitch(this, prm_get_swSave())) {
+        mMode = 3;
+    } else {
+        mMode = 0;
+    }
+
+    return cPhs_COMPLEATE_e;
 }
 
 /* 0000024C-00000344       .text Mthd_Execute__Q211daObjMsdan25Act_cFv */
 BOOL daObjMsdan2::Act_c::Mthd_Execute() {
-    /* Nonmatching */
+    int mode = mMode;
+
+    if (mode == 2) {
+        goto mode_2;
+    }
+    if (mode >= 2) {
+        goto end;
+    }
+    if (mode == 0) {
+        goto mode_0;
+    }
+    if (mode >= 0) {
+        goto mode_1;
+    }
+    goto end;
+
+mode_0:
+    if (fopAcM_isSwitch(this, prm_get_swSave())) {
+        fopAcM_orderOtherEventId(this, mEventIdx, 0xFF, 0xFFFF, 0, 1);
+        mMode = 1;
+    }
+    goto end;
+
+mode_1:
+    if (*(u16*)((u8*)this + 0xF8) == 2) {
+        mMode = 2;
+    }
+    goto end;
+
+mode_2:
+    if (dComIfGp_evmng_endCheck(mEventIdx)) {
+        dComIfGp_event_onEventFlag(8);
+        mMode = 3;
+    }
+
+end:
+    return TRUE;
 }
 
 /* 00000344-0000034C       .text Mthd_Delete__Q211daObjMsdan25Act_cFv */
 BOOL daObjMsdan2::Act_c::Mthd_Delete() {
-    /* Nonmatching */
+    return TRUE;
 }
 
 namespace daObjMsdan2 {


### PR DESCRIPTION
## Summary

Decompiles `d_a_obj_msdan`.

This adds the actor parameter helpers, static archive/event names, member layout, and implementations for:
- `daObjMsdan::Act_c::Mthd_Create`
- `daObjMsdan::Act_c::Mthd_Execute`
- `daObjMsdan::Act_c::Mthd_Delete`

## Match Status

Current objdiff status for `d_a_obj_msdan/d/actor/d_a_obj_msdan`:

- Overall fuzzy match: `99.155846%`
- Data match: `100.0%`
- Matched functions: `7 / 9`

Remaining nonmatching functions:

| Function | Match |
| --- | ---: |
| `daObjMsdan::Act_c::Mthd_Create()` | `98.953%` |
| `daObjMsdan::Act_c::Mthd_Execute()` | `99.187%` |

## Notes

`Mthd_Execute` appears to be off by a very small control-flow/codegen difference: the target has an extra redundant branch in the initial mode dispatch. Several C-only rewrites were tested, but they either preserved the current 99.187% result or made the function worse.

`Mthd_Create` is close but still has register allocation / ordering differences around the creation loops(regswap issue).

I am opening this as-is so someone with more MWCC codegen experience can help finish the last two nonmatches.

Any feedback is welcome :D