### PR TITLE
d_a_magma kiosk 100% matching (adopted from #969, noskap)

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1451,7 +1451,7 @@ config.libs = [
     ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d_a_lamp"),
     ActorRel(NonMatching, "d_a_lod_bg"),
     ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d_a_lwood"),
-    ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d_a_magma"),
+    ActorRel(Matching,    "d_a_magma"),
     ActorRel(Matching,    "d_a_majuu_flag"),
     ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"), "d_a_mdoor"),
     ActorRel(MatchingFor("D44J01"), "d_a_msw"),

--- a/include/d/actor/d_a_magma.h
+++ b/include/d/actor/d_a_magma.h
@@ -7,7 +7,13 @@
 
 class daMagma_c : public fopAc_ac_c {
 public:
+#if VERSION > VERSION_DEMO
     inline ~daMagma_c();
+#else
+    inline ~daMagma_c() {
+        dRes_control_c::deleteRes("Magma", (dRes_info_c*)&g_dComIfG_gameInfo.mResControl, 0x40);
+    }
+#endif
     inline cPhs_State create();
     inline s32 getPathNo() { return fopAcM_GetParam(this); }
 

--- a/src/d/actor/d_a_magma.cpp
+++ b/src/d/actor/d_a_magma.cpp
@@ -9,25 +9,28 @@
 #include "d/d_com_inf_game.h"
 #include "d/d_magma.h"
 
+#if VERSION > VERSION_DEMO
 daMagma_c::~daMagma_c() {
     dComIfG_resDelete(&mPhs, "Magma");
 }
+#endif
 
 cPhs_State daMagma_c::create() {
+#if VERSION > VERSION_DEMO
     fopAcM_ct(this, daMagma_c);
-
+#endif
     cPhs_State result = dComIfG_resLoad(&mPhs, "Magma");
     if (result != cPhs_COMPLEATE_e) {
         return result;
     }
 
     if (dComIfGp_createMagma()) {
-        dComIfGp_getMagma()->newFloor(
-            current.pos,
-            scale,
-            current.roomNo,
-            getPathNo()
-        );
+#if VERSION > VERSION_DEMO
+        dComIfGp_getMagma()->newFloor(current.pos, scale, current.roomNo, getPathNo());
+#else
+        s16 pathNo = fopAcM_GetParam(this);
+        dComIfGp_getMagma()->newFloor(current.pos, scale, fopAcM_GetRoomNo(this), pathNo);
+#endif
     }
 
     return cPhs_ERROR_e;


### PR DESCRIPTION
Adopts [PR #969](https://github.com/zeldaret/tww/pull/969) by @noskap, who explicitly released the changes: *"this pr is from months ago and I've moved on to other projects. Anyone here is free to use my changes, or not, I don't mind"*.

The kiosk demo (D44J01) `d_a_magma` rel differs from the 3 retail versions:
- The demo build inlines the dtor body (`dRes_control_c::deleteRes("Magma", ...)`) instead of calling `dComIfG_resDelete` — `#if VERSION > VERSION_DEMO` guard on both the header dtor and the .cpp definition.
- `daMagma_c::create()` skips `fopAcM_ct` on demo and calls `newFloor` with `fopAcM_GetParam`/`fopAcM_GetRoomNo` instead of `current.pos/roomNo/getPathNo()`.
- Flip `MatchingFor("GZLJ01", "GZLE01", "GZLP01")` → `Matching` in configure.py (covers D44J01 too).

Verified locally: GZLE01 rel sha1 matches `config/GZLE01/build.sha1`, and the D44J01 rel built from this branch matches `config/D44J01/build.sha1` (`467c61d6...`). Attribution: all three-file content is noskap's from #969, adapted to the current tree (only the fopAcM_SetupActor→fopAcM_ct rename and include normalization).