### PR TITLE
d_a_npc_bs1

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1637,7 +1637,7 @@ config.libs = [
     ActorRel(NonMatching, "d_a_npc_bmcon1"),
     ActorRel(NonMatching, "d_a_npc_bms1"),
     ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d_a_npc_bmsw"),
-    ActorRel(MatchingFor("D44J01"), "d_a_npc_bs1"), # regalloc
+    ActorRel(EquivalentFor("GZLJ01", "GZLE01", "GZLP01") or MatchingFor("D44J01"), "d_a_npc_bs1"), # regalloc
     ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),  "d_a_npc_btsw"),
     ActorRel(Matching,    "d_a_npc_btsw2"),
     ActorRel(NonMatching, "d_a_npc_co1"),


### PR DESCRIPTION
Marks the retail versions of d_a_npc_bs1 equivalent while keeping D44J01 matching. The remaining retail difference is a harmless regalloc mismatch in next_msgStatus.

Checked with:
- ninja
- ninja changes_all