### PR TITLE
Match daObjHtetu1_c::check_sw

### DIFF
--- a/include/d/actor/d_a_obj_htetu1.h
+++ b/include/d/actor/d_a_obj_htetu1.h
@@ -5,8 +5,6 @@
 
 class daObjHtetu1_c : public fopAc_ac_c {
 public:
-    // TODO: this function is marked as weak in the REL symbol map, but it does not get inlined for some reason?
-    // void check_sw() {}
     void check_sw();
 
     void solidHeapCB(fopAc_ac_c*);
@@ -21,8 +19,12 @@ public:
     bool _draw();
 
 public:
-    /* Place member variables here */
-};
+    /* 0x290 */ u8 field_0x290[0xC];
+    /* 0x29C */ int mSwitchNo;
+    /* 0x2A0 */ u8 field_0x2A0[0x88];
+};  // Size: 0x328
+
+STATIC_ASSERT(sizeof(daObjHtetu1_c) == 0x328);
 
 class daObjHtetu1Splash_c {
 public:

--- a/src/d/actor/d_a_obj_htetu1.cpp
+++ b/src/d/actor/d_a_obj_htetu1.cpp
@@ -33,7 +33,7 @@ bool daObjHtetu1_c::_delete() {
 
 /* 00000610-00000648       .text check_sw__13daObjHtetu1_cFv */
 void daObjHtetu1_c::check_sw() {
-    /* Nonmatching */
+    fopAcM_isSwitch(this, mSwitchNo);
 }
 
 /* 00000648-000006E4       .text init_mtx__13daObjHtetu1_cFv */


### PR DESCRIPTION
## Summary
- match `daObjHtetu1_c::check_sw()` to the GZLP01 target
- restore the actor's verified 0x328-byte layout and switch-number field

## Verification
- `ninja`
- `objdiff-cli diff --project . --unit d_a_obj_htetu1/d/actor/d_a_obj_htetu1 check_sw__13daObjHtetu1_cFv` (100%)

Closes #414