### PR TITLE
d_a_obj_kanoke 100% matching

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1752,7 +1752,7 @@ config.libs = [
     ActorRel(NonMatching, "d_a_obj_htetu1"),
     ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d_a_obj_iceisland"),
     ActorRel(Matching,    "d_a_obj_jump"),
-    ActorRel(NonMatching, "d_a_obj_kanoke"),
+    ActorRel(Matching,    "d_a_obj_kanoke"),
     ActorRel(Matching,    "d_a_obj_ladder"),
     ActorRel(NonMatching, "d_a_obj_light"),
     ActorRel(Matching,    "d_a_obj_mkie"),

--- a/include/d/actor/d_a_obj_kanoke.h
+++ b/include/d/actor/d_a_obj_kanoke.h
@@ -1,18 +1,34 @@
 #ifndef D_A_OBJ_KANOKE_H
 #define D_A_OBJ_KANOKE_H
 
+#include "d/d_cc_d.h"
+#include "d/d_particle.h"
 #include "f_op/f_op_actor.h"
+
+class dBgW;
+class J3DModel;
 
 class daObjKanoke_c : public fopAc_ac_c {
 public:
     enum Prm_e {
-        
+        PRM_TYPE_W = 1,
+        PRM_TYPE_S = 0,
+        PRM_SEARCH_W = 5,
+        PRM_SEARCH_S = 1,
+        PRM_YURE_W = 1,
+        PRM_YURE_S = 6,
+        PRM_SWNO_W = 8,
+        PRM_SWNO_S = 8,
+        PRM_SWNO2_W = 8,
+        PRM_SWNO2_S = 16,
     };
-    
+
+    typedef void (daObjKanoke_c::*MoveProc)();
+
     daObjKanoke_c();
     cPhs_State _create();
-    void createHeap();
-    void createInit();
+    BOOL createHeap();
+    cPhs_State createInit();
     BOOL _delete();
     BOOL _draw();
     BOOL _execute();
@@ -24,17 +40,48 @@ public:
     void executeOpenTate();
     void executeEffectTate();
     void executeWait();
-    void getPrmType();
-    void getPrmSearch();
-    void getPrmYure();
-    void getPrmSwNo();
-    void getPrmSwNo2();
+    u8 getPrmType();
+    u8 getPrmSearch();
+    u8 getPrmYure();
+    u8 getPrmSwNo();
+    u8 getPrmSwNo2();
     void setMtx();
     void setMtxHontai();
     void setMtxHuta(cXyz*);
 
 public:
-    /* Place member variables here */
+    /* 0x290 */ request_of_phase_process_class mPhs;
+    /* 0x298 */ J3DModel* mpBodyModel;
+    /* 0x29C */ J3DModel* mpLidModel;
+    /* 0x2A0 */ dBgW* mpBodyBgW;
+    /* 0x2A4 */ dBgW* mpLidBgW;
+    /* 0x2A8 */ Mtx mBodyMtx;
+    /* 0x2D8 */ Mtx mLidMtx;
+    /* 0x308 */ dCcD_Stts mStts;
+    /* 0x344 */ dCcD_Cps mBodyCps;
+    /* 0x47C */ dCcD_Cps mLidCps[3];
+    /* 0x824 */ JPABaseEmitter* mpEmitters[2];
+    /* 0x82C */ dPa_smokeEcallBack mSmokeCallback;
+    /* 0x84C */ cXyz mEffectPos;
+    /* 0x858 */ csXyz mEffectAngle;
+    /* 0x860 */ cXyz mPivotOffset;
+    /* 0x86C */ cXyz mLidOffset;
+    /* 0x878 */ f32 mEffectScale;
+    /* 0x87C */ s16 mLidRotX;
+    /* 0x87E */ s16 mBodyRotY;
+    /* 0x880 */ s16 mLidRotZ;
+    /* 0x882 */ s16 mRotStep;
+    /* 0x884 */ s16 mTimer;
+    /* 0x886 */ s16 mMoveSpeed;
+    /* 0x888 */ s16 mLightTimer;
+    /* 0x88A */ u8 mType;
+    /* 0x88B */ u8 mState;
+    /* 0x88C */ u8 mSearchRange;
+    /* 0x88D */ u8 mSwitchNo;
+    /* 0x88E */ u8 mSwitchNo2;
+    /* 0x88F */ u8 mFlags;
 };
+
+STATIC_ASSERT(sizeof(daObjKanoke_c) == 0x890);
 
 #endif /* D_A_OBJ_KANOKE_H */

--- a/src/d/actor/d_a_obj_kanoke.cpp
+++ b/src/d/actor/d_a_obj_kanoke.cpp
@@ -260,7 +260,7 @@ BOOL daObjKanoke_c::_delete() {
         dComIfG_Bgsp()->Release(mpLidBgW);
     }
     for (int i = 0; i < 2; i++) {
-        // The demo build retains an empty emitter loop.
+        // Preserve the empty counted loop emitted by the D44J01 target.
     }
 #endif
     mSmokeCallback.remove();

--- a/src/d/actor/d_a_obj_kanoke.cpp
+++ b/src/d/actor/d_a_obj_kanoke.cpp
@@ -5,7 +5,15 @@
 
 #include "d/dolzel_rel.h" // IWYU pragma: keep
 #include "d/actor/d_a_obj_kanoke.h"
-#include "d/d_cc_d.h"
+#include "assets/GZLE01/res/Object/Mkanoke.h"
+#include "d/d_a_obj.h"
+#include "d/d_bg_s.h"
+#include "d/d_bg_w.h"
+#include "d/d_com_inf_game.h"
+#include "d/d_particle_name.h"
+#include "m_Do/m_Do_ext.h"
+#include "m_Do/m_Do_audio.h"
+#include "m_Do/m_Do_mtx.h"
 
 static dCcD_SrcCps l_cps_src_body = {
     // dCcD_SrcGObjInf
@@ -68,125 +76,511 @@ static dCcD_SrcCps l_cps_src_huta = {
     }},
 };
 
