### PR TITLE
d_a_obj_msdan 100% Matching

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1759,7 +1759,7 @@ config.libs = [
     ActorRel(Matching,    "d_a_obj_mkiek"),
     ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d_a_obj_mknjd"),
     ActorRel(NonMatching, "d_a_obj_mmrr"),
-    ActorRel(NonMatching, "d_a_obj_msdan"),
+    ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d_a_obj_msdan"),
     ActorRel(NonMatching, "d_a_obj_msdan2"),
     ActorRel(Matching,    "d_a_obj_msdan_sub"),
     ActorRel(NonMatching, "d_a_obj_msdan_sub2"),

--- a/include/d/actor/d_a_obj_msdan.h
+++ b/include/d/actor/d_a_obj_msdan.h
@@ -2,21 +2,42 @@
 #define D_A_OBJ_MSDAN_H
 
 #include "f_op/f_op_actor.h"
+#include "d/d_a_obj.h"
+#include "SSystem/SComponent/c_phase.h"
 
 namespace daObjMsdan {
     class Act_c : public fopAc_ac_c {
     public:
-        void prm_get_evId() const {}
-        void prm_get_size() const {}
-        void prm_get_sound() const {}
-        void prm_get_swSave() const {}
-    
+        enum Prm_e {
+            PRM_SWSAVE_W = 0x8,
+            PRM_SWSAVE_S = 0x0,
+
+            PRM_SIZE_W = 0x1,
+            PRM_SIZE_H = 0x10,
+
+            PRM_SOUND_W = 0x1,
+            PRM_SOUND_S = 0x12,
+
+            PRM_EV_ID_W = 0x8,
+            PRM_EV_ID_S = 0x18,
+        };
+
+        s32 prm_get_swSave() const { return daObj::PrmAbstract(this, PRM_SWSAVE_W, PRM_SWSAVE_S); }
+        s32 prm_get_size() const { return daObj::PrmAbstract(this, PRM_SIZE_W, PRM_SIZE_H); }
+        u8 prm_get_sound() const { return daObj::PrmAbstract(this, PRM_SOUND_W, PRM_SOUND_S); }
+        u8 prm_get_evId() const { return daObj::PrmAbstract(this, PRM_EV_ID_W, PRM_EV_ID_S); }
+
         cPhs_State Mthd_Create();
         BOOL Mthd_Execute();
         BOOL Mthd_Delete();
-    
+
+        static const char M_arcname[];
+        static const char M_evname[];
+
     public:
-        /* Place member variables here */
+        /* 0x290 */ request_of_phase_process_class mPhs;
+        /* 0x298 */ s16 mEvId;
+        /* 0x29C */ s32 mState;
     };
 };
 

--- a/src/d/actor/d_a_obj_msdan.cpp
+++ b/src/d/actor/d_a_obj_msdan.cpp
@@ -67,7 +67,7 @@ BOOL daObjMsdan::Act_c::Mthd_Execute() {
             } else if (prm_get_sound()) {
                 mState = 3;
             } else if (mEvId == -1) {
-                JAIZelBasic::getInterface()->seStart(0x806);
+                JAIZelBasic::getInterface()->seStart(JA_SE_READ_RIDDLE_1);
                 mState = 3;
             } else {
                 fopAcM_orderOtherEventId(this, mEvId);
@@ -76,9 +76,9 @@ BOOL daObjMsdan::Act_c::Mthd_Execute() {
         }
         break;
     case 1:
-        if (eventInfo.mCommand == 2) {
+        if (eventInfo.checkCommandDemoAccrpt()) {
             mState = 2;
-            JAIZelBasic::getInterface()->seStart(0x806);
+            JAIZelBasic::getInterface()->seStart(JA_SE_READ_RIDDLE_1);
         } else {
             fopAcM_orderOtherEventId(this, mEvId);
         }

--- a/src/d/actor/d_a_obj_msdan.cpp
+++ b/src/d/actor/d_a_obj_msdan.cpp
@@ -20,8 +20,8 @@ cPhs_State daObjMsdan::Act_c::Mthd_Create() {
     cPhs_State phase_state = dComIfG_resLoad(&mPhs, M_arcname);
 
     if (phase_state == cPhs_COMPLEATE_e) {
-        Vec pos = current.pos;
-        SVec angle = current.angle;
+        cXyz pos = current.pos;
+        csXyz angle = current.angle;
         angle.y += 0x8000;
 
         if (prm_get_size()) {
@@ -30,7 +30,7 @@ cPhs_State daObjMsdan::Act_c::Mthd_Create() {
                 pos.x += 50.0f * cM_ssin(current.angle.y);
                 pos.z += 50.0f * cM_scos(current.angle.y);
                 fopAcM_create(fpcNm_Obj_MsdanSub_e, prm_get_swSave() + (i << 8) + (prm_get_size() << 16),
-                              (cXyz*)&pos, current.roomNo, (csXyz*)&angle, NULL, -1, NULL);
+                              &pos, current.roomNo, &angle, NULL, -1, NULL);
             }
         } else {
             pos.y += 400.0f;
@@ -38,7 +38,7 @@ cPhs_State daObjMsdan::Act_c::Mthd_Create() {
                 pos.x += 50.0f * cM_ssin(current.angle.y);
                 pos.z += 50.0f * cM_scos(current.angle.y);
                 fopAcM_create(fpcNm_Obj_MsdanSub_e, prm_get_swSave() + (i << 8) + (prm_get_size() << 16),
-                              (cXyz*)&pos, current.roomNo, (csXyz*)&angle, NULL, -1, NULL);
+                              &pos, current.roomNo, &angle, NULL, -1, NULL);
             }
         }
 

--- a/src/d/actor/d_a_obj_msdan.cpp
+++ b/src/d/actor/d_a_obj_msdan.cpp
@@ -5,20 +5,101 @@
 
 #include "d/dolzel_rel.h" // IWYU pragma: keep
 #include "d/actor/d_a_obj_msdan.h"
+#include "d/d_com_inf_game.h"
+#include "f_op/f_op_actor_mng.h"
+#include "f_pc/f_pc_name.h"
+#include "JAZelAudio/JAIZelBasic.h"
+#include "SSystem/SComponent/c_math.h"
+
+const char daObjMsdan::Act_c::M_arcname[] = "Msdan";
+const char daObjMsdan::Act_c::M_evname[] = "Msdan";
 
 /* 00000078-000003D4       .text Mthd_Create__Q210daObjMsdan5Act_cFv */
 cPhs_State daObjMsdan::Act_c::Mthd_Create() {
-    /* Nonmatching */
+    fopAcM_ct(this, Act_c);
+    cPhs_State phase_state = dComIfG_resLoad(&mPhs, M_arcname);
+
+    if (phase_state == cPhs_COMPLEATE_e) {
+        Vec pos = current.pos;
+        SVec angle = current.angle;
+        angle.y += 0x8000;
+
+        if (prm_get_size()) {
+            pos.y += 800.0f;
+            for (s32 i = 0; i < 31; i++) {
+                pos.x += 50.0f * cM_ssin(current.angle.y);
+                pos.z += 50.0f * cM_scos(current.angle.y);
+                fopAcM_create(fpcNm_Obj_MsdanSub_e, prm_get_swSave() + (i << 8) + (prm_get_size() << 16),
+                              (cXyz*)&pos, current.roomNo, (csXyz*)&angle, NULL, -1, NULL);
+            }
+        } else {
+            pos.y += 400.0f;
+            for (s32 i = 16; i < 31; i++) {
+                pos.x += 50.0f * cM_ssin(current.angle.y);
+                pos.z += 50.0f * cM_scos(current.angle.y);
+                fopAcM_create(fpcNm_Obj_MsdanSub_e, prm_get_swSave() + (i << 8) + (prm_get_size() << 16),
+                              (cXyz*)&pos, current.roomNo, (csXyz*)&angle, NULL, -1, NULL);
+            }
+        }
+
+        if (prm_get_evId() == 0xFF) {
+            mEvId = dComIfGp_evmng_getEventIdx("Msdan", 0xFF);
+        } else {
+            mEvId = dComIfGp_evmng_getEventIdx(NULL, prm_get_evId());
+        }
+
+        if (fopAcM_isSwitch(this, prm_get_swSave())) {
+            mState = 3;
+        } else {
+            mState = 0;
+        }
+    }
+    return phase_state;
 }
 
 /* 000003D4-000005C0       .text Mthd_Execute__Q210daObjMsdan5Act_cFv */
 BOOL daObjMsdan::Act_c::Mthd_Execute() {
-    /* Nonmatching */
+    switch (mState) {
+    case 0:
+        if (fopAcM_isSwitch(this, prm_get_swSave())) {
+            if (prm_get_size()) {
+                mState = 3;
+            } else if (prm_get_sound()) {
+                mState = 3;
+            } else if (mEvId == -1) {
+                JAIZelBasic::getInterface()->seStart(0x806);
+                mState = 3;
+            } else {
+                fopAcM_orderOtherEventId(this, mEvId);
+                mState = 1;
+            }
+        }
+        break;
+    case 1:
+        if (eventInfo.mCommand == 2) {
+            mState = 2;
+            JAIZelBasic::getInterface()->seStart(0x806);
+        } else {
+            fopAcM_orderOtherEventId(this, mEvId);
+        }
+        break;
+    case 2:
+        if (dComIfGp_evmng_endCheck(mEvId)) {
+            dComIfGp_event_onEventFlag(8);
+            mState = 3;
+        }
+        break;
+    case 3:
+    default:
+        break;
+    }
+    return TRUE;
 }
 
 /* 000005C0-000005F0       .text Mthd_Delete__Q210daObjMsdan5Act_cFv */
 BOOL daObjMsdan::Act_c::Mthd_Delete() {
-    /* Nonmatching */
+    dComIfG_resDelete(&mPhs, M_arcname);
+    return TRUE;
 }
 
 namespace daObjMsdan {


### PR DESCRIPTION
Full matching decompilation of d_a_obj_msdan (riddle stone / demo-accept event actor).

- 9/9 functions at 100% fuzzy match (objdiff)
- All code follows repo conventions: `JA_SE_READ_RIDDLE_1` enum instead of raw seStart ids, `eventInfo.checkCommandDemoAccrpt()` instead of raw `mCommand == 2` (per review feedback)
- cXyz/csXyz locals match the original codegen (matched sibling d_a_npc_mt uses the same pattern)
- configure.py: `ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"), "d_a_obj_msdan")` — the D44J01 kiosk demo build of this rel differs (verified: clean D44J01 build with plain Matching fails only on msdan.rel; same precedent as d_a_obj_msdan2 #1092 / d_a_obj_msdan_sub2 #1094)

This is the first fully-Matching actor from the decomp org.