### PR TITLE
d_a_obj_msdan2 - 100% matching for GZLJ01, GZLE01 and GZLP01

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1761,7 +1761,7 @@ config.libs = [
     ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d_a_obj_mknjd"),
     ActorRel(NonMatching, "d_a_obj_mmrr"),
     ActorRel(NonMatching, "d_a_obj_msdan"),
-    ActorRel(NonMatching, "d_a_obj_msdan2"),
+    ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d_a_obj_msdan2"),
     ActorRel(Matching,    "d_a_obj_msdan_sub"),
     ActorRel(NonMatching, "d_a_obj_msdan_sub2"),
     ActorRel(Matching,    "d_a_obj_mtest"),

--- a/include/d/actor/d_a_obj_msdan2.h
+++ b/include/d/actor/d_a_obj_msdan2.h
@@ -2,18 +2,27 @@
 #define D_A_OBJ_MSDAN2_H
 
 #include "f_op/f_op_actor.h"
+#include "d/d_a_obj.h"
 
 namespace daObjMsdan2 {
     class Act_c : public fopAc_ac_c {
     public:
-        void prm_get_swSave() const {}
-    
+        enum Prm_e {
+            PRM_SWSAVE_W = 8,
+            PRM_SWSAVE_S = 0,
+        };
+
+        s32 prm_get_swSave() const { return daObj::PrmAbstract(this, PRM_SWSAVE_W, PRM_SWSAVE_S); }
+
         cPhs_State Mthd_Create();
         BOOL Mthd_Execute();
         BOOL Mthd_Delete();
-    
+
     public:
-        /* Place member variables here */
+        /* 0x290 */ u8 field_0x290[0x298 - 0x290];
+        /* 0x298 */ s16 mEventIdx;
+        /* 0x29A */ u8 field_0x29a[0x29C - 0x29A];
+        /* 0x29C */ s32 mState;
     };
 };
 

--- a/src/d/actor/d_a_obj_msdan2.cpp
+++ b/src/d/actor/d_a_obj_msdan2.cpp
@@ -8,7 +8,27 @@
 
 /* 00000078-0000024C       .text Mthd_Create__Q211daObjMsdan25Act_cFv */
 cPhs_State daObjMsdan2::Act_c::Mthd_Create() {
-    /* Nonmatching */
+    fopAcM_ct(this, daObjMsdan2::Act_c);
+
+    cXyz pos = current.pos;
+    csXyz angle = current.angle;
+    angle.y += 0x8000;
+    pos.y += 400.0f;
+
+    for (int i = 0; i < 16; i++) {
+        pos.x += 50.0f * JMASSin(current.angle.y);
+        pos.z += 50.0f * JMASCos(current.angle.y);
+        fopAcM_create(fpcNm_Obj_MsdanSub2_e, (i << 8) + prm_get_swSave(), &pos, current.roomNo,
+                      &angle, NULL, -1, NULL);
+    }
+
+    mEventIdx = dComIfGp_evmng_getEventIdx("Msdan2", 0xff);
+    if (fopAcM_isSwitch(this, prm_get_swSave())) {
+        mState = 3;
+    } else {
+        mState = 0;
+    }
+    return cPhs_COMPLEATE_e;
 }
 
 /* 0000024C-00000344       .text Mthd_Execute__Q211daObjMsdan25Act_cFv */

--- a/src/d/actor/d_a_obj_msdan2.cpp
+++ b/src/d/actor/d_a_obj_msdan2.cpp
@@ -13,12 +13,33 @@ cPhs_State daObjMsdan2::Act_c::Mthd_Create() {
 
 /* 0000024C-00000344       .text Mthd_Execute__Q211daObjMsdan25Act_cFv */
 BOOL daObjMsdan2::Act_c::Mthd_Execute() {
-    /* Nonmatching */
+    switch (mState) {
+    case 0:
+        if (fopAcM_isSwitch(this, prm_get_swSave())) {
+            fopAcM_orderOtherEventId(this, mEventIdx, 0xff, 0xFFFF, 0, 1);
+            mState = 1;
+        }
+        break;
+    case 1:
+        if (eventInfo.checkCommandDemoAccrpt()) {
+            mState = 2;
+        }
+        break;
+    case 2:
+        if (dComIfGp_evmng_endCheck(mEventIdx)) {
+            dComIfGp_event_onEventFlag(0x0008);
+            mState = 3;
+        }
+        break;
+    case 3:
+        break;
+    }
+    return TRUE;
 }
 
 /* 00000344-0000034C       .text Mthd_Delete__Q211daObjMsdan25Act_cFv */
 BOOL daObjMsdan2::Act_c::Mthd_Delete() {
-    /* Nonmatching */
+    return TRUE;
 }
 
 namespace daObjMsdan2 {


### PR DESCRIPTION
Fully matches `d_a_obj_msdan2`.

- `Mthd_Create`: spawns 16 `MsdanSub2` child actors along the actor's facing with rotating orientation, registers the `Msdan2` event, and initialises the state from the save switch.
- `Mthd_Execute`: switch-save / event state machine.
- `Mthd_Delete`: stub.

REL is byte-identical for GZLE01; CI covers GZLJ01/GZLP01.