+static cXyz daObjKanoke_Yoko_pfs = cXyz(100.0f, 0.0f, 0.0f);
+static cXyz daObjKanoke_Tate_pfs[][2] = {
+    {cXyz(50.0f, 0.0f, -175.0f), cXyz(50.0f, 0.0f, 175.0f)},
+    {cXyz(0.0f, 0.0f, -175.0f), cXyz(0.0f, 0.0f, 175.0f)},
+    {cXyz(-50.0f, 0.0f, -175.0f), cXyz(-50.0f, 0.0f, 175.0f)},
+};
+
+static daObjKanoke_c::MoveProc moveProc[] = {
+    &daObjKanoke_c::executeNormal,
+    &daObjKanoke_c::executeYureYoko,
+    &daObjKanoke_c::executeOpenYoko,
+    &daObjKanoke_c::executeEffectYoko,
+    &daObjKanoke_c::executeYureTate,
+    &daObjKanoke_c::executeOpenTate,
+    &daObjKanoke_c::executeEffectTate,
+    &daObjKanoke_c::executeWait,
+};
 
 /* 000000EC-000002F4       .text __ct__13daObjKanoke_cFv */
 daObjKanoke_c::daObjKanoke_c() {
-    /* Nonmatching */
+    mType = getPrmType();
+    mSearchRange = getPrmSearch();
+    mSwitchNo = getPrmSwNo();
+    mSwitchNo2 = getPrmSwNo2();
+
+    if (mType == 0) {
+        mLidOffset.set(0.0f, 0.0f, 0.0f);
+    } else {
+        current.pos.y = home.pos.y + 200.0f;
+        shape_angle.x = 0x4000;
+        mLidOffset.set(0.0f, 35.0f, 200.0f);
+    }
+    mPivotOffset.set(0.0f, 75.0f, 0.0f);
+    mLidRotX = 0;
+    mBodyRotY = 0;
+    mLidRotZ = 0;
+    mRotStep = 0;
+    for (int i = 0; i < 2; i++) {
+        mpEmitters[i] = NULL;
+    }
+    mSmokeCallback.setRateOff(0);
+    mState = 0;
+    mFlags = 0;
+    mLightTimer = 0;
+    setMtxHontai();
+    mDoMtx_copy(mDoMtx_stack_c::get(), mBodyMtx);
+    setMtxHuta(&current.pos);
+    mDoMtx_copy(mDoMtx_stack_c::get(), mLidMtx);
 }
 
 /* 00000644-00000664       .text CheckCreateHeap__FP10fopAc_ac_c */
