### PR TITLE
d_a_obj_ikada 100% Matching

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1471,7 +1471,7 @@ config.libs = [
     ActorRel(Matching,    "d_a_obj_hfuck1"),
     ActorRel(Matching,    "d_a_obj_hole"),
     ActorRel(Matching,    "d_a_obj_ice"),
-    ActorRel(NonMatching, "d_a_obj_ikada"),
+    ActorRel(Equivalent,  "d_a_obj_ikada"), # weak func order: extra weak inlines (CrossAtTg/CrossCo/dBgS) vs original weak set
     ActorRel(Matching,    "d_a_obj_kanat"),
     ActorRel(Matching,    "d_a_obj_leaves"),
     ActorRel(Matching,    "d_a_obj_lpalm"),

--- a/src/d/actor/d_a_obj_ikada.cpp
+++ b/src/d/actor/d_a_obj_ikada.cpp
@@ -355,7 +355,6 @@ void daObj_Ikada_c::createWave() {
 
 /* 000012EC-00001528       .text setWave__13daObj_Ikada_cFv */
 void daObj_Ikada_c::setWave() {
-    /* Nonmatching */
     f32 fVar2 = l_HIO.mTrackVel;
     f32 fVar1 = l_HIO.mWaveVelFade;
     f32 target = l_HIO.mSplashScaleMax;
@@ -393,12 +392,12 @@ void daObj_Ikada_c::setWave() {
 
     cXyz sp2C = l_HIO.mWaveCollapsePos[0];
     cXyz sp20 = l_HIO.mWaveCollapsePos[1];
-    cXyz sp14 = l_HIO.mWaveCollapsePos[0];
-    cXyz sp08 = l_HIO.mWaveCollapsePos[1];
+    cXyz sp14 = sp2C;
+    cXyz sp08 = sp20;
 
     mWaveRCallback.setAnchor(&sp2C, &sp20);
-    sp14.x = (f32)(f64)sp14.x * -1.0f;
-    sp08.x = (f32)(f64)sp08.x * -1.0f;
+    sp14.x *= -1.0f;
+    sp08.x *= -1.0f;
     mWaveLCallback.setAnchor(&sp14, &sp08);
 
     mWaveRCallback.setMaxDisSpeed(l_HIO.mWaveVelSpeed);


### PR DESCRIPTION
Decompiles d_a_obj_ikada to 100% per-function matching (all 109 functions, verified via objdiff). Completes the actor by matching setWave (the last remaining function).

- src/d/actor/d_a_obj_ikada.cpp: match setWave (wave-collapse anchor vectors built as copies of the right anchors, negated with x *= -1.0f per the d_a_oship/d_a_ship setAnchor idiom; f64 casts removed)
- configure.py: d_a_obj_ikada -> Equivalent (weak func order: the REL carries extra weak inlines — CrossAtTg/CrossCo/dBgS API inlines — vs the original's weak set; no functional impact, checksum gate skipped)

Per-function match: 109/109 (100%). Equivalent due solely to weak ordering.