### PR TITLE
Match d_a_obj_htetu1

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1749,7 +1749,7 @@ config.libs = [
     ActorRel(Matching,    "d_a_obj_homen"),
     ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d_a_obj_homensmoke"),
     ActorRel(NonMatching, "d_a_obj_hsehi1"),
-    ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d_a_obj_htetu1"),
+    ActorRel(Matching,    "d_a_obj_htetu1"),
     ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d_a_obj_iceisland"),
     ActorRel(Matching,    "d_a_obj_jump"),
     ActorRel(NonMatching, "d_a_obj_kanoke"),

--- a/configure.py
+++ b/configure.py
@@ -1749,7 +1749,7 @@ config.libs = [
     ActorRel(Matching,    "d_a_obj_homen"),
     ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d_a_obj_homensmoke"),
     ActorRel(NonMatching, "d_a_obj_hsehi1"),
-    ActorRel(NonMatching, "d_a_obj_htetu1"),
+    ActorRel(Matching,    "d_a_obj_htetu1"),
     ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d_a_obj_iceisland"),
     ActorRel(Matching,    "d_a_obj_jump"),
     ActorRel(NonMatching, "d_a_obj_kanoke"),

--- a/configure.py
+++ b/configure.py
@@ -1749,7 +1749,7 @@ config.libs = [
     ActorRel(Matching,    "d_a_obj_homen"),
     ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d_a_obj_homensmoke"),
     ActorRel(NonMatching, "d_a_obj_hsehi1"),
-    ActorRel(Matching,    "d_a_obj_htetu1"),
+    ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d_a_obj_htetu1"),
     ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d_a_obj_iceisland"),
     ActorRel(Matching,    "d_a_obj_jump"),
     ActorRel(NonMatching, "d_a_obj_kanoke"),

--- a/include/d/actor/d_a_obj_htetu1.h
+++ b/include/d/actor/d_a_obj_htetu1.h
@@ -62,7 +62,7 @@ class daObjHtetu1_c : public fopAc_ac_c {
 public:
     inline BOOL check_sw();
 
-    static int solidHeapCB(fopAc_ac_c*);
+    static BOOL solidHeapCB(fopAc_ac_c*);
     BOOL create_heap();
     cPhs_State _create();
     bool _delete();

--- a/include/d/actor/d_a_obj_htetu1.h
+++ b/include/d/actor/d_a_obj_htetu1.h
@@ -1,41 +1,95 @@
 #ifndef D_A_OBJ_HTETU1_H
 #define D_A_OBJ_HTETU1_H
 
+#include "d/d_particle.h"
 #include "f_op/f_op_actor.h"
+
+class dBgW;
+
+class daObjHtetu1Splash_c {
+public:
+    bool chk_stop() { return mbIsActive == false; }
+
+    void delete_s() {
+        if (mSplashCb.getEmitter() != NULL) {
+            mSplashCb.remove();
+            mbIsActive = false;
+        }
+    }
+
+    s16 get_timer() { return mTimer; }
+
+    void play_particle() {
+        JPABaseEmitter* emitter = mSplashCb.getEmitter();
+        if (emitter != NULL) {
+            emitter->playCreateParticle();
+            mbIsActive = true;
+        }
+    }
+
+    void set_pos_y(f32 i_y) { mPos.y = i_y; }
+
+    void stop_particle() {
+        JPABaseEmitter* emitter = mSplashCb.getEmitter();
+        if (emitter != NULL) {
+            emitter->stopCreateParticle();
+            mbIsActive = false;
+        }
+    }
+
+    void sub_timer() { mTimer--; }
+
+    void timer_play_particle(s16 i_timer) {
+        JPABaseEmitter* emitter = mSplashCb.getEmitter();
+        if (emitter != NULL) {
+            emitter->playCreateParticle();
+            mbIsActive = true;
+            mTimer = i_timer;
+        }
+    }
+
+    void create_s(u16 i_particleID, cXyz* i_pos, csXyz* i_angle, dKy_tevstr_c* i_tevStr);
+
+public:
+    /* 0x00 */ dPa_followEcallBack mSplashCb;
+    /* 0x14 */ Vec mPos;
+    /* 0x20 */ S16Vec mAngle;
+    /* 0x26 */ s16 mTimer;
+    /* 0x28 */ u8 mbIsActive;
+}; // Size: 0x2C
 
 class daObjHtetu1_c : public fopAc_ac_c {
 public:
-    // TODO: this function is marked as weak in the REL symbol map, but it does not get inlined for some reason?
-    // void check_sw() {}
-    void check_sw();
+    inline BOOL check_sw();
 
-    void solidHeapCB(fopAc_ac_c*);
-    void create_heap();
+    static int solidHeapCB(fopAc_ac_c*);
+    BOOL create_heap();
     cPhs_State _create();
     bool _delete();
     void init_mtx();
     void unlock();
-    void get_water_h();
+    f32 get_water_h();
     void splash_manager();
     bool _execute();
     bool _draw();
 
 public:
-    /* Place member variables here */
-};
+    static const char M_arcname[7];
 
-class daObjHtetu1Splash_c {
-public:
-    void chk_stop() {}
-    void delete_s() {}
-    void get_timer() {}
-    void play_particle() {}
-    void set_pos_y(float) {}
-    void stop_particle() {}
-    void sub_timer() {}
-    void timer_play_particle(short) {}
-
-    void create_s(unsigned short, cXyz*, csXyz*, dKy_tevstr_c*);
-};
+    /* 0x290 */ J3DModel* mpModel;
+    /* 0x294 */ request_of_phase_process_class mPhs;
+    /* 0x29C */ u32 mSwitchNo;
+    /* 0x2A0 */ cXyz mPos;
+    /* 0x2AC */ cXyz mOffset;
+    /* 0x2B8 */ f32 mLowerY;
+    /* 0x2BC */ f32 mUnlockSpeed;
+    /* 0x2C0 */ u16 mUnlockTimer;
+    /* 0x2C2 */ u8 mUnlockState;
+    /* 0x2C4 */ s16 mEventIdx;
+    /* 0x2C6 */ u8 mEventState;
+    /* 0x2C8 */ s16 mQuakeTimer;
+    /* 0x2CC */ dBgW* mpBgw;
+    /* 0x2D0 */ daObjHtetu1Splash_c mSplash[2];
+}; // Size: 0x328
 
 #endif /* D_A_OBJ_HTETU1_H */

--- a/include/d/actor/d_a_obj_htetu1.h
+++ b/include/d/actor/d_a_obj_htetu1.h
@@ -8,11 +8,15 @@ class dBgW;
 
 class daObjHtetu1Splash_c {
 public:
+    JPABaseEmitter* get_emitter() { return DEMO_SELECT(mpEmitter, mSplashCb.getEmitter()); }
     bool chk_stop() { return mbIsActive == false; }
 
     void delete_s() {
-        if (mSplashCb.getEmitter() != NULL) {
+        if (get_emitter() != NULL) {
             mSplashCb.remove();
+#if VERSION == VERSION_DEMO
+            mpEmitter = NULL;
+#endif
             mbIsActive = false;
         }
     }
@@ -20,7 +24,7 @@ public:
     s16 get_timer() { return mTimer; }
 
     void play_particle() {
-        JPABaseEmitter* emitter = mSplashCb.getEmitter();
+        JPABaseEmitter* emitter = get_emitter();
         if (emitter != NULL) {
             emitter->playCreateParticle();
             mbIsActive = true;
@@ -30,7 +34,7 @@ public:
     void set_pos_y(f32 i_y) { mPos.y = i_y; }
 
     void stop_particle() {
-        JPABaseEmitter* emitter = mSplashCb.getEmitter();
+        JPABaseEmitter* emitter = get_emitter();
         if (emitter != NULL) {
             emitter->stopCreateParticle();
             mbIsActive = false;
@@ -40,7 +44,7 @@ public:
     void sub_timer() { mTimer--; }
 
     void timer_play_particle(s16 i_timer) {
-        JPABaseEmitter* emitter = mSplashCb.getEmitter();
+        JPABaseEmitter* emitter = get_emitter();
         if (emitter != NULL) {
             emitter->playCreateParticle();
             mbIsActive = true;
@@ -51,12 +55,15 @@ public:
     void create_s(u16 i_particleID, cXyz* i_pos, csXyz* i_angle, dKy_tevstr_c* i_tevStr);
 
 public:
-    /* 0x00 */ dPa_followEcallBack mSplashCb;
-    /* 0x14 */ Vec mPos;
-    /* 0x20 */ S16Vec mAngle;
-    /* 0x26 */ s16 mTimer;
-    /* 0x28 */ u8 mbIsActive;
-}; // Size: 0x2C
+#if VERSION == VERSION_DEMO
+    /* 0x00 */ JPABaseEmitter* mpEmitter;
+#endif
+    /* 0x00 (retail) / 0x04 (demo) */ dPa_followEcallBack mSplashCb;
+    /* 0x14 (retail) / 0x18 (demo) */ Vec mPos;
+    /* 0x20 (retail) / 0x24 (demo) */ S16Vec mAngle;
+    /* 0x26 (retail) / 0x2A (demo) */ s16 mTimer;
+    /* 0x28 (retail) / 0x2C (demo) */ u8 mbIsActive;
+}; // Size: 0x2C, demo size: 0x30
 
 class daObjHtetu1_c : public fopAc_ac_c {
 public:
@@ -90,6 +97,6 @@ public:
     /* 0x2C8 */ s16 mQuakeTimer;
     /* 0x2CC */ dBgW* mpBgw;
     /* 0x2D0 */ daObjHtetu1Splash_c mSplash[2];
-}; // Size: 0x328
+}; // Size: 0x328, demo size: 0x330
 
 #endif /* D_A_OBJ_HTETU1_H */

--- a/src/d/actor/d_a_obj_htetu1.cpp
+++ b/src/d/actor/d_a_obj_htetu1.cpp
@@ -24,12 +24,19 @@ void daObjHtetu1Splash_c::create_s(u16 i_particleID, cXyz* i_pos, csXyz* i_angle
     mAngle.x = i_angle->x;
     mAngle.y = i_angle->y;
     mAngle.z = i_angle->z;
-    dComIfGp_particle_set(i_particleID, reinterpret_cast<cXyz*>(&mPos), reinterpret_cast<csXyz*>(&mAngle), NULL, 0xFF,
-                          &mSplashCb);
+#if VERSION == VERSION_DEMO
+    mpEmitter =
+#endif
+        dComIfGp_particle_set(i_particleID, reinterpret_cast<cXyz*>(&mPos), reinterpret_cast<csXyz*>(&mAngle), NULL,
+                              0xFF, &mSplashCb);
 
-    if (mSplashCb.getEmitter() != NULL) {
-        mSplashCb.getEmitter()->setGlobalPrmColor(i_tevStr->mColorC0.r, i_tevStr->mColorC0.g, i_tevStr->mColorC0.b);
+#if VERSION == VERSION_DEMO
+    mpEmitter->setGlobalPrmColor(i_tevStr->mColorC0.r, i_tevStr->mColorC0.g, i_tevStr->mColorC0.b);
+#else
+    if (get_emitter() != NULL) {
+        get_emitter()->setGlobalPrmColor(i_tevStr->mColorC0.r, i_tevStr->mColorC0.g, i_tevStr->mColorC0.b);
     }
+#endif
 
     stop_particle();
     mbIsActive = false;
@@ -45,7 +52,7 @@ BOOL daObjHtetu1_c::solidHeapCB(fopAc_ac_c* i_this) {
 BOOL daObjHtetu1_c::create_heap() {
     BOOL ret = TRUE;
     J3DModelData* mdl_data = static_cast<J3DModelData*>(dComIfG_getObjectRes(M_arcname, dRes_INDEX_HTETU1_BDL_HTETU1_e));
-    JUT_ASSERT(281, mdl_data != NULL);
+    JUT_ASSERT(DEMO_SELECT(279, 281), mdl_data != NULL);
 
     if (mdl_data == NULL) {
         ret = FALSE;
@@ -104,12 +111,14 @@ bool daObjHtetu1_c::_delete() {
         mSplash[i].delete_s();
     }
 
-    if (heap != NULL && mpBgw != NULL && mpBgw->ChkUsed()) {
+    if (DEMO_SELECT(mpBgw != NULL, heap != NULL && mpBgw != NULL) && mpBgw->ChkUsed()) {
         dComIfG_Bgsp()->Release(mpBgw);
+#if VERSION > VERSION_DEMO
         mpBgw = NULL;
+#endif
     }
 
-    dComIfG_resDelete(&mPhs, M_arcname);
+    dComIfG_resDeleteDemo(&mPhs, M_arcname);
     return true;
 }
 
@@ -131,8 +140,12 @@ void daObjHtetu1_c::init_mtx() {
 void daObjHtetu1_c::unlock() {
     cXyz offset = cXyz::BaseY;
     mPos -= mOffset;
+#if VERSION == VERSION_DEMO
+    offset *= std::fabsf((s16)(mUnlockSpeed * cM_ssin(mUnlockTimer * 0x859)));
+#else
     f32 speed = *reinterpret_cast<volatile f32*>(&mUnlockSpeed);
     offset *= std::fabsf((s16)(speed * cM_ssin(mUnlockTimer * 0x859)));
+#endif
     mPos += offset;
     mOffset = offset;
     cLib_addCalc(&mUnlockSpeed, 0.0f, 0.13f, 50.0f, 1.0f);
@@ -186,7 +199,7 @@ bool daObjHtetu1_c::_execute() {
     int i;
     switch (mEventState) {
     case 0:
-        if (check_sw() != FALSE) {
+        if (check_sw()) {
             if (!eventInfo.checkCommandDemoAccrpt()) {
                 fopAcM_orderOtherEventId(this, mEventIdx, 0xFF, 0xFFFF, 0, 1);
                 eventInfo.onCondition(dEvtCnd_UNK2_e);
@@ -239,13 +252,8 @@ bool daObjHtetu1_c::_execute() {
         mPos.y -= 5.0f;
         mDoAud_seStart(JA_SE_OBJ_ST_KOUSHI_MOVE, &current.pos, 0, dComIfGp_getReverb(fopAcM_GetRoomNo(this)));
         if (mPos.y <= mLowerY) {
-            i = 0;
-            int inactive = i;
-            for (; i < 2; i++) {
-                if (mSplash[i].mSplashCb.getEmitter() != NULL) {
-                    mSplash[i].mSplashCb.remove();
-                    mSplash[i].mbIsActive = inactive;
-                }
+            for (i = 0; i < 2; i++) {
+                mSplash[i].delete_s();
             }
             mPos.y = mLowerY;
             mUnlockState = 0;
@@ -266,7 +274,7 @@ bool daObjHtetu1_c::_execute() {
         mQuakeTimer--;
     }
 
-    if (heap != NULL && mpBgw != NULL && mpBgw->ChkUsed()) {
+    if (DEMO_SELECT(mpBgw != NULL, heap != NULL && mpBgw != NULL) && mpBgw->ChkUsed()) {
         mpBgw->Move();
     }
 

--- a/src/d/actor/d_a_obj_htetu1.cpp
+++ b/src/d/actor/d_a_obj_htetu1.cpp
@@ -5,65 +5,280 @@
 
 #include "d/dolzel_rel.h" // IWYU pragma: keep
 #include "d/actor/d_a_obj_htetu1.h"
+#include "d/d_bg_s_func.h"
+#include "d/d_bg_s_wtr_chk.h"
+#include "d/d_bg_w.h"
+#include "d/d_com_inf_game.h"
+#include "res/Object/Htetu1.h"
+
+static const u16 l_daObjHtetu1_splash_id_table[] = {
+    dPa_name::ID_AK_SN_SIRENWATERGATE00,
+    dPa_name::ID_AK_SN_SIRENWATERGATE01,
+};
+
+const char daObjHtetu1_c::M_arcname[] = "Htetu1";
 
 /* 00000078-00000178       .text create_s__19daObjHtetu1Splash_cFUsP4cXyzP5csXyzP12dKy_tevstr_c */
-void daObjHtetu1Splash_c::create_s(unsigned short, cXyz*, csXyz*, dKy_tevstr_c*) {
-    /* Nonmatching */
+void daObjHtetu1Splash_c::create_s(u16 i_particleID, cXyz* i_pos, csXyz* i_angle, dKy_tevstr_c* i_tevStr) {
+    mPos = *i_pos;
+    mAngle.x = i_angle->x;
+    mAngle.y = i_angle->y;
+    mAngle.z = i_angle->z;
+    dComIfGp_particle_set(i_particleID, reinterpret_cast<cXyz*>(&mPos), reinterpret_cast<csXyz*>(&mAngle), NULL, 0xFF,
+                          &mSplashCb);
+
+    if (mSplashCb.getEmitter() != NULL) {
+        mSplashCb.getEmitter()->setGlobalPrmColor(i_tevStr->mColorC0.r, i_tevStr->mColorC0.g, i_tevStr->mColorC0.b);
+    }
+
+    stop_particle();
+    mbIsActive = false;
+    mTimer = -2;
 }
 
 /* 00000178-00000198       .text solidHeapCB__13daObjHtetu1_cFP10fopAc_ac_c */
-void daObjHtetu1_c::solidHeapCB(fopAc_ac_c*) {
-    /* Nonmatching */
+int daObjHtetu1_c::solidHeapCB(fopAc_ac_c* i_this) {
+    return static_cast<daObjHtetu1_c*>(i_this)->create_heap();
 }
 
 /* 00000198-00000298       .text create_heap__13daObjHtetu1_cFv */
-void daObjHtetu1_c::create_heap() {
-    /* Nonmatching */
+BOOL daObjHtetu1_c::create_heap() {
+    BOOL ret = TRUE;
+    J3DModelData* mdl_data = static_cast<J3DModelData*>(dComIfG_getObjectRes(M_arcname, dRes_INDEX_HTETU1_BDL_HTETU1_e));
+    JUT_ASSERT(281, mdl_data != NULL);
+
+    if (mdl_data == NULL) {
+        ret = FALSE;
+    } else {
+        mpModel = mDoExt_J3DModel__create(mdl_data, 0, 0x11020203);
+        mpBgw = dBgW_NewSet(static_cast<cBgD_t*>(dComIfG_getObjectRes(M_arcname, dRes_INDEX_HTETU1_DZB_HTETU1_e)), 1,
+                            &mpModel->getBaseTRMtx());
+        if (mpBgw == NULL) {
+            ret = FALSE;
+        }
+    }
+
+    return ret;
 }
 
 /* 00000298-00000460       .text _create__13daObjHtetu1_cFv */
 cPhs_State daObjHtetu1_c::_create() {
-    /* Nonmatching */
+    fopAcM_ct(this, daObjHtetu1_c);
+    cPhs_State ret = dComIfG_resLoad(&mPhs, M_arcname);
+    if (ret == cPhs_COMPLEATE_e) {
+        ret = cPhs_ERROR_e;
+        if (fopAcM_entrySolidHeap(this, solidHeapCB, 0xAE0) != false) {
+            fopAcM_SetMtx(this, mpModel->getBaseTRMtx());
+            mSwitchNo = fpcM_GetParam(this) & 0xFF;
+            mLowerY = current.pos.y - 2300.0f;
+            if (check_sw() != FALSE) {
+                current.pos.y = mLowerY;
+                mEventState = 2;
+            }
+
+            mQuakeTimer = -1;
+            init_mtx();
+            dKy_getEnvlight().settingTevStruct(TEV_TYPE_BG1, &current.pos, &tevStr);
+            for (int i = 0; i < 2; i++) {
+                mSplash[i].create_s(l_daObjHtetu1_splash_id_table[i], &current.pos, &current.angle, &tevStr);
+            }
+
+            fopAcM_setCullSizeBox(this, -950.0f, -1000.0f, -100.0f, 950.0f, 1300.0f, 100.0f);
+            dComIfG_Bgsp()->Regist(mpBgw, this);
+            mEventIdx = dComIfGp_evmng_getEventIdx("htetu1_open");
+            ret = cPhs_COMPLEATE_e;
+        }
+    }
+
+    return ret;
 }
 
 /* 00000508-00000610       .text _delete__13daObjHtetu1_cFv */
 bool daObjHtetu1_c::_delete() {
-    /* Nonmatching */
+    if (mQuakeTimer > 0) {
+        dComIfGp_getVibration().StopQuake(-1);
+        mQuakeTimer = -1;
+    }
+
+    for (int i = 0; i < 2; i++) {
+        mSplash[i].delete_s();
+    }
+
+    if (heap != NULL && mpBgw != NULL && mpBgw->ChkUsed()) {
+        dComIfG_Bgsp()->Release(mpBgw);
+        mpBgw = NULL;
+    }
+
+    dComIfG_resDelete(&mPhs, M_arcname);
+    return true;
 }
 
 /* 00000610-00000648       .text check_sw__13daObjHtetu1_cFv */
-void daObjHtetu1_c::check_sw() {
-    /* Nonmatching */
+inline BOOL daObjHtetu1_c::check_sw() {
+    return fopAcM_isSwitch(this, mSwitchNo);
 }
 
 /* 00000648-000006E4       .text init_mtx__13daObjHtetu1_cFv */
 void daObjHtetu1_c::init_mtx() {
-    /* Nonmatching */
+    mpModel->setBaseScale(scale);
+    mDoMtx_stack_c::transS(current.pos);
+    mDoMtx_stack_c::ZXYrotM(shape_angle);
+    mpModel->setBaseTRMtx(mDoMtx_stack_c::get());
+    mpModel->calc();
 }
 
 /* 000006E4-000007F8       .text unlock__13daObjHtetu1_cFv */
 void daObjHtetu1_c::unlock() {
-    /* Nonmatching */
+    cXyz offset = cXyz::BaseY;
+    mPos -= mOffset;
+    f32 speed = *reinterpret_cast<volatile f32*>(&mUnlockSpeed);
+    offset *= std::fabsf((s16)(speed * cM_ssin(mUnlockTimer * 0x859)));
+    mPos += offset;
+    mOffset = offset;
+    cLib_addCalc(&mUnlockSpeed, 0.0f, 0.13f, 50.0f, 1.0f);
 }
 
 /* 000007F8-0000098C       .text get_water_h__13daObjHtetu1_cFv */
-void daObjHtetu1_c::get_water_h() {
-    /* Nonmatching */
+f32 daObjHtetu1_c::get_water_h() {
+    dBgS_WtrChk water_chk;
+    cXyz chk_pos = home.pos;
+    f32 ret = current.pos.y;
+
+    cXyz off_vec;
+    mDoMtx_stack_c::YrotS(current.angle.y);
+    mDoMtx_stack_c::multVec(&cXyz::BaseZ, &off_vec);
+    off_vec *= 400.0f;
+    chk_pos += off_vec;
+    if (dBgS_SplGrpChk_In_ObjGnd(chk_pos, &water_chk, 1.0f) != false) {
+        ret = water_chk.GetHeight();
+    }
+    return ret;
 }
 
 /* 00000AB0-00000BCC       .text splash_manager__13daObjHtetu1_cFv */
 void daObjHtetu1_c::splash_manager() {
-    /* Nonmatching */
+    f32 water_h = get_water_h();
+    for (int i = 0; i < 2; i++) {
+        mSplash[i].set_pos_y(water_h);
+        s16 timer = mSplash[i].get_timer();
+        if (timer == 0) {
+            if (!mSplash[i].chk_stop()) {
+                mSplash[i].stop_particle();
+            }
+        } else if (timer > 0 || timer == -1) {
+            if (current.pos.y + 1400.0f > water_h) {
+                if (mSplash[i].chk_stop()) {
+                    mSplash[i].play_particle();
+                }
+            } else if (!mSplash[i].chk_stop()) {
+                mSplash[i].stop_particle();
+            }
+
+            if (timer > 0) {
+                mSplash[i].sub_timer();
+            }
+        }
+    }
 }
 
 /* 00000BCC-0000101C       .text _execute__13daObjHtetu1_cFv */
 bool daObjHtetu1_c::_execute() {
-    /* Nonmatching */
+    int i;
+    switch (mEventState) {
+    case 0:
+        if (check_sw() != FALSE) {
+            if (!eventInfo.checkCommandDemoAccrpt()) {
+                fopAcM_orderOtherEventId(this, mEventIdx, 0xFF, 0xFFFF, 0, 1);
+                eventInfo.onCondition(dEvtCnd_UNK2_e);
+            } else {
+                f32 speed = 50.0f;
+                mUnlockSpeed = speed;
+                mUnlockTimer = 70;
+                mOffset = cXyz::BaseY * speed;
+                mDoAud_seStart(JA_SE_READ_RIDDLE_1);
+                mUnlockState = 1;
+                mEventState = 1;
+                dComIfGp_getVibration().StartShock(5, -0x21, cXyz(0.0f, 1.0f, 0.0f));
+                for (i = 0; i < 2; i++) {
+                    mSplash[i].timer_play_particle(30);
+                }
+            }
+        }
+        break;
+    case 1:
+        if (dComIfGp_evmng_endCheck(mEventIdx)) {
+            dComIfGp_event_reset();
+            mEventState = 2;
+        }
+        break;
+    case 2:
+        break;
+    default:
+        break;
+    }
+
+    mPos = current.pos;
+    switch (mUnlockState) {
+    case 0:
+        break;
+    case 1:
+        unlock();
+        if (mUnlockTimer != 0) {
+            mUnlockTimer--;
+            mDoAud_seStart(JA_SE_OBJ_ST_KOUSHI_MOVE, &current.pos, 0, dComIfGp_getReverb(fopAcM_GetRoomNo(this)));
+        } else {
+            dComIfGp_getVibration().StartQuake(6, 3, cXyz(0.0f, 1.0f, 0.0f));
+            mUnlockState = 2;
+            mQuakeTimer = 200;
+            for (i = 0; i < 2; i++) {
+                mSplash[i].timer_play_particle(-1);
+            }
+        }
+        break;
+    case 2:
+        mPos.y -= 5.0f;
+        mDoAud_seStart(JA_SE_OBJ_ST_KOUSHI_MOVE, &current.pos, 0, dComIfGp_getReverb(fopAcM_GetRoomNo(this)));
+        if (mPos.y <= mLowerY) {
+            i = 0;
+            int inactive = i;
+            for (; i < 2; i++) {
+                if (mSplash[i].mSplashCb.getEmitter() != NULL) {
+                    mSplash[i].mSplashCb.remove();
+                    mSplash[i].mbIsActive = inactive;
+                }
+            }
+            mPos.y = mLowerY;
+            mUnlockState = 0;
+        }
+        break;
+    default:
+        break;
+    }
+
+    current.pos = mPos;
+    init_mtx();
+    splash_manager();
+
+    if (mQuakeTimer == 0) {
+        dComIfGp_getVibration().StopQuake(-1);
+        mQuakeTimer = -1;
+    } else if (mQuakeTimer > 0) {
+        mQuakeTimer--;
+    }
+
+    if (heap != NULL && mpBgw != NULL && mpBgw->ChkUsed()) {
+        mpBgw->Move();
+    }
+
+    return true;
 }
 
 /* 0000101C-0000107C       .text _draw__13daObjHtetu1_cFv */
 bool daObjHtetu1_c::_draw() {
-    /* Nonmatching */
+    dKy_getEnvlight().settingTevStruct(TEV_TYPE_BG0, &current.pos, &tevStr);
+    dKy_getEnvlight().setLightTevColorType(mpModel, &tevStr);
+    mDoExt_modelUpdateDL(mpModel);
+    return true;
 }
 
 namespace {

--- a/src/d/actor/d_a_obj_htetu1.cpp
+++ b/src/d/actor/d_a_obj_htetu1.cpp
@@ -37,7 +37,7 @@ void daObjHtetu1Splash_c::create_s(u16 i_particleID, cXyz* i_pos, csXyz* i_angle
 }
 
 /* 00000178-00000198       .text solidHeapCB__13daObjHtetu1_cFP10fopAc_ac_c */
-int daObjHtetu1_c::solidHeapCB(fopAc_ac_c* i_this) {
+BOOL daObjHtetu1_c::solidHeapCB(fopAc_ac_c* i_this) {
     return static_cast<daObjHtetu1_c*>(i_this)->create_heap();
 }
 


### PR DESCRIPTION
Fully decompiles `d_a_obj_htetu1` (Tower of the Gods yellow gate) — **40/40 functions, 100% code + data**, rel SHA byte-exact across all four builds.

- `ActorRel(Matching)` for D44J01, GZLJ01, GZLE01, and GZLP01.
- D44J01 uses the original demo particle layout: a separate `JPABaseEmitter*` before `dPa_followEcallBack`, making each splash object `0x30` bytes instead of retail's `0x2C`.
- Demo-specific resource deletion, heap guards, emitter cleanup, and unlock scheduling are selected with existing version helpers/guards.
- Verified locally against D44J01, GZLJ01, and GZLP01: 40/40, 100% code/data, exact REL SHA. GZLE01 is covered by CI.

Supersedes #1119.