-static BOOL CheckCreateHeap(fopAc_ac_c*) {
-    /* Nonmatching */
+static BOOL CheckCreateHeap(fopAc_ac_c* i_actor) {
+    return ((daObjKanoke_c*)i_actor)->createHeap();
 }
 
 /* 00000664-00000700       .text _create__13daObjKanoke_cFv */
 cPhs_State daObjKanoke_c::_create() {
-    /* Nonmatching */
+    fopAcM_ct(this, daObjKanoke_c);
+
+    cPhs_State phase_state = dComIfG_resLoad(&mPhs, "Mkanoke");
+    if (phase_state == cPhs_COMPLEATE_e) {
+        if (fopAcM_entrySolidHeap(this, CheckCreateHeap, 0x2400)) {
+            phase_state = createInit();
+        } else {
+            mpLidBgW = NULL;
+            mpBodyBgW = NULL;
+            phase_state = cPhs_ERROR_e;
+        }
+    }
+    return phase_state;
 }
 
 /* 00000700-000008BC       .text createHeap__13daObjKanoke_cFv */
-void daObjKanoke_c::createHeap() {
-    /* Nonmatching */
+BOOL daObjKanoke_c::createHeap() {
+    J3DModelData* modelData = (J3DModelData*)dComIfG_getObjectRes(
+        "Mkanoke", dRes_INDEX_MKANOKE_BDL_MOKE1_e);
+    if (modelData == NULL) {
+        return FALSE;
+    }
+    mpBodyModel = mDoExt_J3DModel__create(modelData, 0, 0x11020203);
+    if (mpBodyModel == NULL) {
+        return FALSE;
+    }
+
+    mpBodyBgW = new dBgW();
+    if (mpBodyBgW == NULL) {
+        return FALSE;
+    }
+    cBgD_t* bodyDzb = (cBgD_t*)dComIfG_getObjectRes(
+        "Mkanoke", dRes_INDEX_MKANOKE_DZB_MOKE1_e);
+    if (mpBodyBgW->Set(bodyDzb, dBgW::MOVE_BG_e, &mBodyMtx) == true) {
+        return FALSE;
+    }
+
+    modelData = (J3DModelData*)dComIfG_getObjectRes(
+        "Mkanoke", dRes_INDEX_MKANOKE_BDL_MOKE2_e);
+    if (modelData == NULL) {
+        return FALSE;
+    }
+    mpLidModel = mDoExt_J3DModel__create(modelData, 0, 0x11020203);
+    if (mpLidModel == NULL) {
+        return FALSE;
+    }
+
+    mpLidBgW = new dBgW();
+    if (mpLidBgW == NULL) {
+        return FALSE;
+    }
+    cBgD_t* lidDzb = (cBgD_t*)dComIfG_getObjectRes(
+        "Mkanoke", dRes_INDEX_MKANOKE_DZB_MOKE2_e);
+    BOOL result = mpLidBgW->Set(lidDzb, dBgW::MOVE_BG_e, &mLidMtx);
+    if (result == TRUE) {
+        return FALSE;
+    }
+    return TRUE;
 }
 
 /* 000008BC-00000B28       .text createInit__13daObjKanoke_cFv */
-void daObjKanoke_c::createInit() {
-    /* Nonmatching */
+cPhs_State daObjKanoke_c::createInit() {
+    if (dComIfG_Bgsp()->Regist(mpBodyBgW, this)) {
+        return cPhs_ERROR_e;
+    }
+
+    if (mSwitchNo != 0xFF) {
+        if (dComIfGs_isSwitch(mSwitchNo, fopAcM_GetHomeRoomNo(this))) {
+            mState = 7;
+            if (mType == 0) {
+                if (dComIfG_Bgsp()->Regist(mpLidBgW, this)) {
+                    return cPhs_ERROR_e;
+                }
+                mPivotOffset.set(148.0f, 75.0f, 0.0f);
+                mLidOffset.set(-48.0f, 0.0f, 0.0f);
+                mLidRotZ = -0x15E0;
+            } else {
+                mFlags |= 2;
+            }
+        } else if (dComIfG_Bgsp()->Regist(mpLidBgW, this)) {
+            return cPhs_ERROR_e;
+        }
+    } else if (dComIfG_Bgsp()->Regist(mpLidBgW, this)) {
+        return cPhs_ERROR_e;
+    }
+
+    mStts.Init(0xFF, 0xFF, this);
+    mBodyCps.Set(l_cps_src_body);
+    mBodyCps.SetStts(&mStts);
+    mBodyCps.SetStartEnd(current.pos, current.pos);
+    for (int i = 0; i < 3; i++) {
+        mLidCps[i].Set(l_cps_src_huta);
+        mLidCps[i].SetStts(&mStts);
+        mLidCps[i].SetStartEnd(current.pos, current.pos);
+    }
+
+    fopAcM_SetMtx(this, mpBodyModel->getBaseTRMtx());
+    setMtx();
+    if (mType == 0) {
+        fopAcM_setCullSizeBox(this, -110.0f, 0.0f, -210.0f, 310.0f, 120.0f, 210.0f);
+    } else {
+        fopAcM_setCullSizeBox(this, -110.0f, 0.0f, -210.0f, 110.0f, 520.0f, 210.0f);
+    }
+    return cPhs_COMPLEATE_e;
 }
 
 /* 00000B28-00000C0C       .text _delete__13daObjKanoke_cFv */
 BOOL daObjKanoke_c::_delete() {
-    /* Nonmatching */
+    if (heap != NULL) {
+        if (mpBodyBgW != NULL && mpBodyBgW->ChkUsed()) {
+            dComIfG_Bgsp()->Release(mpBodyBgW);
+        }
+        if (mpLidBgW != NULL && mpLidBgW->ChkUsed()) {
+            dComIfG_Bgsp()->Release(mpLidBgW);
+        }
+    }
+    mSmokeCallback.remove();
+    dComIfG_resDelete(&mPhs, "Mkanoke");
+    return TRUE;
 }
 
 /* 00000C0C-00000CE0       .text _draw__13daObjKanoke_cFv */
 BOOL daObjKanoke_c::_draw() {
-    /* Nonmatching */
+    g_env_light.settingTevStruct(TEV_TYPE_BG0, &current.pos, &tevStr);
+    g_env_light.setLightTevColorType(mpBodyModel, &tevStr);
+    g_env_light.setLightTevColorType(mpLidModel, &tevStr);
+    dComIfGd_setListBG();
+    if (!(mFlags & 1)) {
+        mDoExt_modelUpdateDL(mpBodyModel);
+    }
+    if (!(mFlags & 2)) {
+        mDoExt_modelUpdateDL(mpLidModel);
+    }
+    dComIfGd_setList();
+    return TRUE;
 }
 
 /* 00000CE0-00000E7C       .text _execute__13daObjKanoke_cFv */
 BOOL daObjKanoke_c::_execute() {
-    /* Nonmatching */
+    cXyz bodyStart(0.0f, 0.0f, -100.0f);
+    cXyz bodyEnd(0.0f, 0.0f, 100.0f);
+    mDoMtx_stack_c::YrotS(shape_angle.y);
+    mDoMtx_stack_c::XrotM(shape_angle.x);
+    mDoMtx_stack_c::multVec(&bodyStart, &bodyStart);
+    mDoMtx_stack_c::multVec(&bodyEnd, &bodyEnd);
+    bodyStart += current.pos;
+    bodyEnd += current.pos;
+    mBodyCps.SetStartEnd(bodyStart, bodyEnd);
+    mBodyCps.SetR(140.0f);
+    dComIfG_Ccsp()->Set(&mBodyCps);
+
+    (this->*moveProc[mState])();
+    setMtx();
+    if (mpBodyBgW->ChkUsed()) {
+        mpBodyBgW->Move();
+    }
+    if (mpLidBgW->ChkUsed()) {
+        mpLidBgW->Move();
+    }
+    return TRUE;
 }
 
 /* 00000E7C-0000122C       .text executeNormal__13daObjKanoke_cFv */
 void daObjKanoke_c::executeNormal() {
-    /* Nonmatching */
+    bool open = false;
+    if (mSwitchNo != 0xFF && dComIfGs_isSwitch(mSwitchNo, fopAcM_GetHomeRoomNo(this))) {
+        open = true;
+    } else if (dComIfGp_getDetect().chk_light(&current.pos) || mBodyCps.ChkTgHit()) {
+        mLightTimer++;
+        if (mLightTimer > 20) {
+            mBodyCps.SetTgType(0);
+            open = true;
+        }
+    } else {
+        mLightTimer = 0;
+        if (mSearchRange != 0) {
+            fopAc_ac_c* player = dComIfGp_getPlayer(0);
+            cXyz delta = home.pos - player->current.pos;
+            if (delta.abs() < 100.0f * mSearchRange) {
+                open = true;
+            }
+        }
+    }
+
+    if (open) {
+        mBodyCps.ClrTgHit();
+        if (mSwitchNo != 0xFF) {
+            dComIfGs_onSwitch(mSwitchNo, fopAcM_GetHomeRoomNo(this));
+        }
+        mRotStep = 0;
+        if (getPrmYure()) {
+            mTimer = 0;
+            if (mType == 0) {
+                mDoAud_seStart(JA_SE_OBJ_KANOKE_Y_GATA, &current.pos, 0,
+                               dComIfGp_getReverb(fopAcM_GetRoomNo(this)));
+                mState = 1;
+                mLidRotZ = 0;
+                mMoveSpeed = 0x100;
+            } else {
+                mDoAud_seStart(JA_SE_OBJ_KANOKE_T_GATA, &current.pos, 0,
+                               dComIfGp_getReverb(fopAcM_GetRoomNo(this)));
+                mState = 4;
+                mBodyRotY = 0;
+                mMoveSpeed = 0x400;
+            }
+        } else if (mType == 0) {
+            mDoAud_seStart(JA_SE_OBJ_KANOKE_Y_OPEN, &current.pos, 0,
+                           dComIfGp_getReverb(fopAcM_GetRoomNo(this)));
+            mState = 2;
+            mLidRotZ = 0;
+        } else {
+            mDoAud_seStart(JA_SE_OBJ_KANOKE_T_OPEN, &current.pos, 0,
+                           dComIfGp_getReverb(fopAcM_GetRoomNo(this)));
+            mState = 5;
+            if (mpLidBgW->ChkUsed()) {
+                dComIfG_Bgsp()->Release(mpLidBgW);
+            }
+            mLidRotX = 0;
+        }
+    }
 }
 
 /* 0000122C-00001358       .text executeYureYoko__13daObjKanoke_cFv */
 void daObjKanoke_c::executeYureYoko() {
-    /* Nonmatching */
+    mTimer += 0x2000;
+    mMoveSpeed -= 8;
+    mLidRotZ = mMoveSpeed * cM_ssin(mTimer);
+    if (mLidRotZ < 0) {
+        mLidOffset.x = 100.0f;
+    } else {
+        mLidOffset.x = -100.0f;
+    }
+    if (mMoveSpeed <= 0) {
+        mDoAud_seStart(JA_SE_OBJ_KANOKE_Y_OPEN, &current.pos, 0,
+                       dComIfGp_getReverb(fopAcM_GetRoomNo(this)));
+        mState = 2;
+        mLidRotZ = 0;
+        mLidOffset.x = 0.0f;
+    }
 }
 
 /* 00001358-00001544       .text executeOpenYoko__13daObjKanoke_cFv */
 void daObjKanoke_c::executeOpenYoko() {
-    /* Nonmatching */
+    mPivotOffset.x += 4.0f;
+    mLidOffset.x = 100.0f - mPivotOffset.x;
+    if (mPivotOffset.x > 100.0f) {
+        mLidRotZ += mRotStep;
+        mRotStep -= 100;
+        if (mLidRotZ <= -0x15E0) {
+            mLidRotZ = -0x15E0;
+            mState = 3;
+
+            mDoMtx_stack_c::YrotS(shape_angle.y);
+            mDoMtx_stack_c::transM(100.0f, 75.0f, 0.0f);
+            mDoMtx_stack_c::ZrotM(mLidRotZ);
+            mDoMtx_stack_c::transM(-100.0f, -75.0f, 0.0f);
+            Mtx mtx;
+            mDoMtx_copy(mDoMtx_stack_c::get(), mtx);
+
+            mEffectAngle.set(0, shape_angle.y, 0);
+            mEffectScale = 180.0f;
+            cXyz effectPos = mPivotOffset + daObjKanoke_Yoko_pfs;
+            mDoMtx_multVec(mtx, &effectPos, &effectPos);
+            mEffectPos = effectPos + current.pos;
+            if (mSmokeCallback.getEmitter() == NULL) {
+                dComIfGp_particle_setToon(dPa_name::ID_IT_ST_KANOKE_SMOKE01, &mEffectPos,
+                                           &mEffectAngle, NULL, (u8)mEffectScale,
+                                           &mSmokeCallback);
+            }
+            if (mSmokeCallback.getEmitter() != NULL) {
+                mSmokeCallback.getEmitter()->becomeImmortalEmitter();
+            }
+            mTimer = 60;
+        }
+    }
 }
 
 /* 00001544-000015F8       .text executeEffectYoko__13daObjKanoke_cFv */
 void daObjKanoke_c::executeEffectYoko() {
-    /* Nonmatching */
+    mTimer--;
+    if (mTimer != 0) {
+        if (mTimer <= 50) {
+            mEffectScale -= 3.6f;
+            if (mEffectScale < 0.0f) {
+                mEffectScale = 0.0f;
+            }
+            if (mSmokeCallback.getEmitter() != NULL) {
+                mSmokeCallback.getEmitter()->setGlobalAlpha((u8)mEffectScale);
+            }
+        }
+    } else {
+        mSmokeCallback.remove();
+        mState = 7;
+    }
 }
 
 /* 000015F8-00001764       .text executeYureTate__13daObjKanoke_cFv */
 void daObjKanoke_c::executeYureTate() {
-    /* Nonmatching */
+    mTimer += 0x2000;
+    mMoveSpeed -= 0x20;
+    mBodyRotY = mMoveSpeed * cM_ssin(mTimer);
+    if (mBodyRotY < 0) {
+        mLidOffset.x = 100.0f;
+    } else {
+        mLidOffset.x = -100.0f;
+    }
+    if (mMoveSpeed <= 0) {
+        mDoAud_seStart(JA_SE_OBJ_KANOKE_T_OPEN, &current.pos, 0,
+                       dComIfGp_getReverb(fopAcM_GetRoomNo(this)));
+        mState = 5;
+        if (mpLidBgW->ChkUsed()) {
+            dComIfG_Bgsp()->Release(mpLidBgW);
+        }
+        mLidRotX = 0;
+        mBodyRotY = 0;
+        mLidOffset.x = 0.0f;
+    }
 }
 
 /* 00001764-00001A6C       .text executeOpenTate__13daObjKanoke_cFv */
 void daObjKanoke_c::executeOpenTate() {
-    /* Nonmatching */
+    mLidRotX += mRotStep;
+    mRotStep += 100;
+    if (mLidRotX >= 0x4000) {
+        dComIfGp_getVibration().StartShock(4, -0x21, cXyz(0.0f, 1.0f, 0.0f));
+        mLidRotX = 0x4000;
+        mState = 6;
+        mFlags |= 2;
+        mEffectPos.x = mLidMtx[0][3];
+        mEffectPos.y = mLidMtx[1][3];
+        mEffectPos.z = mLidMtx[2][3];
+        mEffectAngle.set(0, shape_angle.y, 0);
+        mpEmitters[0] = dComIfGp_particle_set(
+            dPa_name::ID_IT_SN_KANOKE_ROCK00, &mEffectPos, &mEffectAngle, NULL, 0xFF, NULL,
+            -1, &tevStr.mColorK0, &tevStr.mColorK0);
+        mEffectScale = 180.0f;
+        if (mSmokeCallback.getEmitter() == NULL) {
+            dComIfGp_particle_setToon(dPa_name::ID_IT_ST_KANOKE_SMOKE00, &mEffectPos,
+                                       &mEffectAngle, NULL, (u8)mEffectScale,
+                                       &mSmokeCallback);
+        }
+        if (mSmokeCallback.getEmitter() != NULL) {
+            mSmokeCallback.getEmitter()->becomeImmortalEmitter();
+        }
+        mTimer = 60;
+    } else {
+        mDoMtx_stack_c::YrotS(shape_angle.y);
+        mDoMtx_stack_c::XrotM(shape_angle.x);
+        mDoMtx_stack_c::transM(0.0f, 110.0f, 200.0f);
+        mDoMtx_stack_c::XrotM(mLidRotX);
+        mDoMtx_stack_c::transM(0.0f, -110.0f, -200.0f);
+        for (int i = 0; i < 3; i++) {
+            cXyz start = daObjKanoke_Tate_pfs[i][0] + mPivotOffset;
+            cXyz end = daObjKanoke_Tate_pfs[i][1] + mPivotOffset;
+            mDoMtx_stack_c::multVec(&start, &start);
+            mDoMtx_stack_c::multVec(&end, &end);
+            start += current.pos;
+            end += current.pos;
+            mLidCps[i].SetStartEnd(start, end);
+            dComIfG_Ccsp()->Set(&mLidCps[i]);
+        }
+    }
 }
 
 /* 00001A6C-00001B24       .text executeEffectTate__13daObjKanoke_cFv */
 void daObjKanoke_c::executeEffectTate() {
-    /* Nonmatching */
+    mTimer--;
+    if (mTimer != 0) {
+        if (mSmokeCallback.getEmitter() != NULL && mTimer <= 50) {
+            mEffectScale -= 3.6f;
+            if (mEffectScale < 0.0f) {
+                mEffectScale = 0.0f;
+            }
+            mSmokeCallback.getEmitter()->setGlobalAlpha((u8)mEffectScale);
+        }
+    } else {
+        mSmokeCallback.remove();
+        mState = 7;
+    }
 }
 
 /* 00001B24-00001B28       .text executeWait__13daObjKanoke_cFv */
 void daObjKanoke_c::executeWait() {
-    /* Nonmatching */
 }
 
 /* 00001B28-00001B54       .text getPrmType__13daObjKanoke_cFv */
-void daObjKanoke_c::getPrmType() {
-    /* Nonmatching */
+u8 daObjKanoke_c::getPrmType() {
+    return daObj::PrmAbstract<Prm_e>(this, PRM_TYPE_W, PRM_TYPE_S);
 }
 
 /* 00001B54-00001B80       .text getPrmSearch__13daObjKanoke_cFv */
-void daObjKanoke_c::getPrmSearch() {
-    /* Nonmatching */
+u8 daObjKanoke_c::getPrmSearch() {
+    return daObj::PrmAbstract<Prm_e>(this, PRM_SEARCH_W, PRM_SEARCH_S);
 }
 
 /* 00001B80-00001BAC       .text getPrmYure__13daObjKanoke_cFv */
-void daObjKanoke_c::getPrmYure() {
-    /* Nonmatching */
+u8 daObjKanoke_c::getPrmYure() {
+    return daObj::PrmAbstract<Prm_e>(this, PRM_YURE_W, PRM_YURE_S);
 }
 
 /* 00001BAC-00001BD8       .text getPrmSwNo__13daObjKanoke_cFv */
-void daObjKanoke_c::getPrmSwNo() {
-    /* Nonmatching */
+u8 daObjKanoke_c::getPrmSwNo() {
+    return daObj::PrmAbstract<Prm_e>(this, PRM_SWNO_W, PRM_SWNO_S);
 }
 
 /* 00001BD8-00001C04       .text getPrmSwNo2__13daObjKanoke_cFv */
-void daObjKanoke_c::getPrmSwNo2() {
-    /* Nonmatching */
+u8 daObjKanoke_c::getPrmSwNo2() {
+    return daObj::PrmAbstract<Prm_e>(this, PRM_SWNO2_W, PRM_SWNO2_S);
 }
 
 /* 00001C04-00001C9C       .text setMtx__13daObjKanoke_cFv */
 void daObjKanoke_c::setMtx() {
-    /* Nonmatching */
+    if (!(mFlags & 1)) {
+        setMtxHontai();
+        mpBodyModel->setBaseTRMtx(mDoMtx_stack_c::get());
+        mDoMtx_copy(mDoMtx_stack_c::get(), mBodyMtx);
+    }
+    if (!(mFlags & 2)) {
+        setMtxHuta(&current.pos);
+        mpLidModel->setBaseTRMtx(mDoMtx_stack_c::get());
+        mDoMtx_copy(mDoMtx_stack_c::get(), mLidMtx);
+    }
 }
 
 /* 00001C9C-00001D38       .text setMtxHontai__13daObjKanoke_cFv */
 void daObjKanoke_c::setMtxHontai() {
-    /* Nonmatching */
+    mDoMtx_stack_c::transS(current.pos);
+    mDoMtx_stack_c::YrotM(shape_angle.y);
+    mDoMtx_stack_c::XrotM(shape_angle.x);
+    mDoMtx_stack_c::transM(mLidOffset);
+    mDoMtx_stack_c::YrotM(mBodyRotY);
+    mDoMtx_stack_c::transM(-mLidOffset.x, -mLidOffset.y, -mLidOffset.z);
 }
 
 /* 00001D38-00001E4C       .text setMtxHuta__13daObjKanoke_cFP4cXyz */
-void daObjKanoke_c::setMtxHuta(cXyz*) {
-    /* Nonmatching */
+void daObjKanoke_c::setMtxHuta(cXyz* i_pos) {
+    cXyz pivot;
+    mDoMtx_stack_c::YrotS(shape_angle.y);
+    mDoMtx_stack_c::XrotM(shape_angle.x);
+    mDoMtx_stack_c::multVec(&mPivotOffset, &pivot);
+    mDoMtx_stack_c::transS(i_pos->x + pivot.x, i_pos->y + pivot.y, i_pos->z + pivot.z);
+    mDoMtx_stack_c::YrotM(shape_angle.y);
+    mDoMtx_stack_c::XrotM(shape_angle.x);
+    mDoMtx_stack_c::transM(mLidOffset);
+    mDoMtx_stack_c::XrotM(mLidRotX);
+    mDoMtx_stack_c::YrotM(mBodyRotY);
+    mDoMtx_stack_c::ZrotM(mLidRotZ);
+    mDoMtx_stack_c::transM(-mLidOffset.x, -mLidOffset.y, -mLidOffset.z);
 }
 
 /* 00001E4C-00001E6C       .text daObjKanokeCreate__FPv */

--- a/src/d/actor/d_a_obj_kanoke.cpp
+++ b/src/d/actor/d_a_obj_kanoke.cpp
@@ -140,8 +140,10 @@ cPhs_State daObjKanoke_c::_create() {
         if (fopAcM_entrySolidHeap(this, CheckCreateHeap, 0x2400)) {
             phase_state = createInit();
         } else {
+#if VERSION > VERSION_DEMO
             mpLidBgW = NULL;
             mpBodyBgW = NULL;
+#endif
             phase_state = cPhs_ERROR_e;
         }
     }
@@ -241,6 +243,7 @@ cPhs_State daObjKanoke_c::createInit() {
 
 /* 00000B28-00000C0C       .text _delete__13daObjKanoke_cFv */
 BOOL daObjKanoke_c::_delete() {
+#if VERSION > VERSION_DEMO
     if (heap != NULL) {
         if (mpBodyBgW != NULL && mpBodyBgW->ChkUsed()) {
             dComIfG_Bgsp()->Release(mpBodyBgW);
@@ -249,8 +252,19 @@ BOOL daObjKanoke_c::_delete() {
             dComIfG_Bgsp()->Release(mpLidBgW);
         }
     }
+#else
+    if (mpBodyBgW->ChkUsed()) {
+        dComIfG_Bgsp()->Release(mpBodyBgW);
+    }
+    if (mpLidBgW->ChkUsed()) {
+        dComIfG_Bgsp()->Release(mpLidBgW);
+    }
+    for (int i = 0; i < 2; i++) {
+        // The demo build retains an empty emitter loop.
+    }
+#endif
     mSmokeCallback.remove();
-    dComIfG_resDelete(&mPhs, "Mkanoke");
+    dComIfG_resDeleteDemo(&mPhs, "Mkanoke");
     return TRUE;
 }
 
@@ -376,13 +390,27 @@ void daObjKanoke_c::executeYureYoko() {
 
 /* 00001358-00001544       .text executeOpenYoko__13daObjKanoke_cFv */
 void daObjKanoke_c::executeOpenYoko() {
+#if VERSION == VERSION_DEMO
+    f32 maxOffset = 100.0f;
+    s16 maxRotation = -0x15E0;
+#endif
     mPivotOffset.x += 4.0f;
+#if VERSION == VERSION_DEMO
+    mLidOffset.x = maxOffset - mPivotOffset.x;
+    if (mPivotOffset.x > maxOffset) {
+#else
     mLidOffset.x = 100.0f - mPivotOffset.x;
     if (mPivotOffset.x > 100.0f) {
+#endif
         mLidRotZ += mRotStep;
         mRotStep -= 100;
+#if VERSION == VERSION_DEMO
+        if (mLidRotZ <= maxRotation) {
+            mLidRotZ = maxRotation;
+#else
         if (mLidRotZ <= -0x15E0) {
             mLidRotZ = -0x15E0;
+#endif
             mState = 3;
 
             mDoMtx_stack_c::YrotS(shape_angle.y);
@@ -397,7 +425,10 @@ void daObjKanoke_c::executeOpenYoko() {
             cXyz effectPos = mPivotOffset + daObjKanoke_Yoko_pfs;
             mDoMtx_multVec(mtx, &effectPos, &effectPos);
             mEffectPos = effectPos + current.pos;
-            if (mSmokeCallback.getEmitter() == NULL) {
+#if VERSION > VERSION_DEMO
+            if (mSmokeCallback.getEmitter() == NULL)
+#endif
+            {
                 dComIfGp_particle_setToon(dPa_name::ID_IT_ST_KANOKE_SMOKE01, &mEffectPos,
                                            &mEffectAngle, NULL, (u8)mEffectScale,
                                            &mSmokeCallback);
@@ -469,7 +500,10 @@ void daObjKanoke_c::executeOpenTate() {
             dPa_name::ID_IT_SN_KANOKE_ROCK00, &mEffectPos, &mEffectAngle, NULL, 0xFF, NULL,
             -1, &tevStr.mColorK0, &tevStr.mColorK0);
         mEffectScale = 180.0f;
-        if (mSmokeCallback.getEmitter() == NULL) {
+#if VERSION > VERSION_DEMO
+        if (mSmokeCallback.getEmitter() == NULL)
+#endif
+        {
             dComIfGp_particle_setToon(dPa_name::ID_IT_ST_KANOKE_SMOKE00, &mEffectPos,
                                        &mEffectAngle, NULL, (u8)mEffectScale,
                                        &mSmokeCallback);


### PR DESCRIPTION
Decompiles `d_a_obj_kanoke` (Earth Temple coffin, `MKanoke`/`MKanoK2`) to
100% matching.