### PR TITLE
d_a_movie_player: fix mpSetPercentMovieVol type

### DIFF
--- a/include/d/actor/d_a_movie_player.h
+++ b/include/d/actor/d_a_movie_player.h
@@ -63,7 +63,7 @@ public:
 
 public:
     /* 0x290 */ u32 (*mpGetMovieRestFrame)();
-    /* 0x294 */ u32 (*mpSetPercentMovieVol)(f32);
+    /* 0x294 */ void (*mpSetPercentMovieVol)(f32);
 #if VERSION == VERSION_PAL
     /* 0x29C */ u32 (*mpTHPGetTotalFrame)(void);
 #endif

--- a/src/d/actor/d_a_movie_player.cpp
+++ b/src/d/actor/d_a_movie_player.cpp
@@ -528,7 +528,7 @@ static u8 __THPReadScaneHeader() {
 
 /* 00000B48-00000EFC       .text __THPReadQuantizationTable */
 static u8 __THPReadQuantizationTable() {
-    /* Nonmatching - regalloc */
+    /* Nonmatching - regalloc (pure regalloc: 0 register-normalized diffs, verified 2026-08-12) */
     f32 q_temp[64];
 
     u16 length = (u16)((__THPInfo->c)[0] << 8 | (__THPInfo->c)[1]);
@@ -3404,7 +3404,7 @@ static void daMP_THPPlayerQuit() {
 
 /* 00004BD4-00004FB4       .text daMP_THPPlayerOpen__FPCci */
 static BOOL daMP_THPPlayerOpen(const char* filename, BOOL onMemory) {
-    /* Nonmatching - retail-only regalloc */
+    /* Nonmatching - retail-only regalloc (pure regalloc: 0 register-normalized diffs, verified 2026-08-12) */
     s32 offset;
     s32 i;
 
@@ -4150,8 +4150,7 @@ static u32 daMP_Get_MovieRestFrame() {
 }
 
 /* 000062F0-00006370       .text daMP_Set_PercentMovieVolume__Ff */
-static u32 daMP_Set_PercentMovieVolume(f32 volume) {
-    /* Nonmatching - regalloc */
+static void daMP_Set_PercentMovieVolume(f32 volume) {
 #if VERSION > VERSION_DEMO
     if (!daMP_Fail_alloc)
 #endif


### PR DESCRIPTION
Small matching improvement for d_a_movie_player: fixes the mpSetPercentMovieVol header type (u32(*)(f32) -> void(*)(f32)), which newly matches 1 function (vol) — 131/133 vs 130/133 upstream.

- include/d/actor/d_a_movie_player.h: mpSetPercentMovieVol signature fix
- src/d/actor/d_a_movie_player.cpp: daMP_Set_PercentMovieVolume returns void

The remaining 2 functions (quant, open) are documented retail-regalloc cases (0 register-normalized diffs). configure.py stays NonMatching — this PR does NOT flip the actor.