### PR TITLE
d_a_tag_kf1 12%

### DIFF
--- a/include/d/actor/d_a_tag_kf1.h
+++ b/include/d/actor/d_a_tag_kf1.h
@@ -1,6 +1,7 @@
 #ifndef D_A_TAG_KF1_H
 #define D_A_TAG_KF1_H
 
+#include "d/d_npc.h"
 #include "f_op/f_op_actor.h"
 
 class daTag_Kf1_c : public fopAc_ac_c {
@@ -10,9 +11,9 @@ public:
     void next_msgStatus(unsigned long*);
     void eventOrder();
     void checkOrder();
-    void chkAttention(cXyz);
+    BOOL chkAttention(cXyz);
     void partner_srch();
-    void checkPartner();
+    s16 checkPartner();
     void goto_nextStage();
     void event_talkInit(int);
     void event_mesSet();
@@ -23,17 +24,33 @@ public:
     void privateCut();
     void event_proc();
     void set_action(int (daTag_Kf1_c::*)(void*), void*);
-    void wait01();
-    void wait02();
-    void wait_action1(void*);
+    BOOL wait01();
+    BOOL wait02();
+    BOOL wait_action1(void*);
     BOOL _draw();
     BOOL _execute();
     BOOL _delete();
     cPhs_State _create();
 
 public:
-    /* Place member variables here */
+    /* 0x290 */ u8 field_0x290[0x6C4 - 0x290];
+    /* 0x6C4 */ int (daTag_Kf1_c::*mActionFunc)(void*);
+    /* 0x6D0 */ dNpc_EventCut_c mEventCut;
+    /* 0x73C */ u8 field_0x73C;
+    /* 0x73D */ u8 field_0x73D;
+    /* 0x73E */ s16 field_0x73E;
+    /* 0x740 */ u8 field_0x740[0x742 - 0x740];
+    /* 0x742 */ u16 field_0x742;
+    /* 0x744 */ u8 field_0x744[0x764 - 0x744];
+    /* 0x764 */ s16 field_0x764;
+    /* 0x766 */ s8 mAction;
+    /* 0x767 */ s8 field_0x767;
+    /* 0x768 */ s8 mStt;
+    /* 0x769 */ u8 field_0x769;
+    /* 0x76A */ s8 field_0x76A;
+    /* 0x76B */ u8 field_0x76B;
 };
+STATIC_ASSERT(sizeof(daTag_Kf1_c) == 0x76C);
 
 class daTag_Kf1_HIO_c {
 public:

--- a/src/d/actor/d_a_tag_kf1.cpp
+++ b/src/d/actor/d_a_tag_kf1.cpp
@@ -22,8 +22,13 @@ void daTag_Kf1_c::createInit() {
 }
 
 /* 00000220-00000234       .text setStt__11daTag_Kf1_cFSc */
-void daTag_Kf1_c::setStt(signed char) {
+void daTag_Kf1_c::setStt(signed char stt) {
     /* Nonmatching */
+    mStt = stt;
+    switch (mStt) {
+    case 3:
+        break;
+    }
 }
 
 /* 00000234-00000294       .text next_msgStatus__11daTag_Kf1_cFPUl */
@@ -42,7 +47,7 @@ void daTag_Kf1_c::checkOrder() {
 }
 
 /* 00000380-00000470       .text chkAttention__11daTag_Kf1_cF4cXyz */
-void daTag_Kf1_c::chkAttention(cXyz) {
+BOOL daTag_Kf1_c::chkAttention(cXyz) {
     /* Nonmatching */
 }
 
@@ -52,7 +57,7 @@ void daTag_Kf1_c::partner_srch() {
 }
 
 /* 0000057C-00000604       .text checkPartner__11daTag_Kf1_cFv */
-void daTag_Kf1_c::checkPartner() {
+s16 daTag_Kf1_c::checkPartner() {
     /* Nonmatching */
 }
 
@@ -83,12 +88,12 @@ void daTag_Kf1_c::bensyoInit() {
 
 /* 000007A4-000007C4       .text event_bensyo__11daTag_Kf1_cFv */
 void daTag_Kf1_c::event_bensyo() {
-    /* Nonmatching */
+    event_mesSet();
 }
 
 /* 000007C4-000007FC       .text event_cntTsubo__11daTag_Kf1_cFv */
 void daTag_Kf1_c::event_cntTsubo() {
-    /* Nonmatching */
+    field_0x73E = field_0x764 - checkPartner();
 }
 
 /* 000007FC-00000978       .text privateCut__11daTag_Kf1_cFv */
@@ -107,23 +112,45 @@ void daTag_Kf1_c::set_action(int (daTag_Kf1_c::*)(void*), void*) {
 }
 
 /* 00000AB8-00000B14       .text wait01__11daTag_Kf1_cFv */
-void daTag_Kf1_c::wait01() {
-    /* Nonmatching */
+BOOL daTag_Kf1_c::wait01() {
+    field_0x767 = 0;
+    if (field_0x73C != 0 && field_0x764 != checkPartner()) {
+        field_0x767 = 3;
+    }
+    return TRUE;
 }
 
 /* 00000B14-00000B1C       .text wait02__11daTag_Kf1_cFv */
-void daTag_Kf1_c::wait02() {
-    /* Nonmatching */
+BOOL daTag_Kf1_c::wait02() {
+    return TRUE;
 }
 
 /* 00000B1C-00000BE8       .text wait_action1__11daTag_Kf1_cFPv */
-void daTag_Kf1_c::wait_action1(void*) {
-    /* Nonmatching */
+BOOL daTag_Kf1_c::wait_action1(void*) {
+    if (field_0x76A == 0) {
+        setStt(1);
+        field_0x76A++;
+    } else if (field_0x76A != -1) {
+        if (field_0x76A == 1) {
+            partner_srch();
+            field_0x76A = 2;
+        }
+        field_0x73C = chkAttention(current.pos);
+        switch (mStt) {
+        case 1:
+            wait01();
+            break;
+        case 2:
+            wait02();
+            break;
+        }
+    }
+    return TRUE;
 }
 
 /* 00000BE8-00000BF0       .text _draw__11daTag_Kf1_cFv */
 BOOL daTag_Kf1_c::_draw() {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 00000BF0-00000C68       .text _execute__11daTag_Kf1_cFv */


### PR DESCRIPTION
Partial match for d_a_tag_kf1.

11/63 functions at 100%. setStt remains nonmatching at 80% due to mwcc optimizing away the extsb sign-extension when comparing s8 to a positive constant.

Checked with:
- ninja
- ninja changes_all

Closes #473