### PR TITLE
d_a_obj_msdan_sub2 - 100% matching for GZLJ01, GZLE01 and GZLP01

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1763,7 +1763,7 @@ config.libs = [
     ActorRel(NonMatching, "d_a_obj_msdan"),
     ActorRel(NonMatching, "d_a_obj_msdan2"),
     ActorRel(Matching,    "d_a_obj_msdan_sub"),
-    ActorRel(NonMatching, "d_a_obj_msdan_sub2"),
+    ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"), "d_a_obj_msdan_sub2"),
     ActorRel(Matching,    "d_a_obj_mtest"),
     ActorRel(Matching,    "d_a_obj_nest"),
     ActorRel(Matching,    "d_a_obj_ojtree"),

--- a/include/d/actor/d_a_obj_msdan_sub2.h
+++ b/include/d/actor/d_a_obj_msdan_sub2.h
@@ -6,9 +6,17 @@
 namespace daObjMsdanSub2 {
     class Act_c : public dBgS_MoveBgActor {
     public:
-        void prm_get_objNo() const {}
-        void prm_get_swSave() const {}
-    
+        enum Prm_e {
+            PRM_SWSAVE_W = 0x8,
+            PRM_SWSAVE_S = 0x0,
+
+            PRM_OBJNO_W = 0x8,
+            PRM_OBJNO_S = 0x8,
+        };
+
+        s32 prm_get_objNo() const { return daObj::PrmAbstract(this, PRM_OBJNO_W, PRM_OBJNO_S); }
+        s32 prm_get_swSave() const { return daObj::PrmAbstract(this, PRM_SWSAVE_W, PRM_SWSAVE_S); }
+
         virtual BOOL CreateHeap();
         virtual BOOL Create();
         cPhs_State Mthd_Create();
@@ -18,9 +26,16 @@ namespace daObjMsdanSub2 {
         void init_mtx();
         virtual BOOL Execute(Mtx**);
         virtual BOOL Draw();
-    
+
+        static const char M_arcname[];
+        static Mtx M_tmp_mtx;
+
     public:
-        /* Place member variables here */
+        /* 0x2C8 */ request_of_phase_process_class mPhs;
+        /* 0x2D0 */ J3DModel* mModel;
+        /* 0x2D4 */ s32 m2D4;
+        /* 0x2D8 */ f32 m2D8;
+        /* 0x2DC */ f32 m2DC;
     };
 };
 

--- a/src/d/actor/d_a_obj_msdan_sub2.cpp
+++ b/src/d/actor/d_a_obj_msdan_sub2.cpp
@@ -5,50 +5,145 @@
 
 #include "d/dolzel_rel.h" // IWYU pragma: keep
 #include "d/actor/d_a_obj_msdan_sub2.h"
+#include "res/Object/Msdan.h"
+#include "m_Do/m_Do_mtx.h"
+#include "d/d_com_inf_game.h"
+#include "d/d_bg_s_movebg_actor.h"
+#include "SSystem/SComponent/c_bg_w.h"
+#include "JAZelAudio/JAIZelBasic.h"
+
+const char daObjMsdanSub2::Act_c::M_arcname[] = "Msdan";
+Mtx daObjMsdanSub2::Act_c::M_tmp_mtx;
 
 /* 00000078-0000012C       .text CreateHeap__Q214daObjMsdanSub25Act_cFv */
 BOOL daObjMsdanSub2::Act_c::CreateHeap() {
-    /* Nonmatching */
+    J3DModelData* model_data = (J3DModelData*)dComIfG_getObjectRes(M_arcname, dRes_INDEX_MSDAN_BDL_MSDAN_e);
+    JUT_ASSERT(87, model_data != NULL);
+    mModel = mDoExt_J3DModel__create(model_data, 0, 0x11020203);
+    return mModel != NULL;
 }
 
 /* 0000012C-000002E4       .text Create__Q214daObjMsdanSub25Act_cFv */
 BOOL daObjMsdanSub2::Act_c::Create() {
-    /* Nonmatching */
+    fopAcM_SetMtx(this, mModel->getBaseTRMtx());
+    fopAcM_setCullSizeBox(this, -1500.0f, -1000.0f, -1500.0f, 1500.0f, 1000.0f, 1500.0f);
+    if (fopAcM_isSwitch(this, prm_get_swSave())) {
+        if ((prm_get_objNo() & 1) == 0) {
+            current.pos.x = home.pos.x + 600.0f * JMASCos(current.angle.y);
+            current.pos.z = home.pos.z + 600.0f * JMASSin(current.angle.y);
+        } else {
+            current.pos.x = home.pos.x - 600.0f * JMASCos(current.angle.y);
+            current.pos.z = home.pos.z - 600.0f * JMASSin(current.angle.y);
+        }
+        m2D4 = 0x10;
+    } else {
+        m2D4 = 0;
+        m2D8 = 0.0f;
+        m2DC = 0.0f;
+    }
+    init_mtx();
+    mpBgW->Move();
+    return TRUE;
 }
 
 /* 000002E4-00000454       .text Mthd_Create__Q214daObjMsdanSub25Act_cFv */
 cPhs_State daObjMsdanSub2::Act_c::Mthd_Create() {
-    /* Nonmatching */
+    fopAcM_ct(this, Act_c);
+    cPhs_State phase_state = dComIfG_resLoad(&mPhs, M_arcname);
+
+    if (phase_state == cPhs_COMPLEATE_e) {
+        phase_state = MoveBGCreate(M_arcname, dRes_INDEX_MSDAN_DZB_MSDAN_e, dBgS_MoveBGProc_Trans, 0x9A0);
+        JUT_ASSERT(145, (phase_state == cPhs_COMPLEATE_e) || (phase_state == cPhs_ERROR_e));
+        if (fopAcM_isSwitch(this, prm_get_swSave())) {
+            if (mpBgW != NULL && mpBgW->ChkUsed()) {
+                dComIfG_Bgsp()->Release(mpBgW);
+            }
+        }
+    }
+    return phase_state;
 }
 
 /* 00000454-0000045C       .text Delete__Q214daObjMsdanSub25Act_cFv */
 BOOL daObjMsdanSub2::Act_c::Delete() {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 0000045C-000004A8       .text Mthd_Delete__Q214daObjMsdanSub25Act_cFv */
 BOOL daObjMsdanSub2::Act_c::Mthd_Delete() {
-    /* Nonmatching */
+    BOOL move_bg_delete_val = MoveBGDelete();
+    dComIfG_resDeleteDemo(&mPhs, M_arcname);
+    return move_bg_delete_val;
 }
 
 /* 000004A8-00000528       .text set_mtx__Q214daObjMsdanSub25Act_cFv */
 void daObjMsdanSub2::Act_c::set_mtx() {
-    /* Nonmatching */
+    mDoMtx_stack_c::transS(current.pos);
+    mDoMtx_stack_c::ZXYrotM(shape_angle);
+    mModel->setBaseTRMtx(mDoMtx_stack_c::get());
+    cMtx_copy(mDoMtx_stack_c::get(), M_tmp_mtx);
 }
 
 /* 00000528-00000598       .text init_mtx__Q214daObjMsdanSub25Act_cFv */
 void daObjMsdanSub2::Act_c::init_mtx() {
-    /* Nonmatching */
+    scale *= 1.01f;
+    mModel->setBaseScale(scale);
+    cMtx_copy(M_tmp_mtx, mBgMtx);
+    set_mtx();
 }
 
 /* 00000598-0000090C       .text Execute__Q214daObjMsdanSub25Act_cFPPA3_A4_f */
-BOOL daObjMsdanSub2::Act_c::Execute(Mtx**) {
-    /* Nonmatching */
+BOOL daObjMsdanSub2::Act_c::Execute(Mtx** pMtx) {
+    if (fopAcM_isSwitch(this, prm_get_swSave())) {
+        if (m2DC < 0.0f) {
+            m2DC = 0.0f;
+        }
+        if (m2D4 < 0x10) {
+            if (m2DC == 0.0f) {
+                JAIZelBasic::zel_basic->seStart(JA_SE_OBJ_SW_STAIR2_ON_1, &current.pos, 0,
+                                                dComIfGp_getReverb(fopAcM_GetRoomNo(this)),
+                                                1.0f, 1.0f, -1.0f, -1.0f, 0);
+            }
+            m2DC += 10.0f;
+            m2D8 += m2DC;
+            if (m2D4 == prm_get_objNo()) {
+                if ((m2D4 & 1) == 0) {
+                    current.pos.x = home.pos.x + m2D8 * JMASCos(current.angle.y);
+                    current.pos.z = home.pos.z + m2D8 * JMASSin(current.angle.y);
+                } else {
+                    current.pos.x = home.pos.x - m2D8 * JMASCos(current.angle.y);
+                    current.pos.z = home.pos.z - m2D8 * JMASSin(current.angle.y);
+                }
+            }
+            if (m2D8 >= 600.0f) {
+                if (m2D4 == prm_get_objNo()) {
+                    if ((m2D4 & 1) == 0) {
+                        current.pos.x = home.pos.x + 600.0f * JMASCos(current.angle.y);
+                        current.pos.z = home.pos.z + 600.0f * JMASSin(current.angle.y);
+                    } else {
+                        current.pos.x = home.pos.x - 600.0f * JMASCos(current.angle.y);
+                        current.pos.z = home.pos.z - 600.0f * JMASSin(current.angle.y);
+                    }
+                    dComIfGp_getVibration().StartShock(1, 1, cXyz(0.0f, 1.0f, 0.0f));
+                }
+                m2D4++;
+                m2DC = 0.0f;
+                m2D8 = 0.0f;
+            }
+        }
+    }
+    set_mtx();
+    *pMtx = &M_tmp_mtx;
+    return TRUE;
 }
 
 /* 0000090C-000009AC       .text Draw__Q214daObjMsdanSub25Act_cFv */
 BOOL daObjMsdanSub2::Act_c::Draw() {
-    /* Nonmatching */
+    g_env_light.settingTevStruct(TEV_TYPE_BG0, &current.pos, &tevStr);
+    g_env_light.setLightTevColorType(mModel, &tevStr);
+    dComIfGd_setListBG();
+    mDoExt_modelUpdateDL(mModel);
+    dComIfGd_setList();
+    return TRUE;
 }
 
 namespace daObjMsdanSub2 {


### PR DESCRIPTION
Decompiles `d_a_obj_msdan_sub2` (WindFall Island staircase / movable stair sub-object) to 100% matching for the three retail regions GZLJ01, GZLE01 and GZLP01.

- All 9 functions byte-identical (verified via `dtk shasum -c` against retail rel sha `78b670a8`).
- `Act_c` derives from `dBgS_MoveBgActor`; implements CreateHeap/Create/Mthd_Create/Delete/Mthd_Delete/set_mtx/init_mtx/Execute/Draw.
- Uses the `MoveBGCreate` / `MoveBGDelete` idiom, `fopAcM_isSwitch` + `PrmAbstract` parameter access, and the switch-stair oscillation logic in Execute.