### PR TITLE
d_a_obj_Vds: match Event_init

### DIFF
--- a/include/d/actor/d_a_obj_Vds.h
+++ b/include/d/actor/d_a_obj_Vds.h
@@ -1,8 +1,12 @@
 #ifndef D_A_OBJ_VDS_H
 #define D_A_OBJ_VDS_H
 
+#include "SSystem/SComponent/c_phase.h"
 #include "f_op/f_op_actor.h"
+#include "m_Do/m_Do_ext.h"
 
+class dBgW;
+class J3DAnmTevRegKey;
 class J3DAnmTransformKey;
 
 namespace daObjVds {
@@ -10,6 +14,8 @@ namespace daObjVds {
 
     class Act_c : public fopAc_ac_c {
     public:
+        virtual ~Act_c() {}
+
         void is_switch() const {}
     
         void SetLoopJointAnimation(J3DAnmTransformKey*, J3DAnmTransformKey*, float, float);
@@ -37,8 +43,32 @@ namespace daObjVds {
         bool _draw();
     
     public:
-        /* Place member variables here */
+        /* 0x290 */  // vtable
+        /* 0x294 */ request_of_phase_process_class mPhs;
+        /* 0x29C */ Mtx mMtx;
+        /* 0x2CC */ mDoExt_McaMorf* mpMorf0;
+        /* 0x2D0 */ J3DAnmTransformKey* mpBck0;
+        /* 0x2D4 */ mDoExt_brkAnm mBrk0;
+        /* 0x2EC */ J3DAnmTevRegKey* mpBrk0;
+        /* 0x2F0 */ mDoExt_McaMorf* mpMorf1;
+        /* 0x2F4 */ J3DAnmTransformKey* mpBck1;
+        /* 0x2F8 */ mDoExt_brkAnm mBrk1;
+        /* 0x310 */ J3DAnmTevRegKey* mpBrk1;
+        /* 0x314 */ dBgW* mpBgW;
+        /* 0x318 */ int field_0x318;
+        /* 0x31C */ int field_0x31C;
+        /* 0x320 */ int field_0x320;
+        /* 0x324 */ fpc_ProcID field_0x324[2];
+        /* 0x32C */ f32 field_0x32C[2];
+        /* 0x334 */ s16 field_0x334;
+        /* 0x336 */ s16 field_0x336;
+        /* 0x338 */ s16 field_0x338;
+        /* 0x33A */ u8 field_0x33A[0x33C - 0x33A];
+        /* 0x33C */ LIGHT_INFLUENCE mLightInfluence[2];
+        /* 0x37C */ cXyz field_0x37C[2];
     };
 };
+
+STATIC_ASSERT(sizeof(daObjVds::Act_c) == 0x394);
 
 #endif /* D_A_OBJ_VDS_H */

--- a/src/d/actor/d_a_obj_Vds.cpp
+++ b/src/d/actor/d_a_obj_Vds.cpp
@@ -83,7 +83,8 @@ void daObjVds::Act_c::delete_point_light() {
 
 /* 00000954-00000968       .text Event_init__Q28daObjVds5Act_cFv */
 void daObjVds::Act_c::Event_init() {
-    /* Nonmatching */
+    field_0x334 = -1;
+    field_0x336 = 0;
 }
 
 /* 00000968-00000A28       .text Event_exe__Q28daObjVds5Act_cFv */


### PR DESCRIPTION
Matches `daObjVds::Act_c::Event_init` for GZLE01.

This also adds the currently known `Act_c` member layout needed for the event state fields used by the function. The rest of `d_a_obj_Vds` remains nonmatching.

Related to #371. This does not close it.

Checked locally on GZLE01:
- `python configure.py --map --version GZLE01`
- `ninja all_source progress build/GZLE01/report.json`
- `git diff --check`
- `build/tools/objdiff-cli diff -p . -u d_a_obj_Vds/d/actor/d_a_obj_Vds Event_init__Q28daObjVds5Act_cFv`
- `build/tools/objdiff-cli report generate -o build/GZLE01/report-pr-final.json`

Matching:
- `Event_init__Q28daObjVds5Act_cFv`: 20.00% -> 100.00%
- `d_a_obj_Vds` remains nonmatching
- Tested locally on GZLE01 only. CI will validate GZLP01, GZLJ01, and D44J01.
