### PR TITLE
d_a_npc_co1 100% Matching

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1662,7 +1662,7 @@ config.libs = [
     ActorRel(MatchingFor("D44J01"), "d_a_npc_bs1"), # regalloc
     ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),  "d_a_npc_btsw"),
     ActorRel(Matching,    "d_a_npc_btsw2"),
-    ActorRel(NonMatching, "d_a_npc_co1"),
+    ActorRel(Equivalent,  "d_a_npc_co1"), # weak data (extra weak vtables from shared headers)
     ActorRel(NonMatching, "d_a_npc_de1"),
     ActorRel(NonMatching, "d_a_npc_ds1"),
     ActorRel(NonMatching, "d_a_npc_gk1"),

--- a/include/d/actor/d_a_npc_co1.h
+++ b/include/d/actor/d_a_npc_co1.h
@@ -1,31 +1,40 @@
 #ifndef D_A_NPC_CO1_H
 #define D_A_NPC_CO1_H
 
+#include "d/d_npc.h"
 #include "f_op/f_op_actor.h"
 
 class J3DNode;
 
-class daNpc_Co1_c : public fopAc_ac_c {
+class daNpc_Co1_c : public fopNpc_npc_c {
 public:
+    typedef int (daNpc_Co1_c::*ActionFunc)(void*);
+
     struct anm_prm_c {
-        
-    };
+        /* 0x00 */ s8 mBckResIndex;
+        /* 0x01 */ s8 mResIndex;
+        /* 0x02 */ s8 mPad_0x02;
+        /* 0x03 */ s8 mPad_0x03;
+        /* 0x04 */ f32 mMorf;
+        /* 0x08 */ f32 mSpeed;
+        /* 0x0C */ int mLoopMode;
+    }; // Size: 0x10
 
     void nodeCo1Control(J3DNode*, J3DModel*);
-    void init_CO1_0();
-    void createInit();
+    BOOL init_CO1_0();
+    BOOL createInit();
     void setMtx(bool);
-    void anmNum_toResID(int);
-    void anmNum_toResID_prl(int);
-    void btpNum_toResID(int);
-    void setBtp(bool, int);
-    void setBtk(bool);
-    void iniTexPttrnAnm(bool);
+    s32 anmNum_toResID(int);
+    s32 anmNum_toResID_prl(int);
+    s32 btpNum_toResID(int);
+    BOOL setBtp(bool, int);
+    BOOL setBtk(bool);
+    BOOL iniTexPttrnAnm(bool);
     void plyTexPttrnAnm();
     void setAnm_tex(signed char);
-    void setAnm_anm(anm_prm_c*);
+    BOOL setAnm_anm(anm_prm_c*);
     void setAnm_NUM(int, int);
-    void setAnm();
+    BOOL setAnm();
     void chg_anmTag();
     void control_anmTag();
     void chg_anmAtr(unsigned char);
@@ -36,56 +45,162 @@ public:
     void checkOrder();
     void setCollision_SP_();
     void set_target(int);
-    void chk_talk();
-    void chk_partsNotMove();
+    BOOL chk_talk();
+    BOOL chk_partsNotMove();
     void lookBack();
-    void next_msgStatus(unsigned long*);
-    void getMsg_CO1_0();
-    void getMsg();
-    void chkAttention();
+    u16 next_msgStatus(unsigned long*);
+    u32 getMsg_CO1_0();
+    u32 getMsg();
+    BOOL chkAttention();
     void setAttention(bool);
-    void charDecide(int);
+    BOOL charDecide(int);
     void eInit_MDR_();
     void eInit_RED_LTR_();
     void event_actionInit(int);
-    void eMove_MDR_();
-    void eMove_RED_LTR_();
-    void event_action();
+    BOOL eMove_MDR_();
+    BOOL eMove_RED_LTR_();
+    BOOL event_action();
     void privateCut(int);
     void endEvent();
-    void isEventEntry();
+    s32 isEventEntry();
     void event_proc(int);
-    void set_action(int (daNpc_Co1_c::*)(void*), void*);
+    BOOL set_action(ActionFunc, void*);
     void setStt(signed char);
-    void wait_1();
-    void wait_2();
-    void wakeup();
-    void talk_1();
-    void toru_1();
-    void read_1();
-    void modoru();
-    void wait_action1(void*);
-    void demo();
+    BOOL wait_1();
+    BOOL wait_2();
+    BOOL wakeup();
+    BOOL talk_1();
+    BOOL toru_1();
+    BOOL read_1();
+    BOOL modoru();
+    BOOL wait_action1(void*);
+    BOOL demo();
     void shadowDraw();
     BOOL _draw();
     BOOL _execute();
     BOOL _delete();
     cPhs_State _create();
-    void create_Anm();
-    void create_prl_Anm();
-    void create_itm_Mdl();
-    void CreateHeap();
+    J3DModelData* create_Anm();
+    J3DModelData* create_prl_Anm();
+    BOOL create_itm_Mdl();
+    BOOL CreateHeap();
 
 public:
-    /* Place member variables here */
-};
+    /* 0x6C4 */ request_of_phase_process_class mPhs;
+    /* 0x6CC */ s8 m_hed_jnt_num;
+    /* 0x6CD */ s8 m_bbone_jnt_num;
+    /* 0x6CE */ s8 m_hnd_R_jnt_num;
+    /* 0x6CF */ u8 mPad_0x6CF;
+    /* 0x6D0 */ mDoExt_McaMorf* mpPrlMorf;
+    /* 0x6D4 */ J3DAnmTextureSRTKey* m_prl_btk;
+    /* 0x6D8 */ s8 m_prl_jnt_num;
+    /* 0x6D9 */ u8 mPad_0x6D9[0x6DC - 0x6D9];
+    /* 0x6DC */ mDoExt_btkAnm mBtkAnm;
+    /* 0x6F0 */ u8 mBtkFrame;
+    /* 0x6F1 */ u8 mPad_0x6F1[0x6F4 - 0x6F1];
+    /* 0x6F4 */ J3DModel* mpItmModel;
+    /* 0x6F8 */ u32 mShadowIdx;
+    /* 0x6FC */ J3DAnmTexPattern* m_hed_tex_pttrn;
+    /* 0x700 */ mDoExt_btpAnm mBtpAnm;
+    /* 0x714 */ u8 mBtpFrame;
+    /* 0x715 */ u8 mPad_0x715;
+    /* 0x716 */ s16 mBtpTimer;
+    /* 0x718 */ ActionFunc mCurrActionFunc;
+    /* 0x724 */ u8 mPad_0x724[8];
+    /* 0x72C */ dNpc_EventCut_c mDemoEventCut;
+    /* 0x798 */ u8 mPad_0x798[4];
+    /* 0x79C */ cXyz mBkPos;
+    /* 0x7A8 */ s16 mBkAngleX;
+    /* 0x7AA */ s16 mBkAngleY;
+    /* 0x7AC */ s16 mBkAngleZ;
+    /* 0x7B0 */ cXyz mHeadPos;
+    /* 0x7BC */ cXyz mEventPos;
+    /* 0x7C8 */ u8 mPad_0x7C8[0x7D4 - 0x7C8];
+    /* 0x7D4 */ f32 mPrevMorfFrame;
+    /* 0x7D8 */ u8 mPad_0x7D8[0x7EC - 0x7D8];
+    /* 0x7EC */ s16 mPrevJntHeadX;
+    /* 0x7EE */ s16 mPrevJntBackboneX;
+    /* 0x7F0 */ s16 mPrevAngleY;
+    /* 0x7F2 */ s16 mEventIdx[3];
+    /* 0x7F8 */ s16 mEvtIdxSel;
+    /* 0x7FA */ u8 mPad_0x7FA[0x7FC - 0x7FA];
+    /* 0x7FC */ s16 mTimer;
+    /* 0x7FE */ u8 mPad_0x7FE[0x802 - 0x7FE];
+    /* 0x802 */ s16 mHeadAngle;
+    /* 0x804 */ s16 mDesiredYRot;
+    /* 0x806 */ u8 mPad_0x806[0x808 - 0x806];
+    /* 0x808 */ s8 mMorfEnd;
+    /* 0x809 */ s8 mAnmLoaded;
+    /* 0x80A */ s8 mHasLetter;
+    /* 0x80B */ u8 mGetItem;
+    /* 0x80C */ u8 mPad_0x80C;
+    /* 0x80D */ u8 mInitFlags;
+    /* 0x80E */ u8 mPad_0x80E;
+    /* 0x80F */ u8 mNoPosMove;
+    /* 0x810 */ u8 mLookFlags;
+    /* 0x811 */ u8 mDemoFlags;
+    /* 0x812 */ u8 mPad_0x812;
+    /* 0x813 */ bool mDrawHandR;
+    /* 0x814 */ u8 mInitStep2;
+    /* 0x815 */ u8 mExecStarted;
+    /* 0x816 */ u8 mPad_0x816[0x818 - 0x816];
+    /* 0x818 */ BOOL mAttnScratch;
+    /* 0x81C */ u8 mAttnFlag;
+    /* 0x81D */ bool mHide;
+    /* 0x81E */ bool mInitDone;
+    /* 0x81F */ bool mDemo;
+    /* 0x820 */ LIGHT_INFLUENCE mLight;
+    /* 0x840 */ cXyz mCurPos;
+    /* 0x84C */ f32 mOscillation;
+    /* 0x850 */ s16 mSinAngle;
+    /* 0x852 */ u8 mPad_0x852[0x854 - 0x852];
+    /* 0x854 */ s8 mCurActIdx;
+    /* 0x855 */ s8 mEventActNo;
+    /* 0x856 */ u8 mCurrAnmAtr;
+    /* 0x857 */ u8 mCurrAnmTag;
+    /* 0x858 */ s8 mTexPatternNum;
+    /* 0x859 */ s8 mCurrAnmNum;
+    /* 0x85A */ u8 mPad_0x85A[0x85C - 0x85A];
+    /* 0x85C */ s8 mEventState;
+    /* 0x85D */ s8 mAnmTagIndex;
+    /* 0x85E */ s8 mNextAnmNum;
+    /* 0x85F */ s8 mActionIndex;
+    /* 0x860 */ s8 mType;
+    /* 0x861 */ s8 mInitStep;
+    /* 0x862 */ s8 mActionState;
+    /* 0x863 */ s8 mMsgAttrCount;
+}; // Size: 0x864
 
-class daNpc_Co1_HIO_c {
+class daNpc_Co1_HIO_c : public mDoHIO_entry_c {
 public:
     daNpc_Co1_HIO_c();
+    virtual ~daNpc_Co1_HIO_c() {}
 
 public:
-    /* Place member variables here */
+    /* 0x04 */ s8 mNo;
+    /* 0x08 */ s32 mNo2;
+
+    struct {
+        /* 0x0C */ s16 mMaxHeadX;
+        /* 0x0E */ s16 mMaxHeadY;
+        /* 0x10 */ s16 mMinHeadX;
+        /* 0x12 */ s16 mMinHeadY;
+        /* 0x14 */ s16 mMaxBackboneX;
+        /* 0x16 */ s16 mMaxBackboneY;
+        /* 0x18 */ s16 mMinBackboneX;
+        /* 0x1A */ s16 mMinBackboneY;
+        /* 0x1C */ s16 mMaxTurnStep;
+        /* 0x1E */ s16 mMaxTurnVel;
+        /* 0x20 */ f32 mAttnYOff;
+        /* 0x24 */ s16 mAttnAngleY;
+        /* 0x26 */ s16 mPrevPosOfsX;
+        /* 0x28 */ s16 mPrevPosOfsY;
+        /* 0x2A */ s16 mPrevPosOfsZ;
+        /* 0x2C */ f32 mOscMaxOfs;
+        /* 0x30 */ f32 mOscMinOfs;
+        /* 0x34 */ s16 mOscAngVel;
+        /* 0x36 */ s16 mAlpha;
+    } mNpc;
 };
 
 #endif /* D_A_NPC_CO1_H */

--- a/src/d/actor/d_a_npc_co1.cpp
+++ b/src/d/actor/d_a_npc_co1.cpp
@@ -1,367 +1,1461 @@
-/**
- * d_a_npc_co1.cpp
- * NPC - Prince Komali (before Dragon Roost Cavern)
- */
-
 #include "d/dolzel_rel.h" // IWYU pragma: keep
 #include "d/actor/d_a_npc_co1.h"
+#include "d/d_snap.h"
+#include "d/d_item_data.h"
+#include "res/Object/Co.h"
+#include "m_Do/m_Do_ext.h"
+#include "d/d_kankyo.h"
+#include "d/d_drawlist.h"
+inline f32 fabs(f32 x) { return __fabs(x); }
 
-/* 000000EC-00000150       .text __ct__15daNpc_Co1_HIO_cFv */
+#define mpBtpRes m_hed_tex_pttrn
+#define mpBtkRes m_prl_btk
+
+// Event sentinels
+#define EVT_NO_EVENT 0xFF
+#define EVT_NO_TARGET 0xFFFF
+
+// Attention system
+#define ATTN_FLAGS 10
+#define ATTN_DIST_SPOKEN 0x46
+#define ATTN_DIST_ACTION 0x45
+
+// BAM angles
+#define BAM_11DEG 0x800
+#define BAM_45DEG 0x2000
+
+// Param mask for character type
+#define CHAR_TYPE_MASK 0xFF
+
+// Event bits
+#define EVTBIT_PRL_FLW_DONE 0xF04
+#define EVTBIT_GREETED 0xF08
+#define EVTBIT_CONTACT_DONE 0x1810
+
+// Message IDs
+#define MSG_CO_GREETING 0x1839
+#define MSG_CO_ALREADY_MET 0x183A
+#define MSG_CO_GOT_ITEM 0x183B
+#define MSG_CO_GOT_LETTER 0x183C
+#define MSG_CO_HAS_LETTER 0x183E
+#define MSG_CO_GIVE_LETTER 0x183F
+#define MSG_CO_GAVE_LETTER 0x1840
+#define MSG_CO_LETTER_PASSED 0x1841
+#define MSG_CO_LETTER_PASSED_1 0x1842
+#define MSG_CO_LETTER_PASSED_2 0x1843
+#define MSG_CO_LETTER_PASSED_3 0x1844
+#define MSG_CO_LETTER_PASSED_4 0x1845
+#define MSG_CO_LETTER_PASSED_5 0x1846
+#define MSG_CO_LETTER_PASSED_6 0x1847
+#define MSG_CO_LETTER_DONE 0x1848
+#define MSG_CO_DELIVERED_START 0x1849
+#define MSG_CO_DELIVERED_END 0x184A
+#define MSG_CO_ENDING 0x184B
+
+static daNpc_Co1_HIO_c l_HIO;
+
+extern daNpc_Co1_c::anm_prm_c a_anm_tbl1[12];
+extern daNpc_Co1_c::anm_prm_c a_anm_tbl2[8];
+extern daNpc_Co1_c::anm_prm_c a_anm_tbl3[14];
+
 daNpc_Co1_HIO_c::daNpc_Co1_HIO_c() {
-    /* Nonmatching */
+    static struct {
+        s16 mMaxHeadX, mMaxHeadY, mMinHeadX, mMinHeadY;
+        s16 mMaxBackboneX, mMaxBackboneY, mMinBackboneX, mMinBackboneY;
+        s16 mMaxTurnStep, mMaxTurnVel;
+        f32 mAttnYOff;
+        s16 mAttnAngleY, mPrevPosOfsX, mPrevPosOfsY, mPrevPosOfsZ;
+        f32 mOscMaxOfs, mOscMinOfs;
+        s16 mOscAngVel, mAlpha;
+    } a_prm_tbl = {
+        0x2000, 0x2328, 0xE000, 0xDCD8,
+        0, 0, 0, 0,
+        0x0400, 0x0400,
+        91.0f,
+        0, 0xFF, 0x96, 0,
+        40.0f, 20.0f,
+        0x0200, 0x40,
+    };
+    memcpy(&mNpc, &a_prm_tbl, sizeof(mNpc));
+    mNo = -1;
+    mNo2 = -1;
 }
 
-/* 00000198-000001E4       .text nodeCallBack_Co1__FP7J3DNodei */
-static BOOL nodeCallBack_Co1(J3DNode*, int) {
-    /* Nonmatching */
+
+static const char* l_evn_tbl[3] = {
+    "Prl_Flw", "Contact", "Red_Ltr",
+};
+
+
+
+
+static BOOL nodeCallBack_Co1(J3DNode* i_node, int i_calcTiming) {
+    if (i_calcTiming == J3DNodeCBCalcTiming_In) {
+        J3DModel* model = j3dSys.getModel();
+        daNpc_Co1_c* co1Actor = (daNpc_Co1_c*)(model->getUserArea());
+        if (co1Actor) {
+            co1Actor->nodeCo1Control(i_node, model);
+        }
+    }
+    return TRUE;
 }
 
-/* 000001E4-00000334       .text nodeCo1Control__11daNpc_Co1_cFP7J3DNodeP8J3DModel */
-void daNpc_Co1_c::nodeCo1Control(J3DNode*, J3DModel*) {
-    /* Nonmatching */
+void daNpc_Co1_c::nodeCo1Control(J3DNode* i_node, J3DModel* i_model) {
+    static cXyz a_att_pos_offst(14.0f, 18.0f, 0.0f);
+    int jointIdx = ((J3DJoint*)i_node)->getJntNo();
+
+    mDoMtx_stack_c::copy(i_model->getAnmMtx(jointIdx));
+
+    if (jointIdx == m_hed_jnt_num) {
+        mDoMtx_stack_c::XrotM(m_jnt.getHead_y());
+        mDoMtx_stack_c::ZrotM(-m_jnt.getHead_x());
+        PSMTXMultVec(mDoMtx_stack_c::get(), &a_att_pos_offst, &mHeadPos);
+    }
+
+    if (jointIdx == m_bbone_jnt_num) {
+        mDoMtx_stack_c::XrotM(m_jnt.getBackbone_y());
+        mDoMtx_stack_c::ZrotM(-m_jnt.getBackbone_x());
+    }
+
+    cMtx_copy(mDoMtx_stack_c::get(), J3DSys::mCurrentMtx);
+    i_model->setAnmMtx(jointIdx, mDoMtx_stack_c::get());
 }
 
-/* 00000370-00000410       .text init_CO1_0__11daNpc_Co1_cFv */
-void daNpc_Co1_c::init_CO1_0() {
-    /* Nonmatching */
+BOOL daNpc_Co1_c::init_CO1_0() {
+    u32 isSym = dComIfGs_isSymbol(1);
+    u32 ret = isSym ? 0 : 1;
+    if ((u8)ret) {
+        actor_status &= ~fopAcStts_NOCULLEXEC_e;
+        actor_status |= fopAcStts_UNK4000_e;
+        set_action(&daNpc_Co1_c::wait_action1, NULL);
+    }
+    return ret;
 }
 
-/* 00000410-00000588       .text createInit__11daNpc_Co1_cFv */
-void daNpc_Co1_c::createInit() {
-    /* Nonmatching */
+
+BOOL daNpc_Co1_c::createInit() {
+    int i = 0;
+    for (; i < 3; i++) {
+        mEventIdx[i] = dComIfGp_evmng_getEventIdx(l_evn_tbl[i], EVT_NO_EVENT);
+    }
+
+    attention_info.flags = 10;
+    attention_info.distances[1] = ATTN_DIST_SPOKEN;
+    attention_info.distances[3] = ATTN_DIST_ACTION;
+    gravity = -4.5f;
+
+    mEventPos.x = current.pos.x;
+    mEventPos.y = current.pos.y;
+    mEventPos.z = current.pos.z;
+
+    mInitDone = TRUE;
+
+    mDemoEventCut.setActorInfo2("Co1", this);
+
+    mCurrAnmNum = 11;
+
+    BOOL result;
+    switch (mInitStep) {
+    case 0:
+        result = init_CO1_0();
+        break;
+    default:
+        result = FALSE;
+        break;
+    }
+    if (result & 0xFF) {
+        shape_angle.x = current.angle.x;
+        shape_angle.y = current.angle.y;
+        shape_angle.z = current.angle.z;
+        goto success;
+    }
+    return FALSE;
+success:
+    mStts.Init(0xFF, 0xFF, this);
+    mCyl.SetStts(&mStts);
+    mCyl.Set(dNpc_cyl_src);
+    mpMorf->setMorf(0.0f);
+    setMtx(TRUE);
+    return TRUE;
 }
 
-/* 00000588-000008E4       .text setMtx__11daNpc_Co1_cFb */
-void daNpc_Co1_c::setMtx(bool) {
-    /* Nonmatching */
+
+void daNpc_Co1_c::setMtx(bool i_init) {
+    if (!mDemo) {
+        plyTexPttrnAnm();
+        mMorfEnd = mpMorf->play(&eyePos, 0, 0);
+
+        mpPrlMorf->setFrame(mpMorf->getFrame());
+
+        if (mpMorf->getFrame() < mPrevMorfFrame) {
+            mMorfEnd = TRUE;
+        }
+        mPrevMorfFrame = mpMorf->getFrame();
+
+        mObjAcch.CrrPos(*dComIfG_Bgsp());
+
+        switch (mCurrAnmNum) {
+        case 8:
+            mDrawHandR = (mpMorf->getFrame() >= 15.0f);
+            break;
+        case 4:
+            mDrawHandR = TRUE;
+            break;
+        default:
+            mDrawHandR = FALSE;
+            break;
+        }
+    }
+
+    dBgS* bgsp = dComIfG_Bgsp();
+    tevStr.mRoomNo = bgsp->GetRoomId(mObjAcch.m_gnd);
+    tevStr.mEnvrIdxOverride = bgsp->GetPolyColor(mObjAcch.m_gnd);
+
+    mDoMtx_stack_c::transS(current.pos);
+    mDoMtx_stack_c::YrotM(current.angle.y);
+    mpMorf->getModel()->setBaseTRMtx(mDoMtx_stack_c::get());
+    mpMorf->calc();
+
+    PSMTXCopy(mpMorf->getModel()->getAnmMtx(m_bbone_jnt_num), mDoMtx_stack_c::get());
+    mpPrlMorf->getModel()->setBaseTRMtx(mDoMtx_stack_c::get());
+    mpPrlMorf->calc();
+
+    if (mDrawHandR) {
+        PSMTXCopy(mpMorf->getModel()->getAnmMtx(m_hnd_R_jnt_num), mDoMtx_stack_c::get());
+        mpItmModel->setBaseTRMtx(mDoMtx_stack_c::get());
+        mpItmModel->calc();
+    }
+
+    cMtx_copy(mpPrlMorf->getModel()->getAnmMtx(m_prl_jnt_num), mDoMtx_stack_c::get());
+    MtxP mtx = mDoMtx_stack_c::get();
+    mCurPos.x = mtx[0][3];
+    mCurPos.y = mtx[1][3];
+    mCurPos.z = mtx[2][3];
+
+    mLight.mPos = mCurPos;
+    mLight.mColor.r = l_HIO.mNpc.mPrevPosOfsX;
+    mLight.mColor.g = l_HIO.mNpc.mPrevPosOfsY;
+    mLight.mColor.b = l_HIO.mNpc.mPrevPosOfsZ;
+
+    mSinAngle += l_HIO.mNpc.mOscAngVel;
+
+    mOscillation = fabs(cM_ssin(mSinAngle));
+
+    f32 diff = l_HIO.mNpc.mOscMaxOfs - l_HIO.mNpc.mOscMinOfs;
+    f32 clampedDiff = cLib_minLimit<f32>(diff, 0.0f);
+
+    mLight.mPower = cLib_minLimit<f32>(clampedDiff * mOscillation + l_HIO.mNpc.mOscMinOfs, 0.001f);
+
+    setAttention(i_init);
 }
 
-/* 000008E4-000008F8       .text anmNum_toResID__11daNpc_Co1_cFi */
-void daNpc_Co1_c::anmNum_toResID(int) {
-    /* Nonmatching */
+static const int a_bck_resID_tbl[11] = {
+    0x10, 0x11, 0x09, 0x0A, 0x0B, 0x0D, 0x0E, 0x0C, 0x0F, 0x0A, 0x09,
+};
+
+static const int a_bck_resID_prl_tbl[11] = {
+    0x07, 0x08, 0x00, 0x01, 0x02, 0x04, 0x05, 0x03, 0x06, 0x01, 0x00,
+};
+
+static const int a_btp_resID_tbl[7] = {
+    0x16, 0x17, 0x1A, 0x1C, 0x19, 0x1B, 0x18,
+};
+
+s32 daNpc_Co1_c::anmNum_toResID(int i_idx) {
+    return a_bck_resID_tbl[i_idx];
 }
 
-/* 000008F8-0000090C       .text anmNum_toResID_prl__11daNpc_Co1_cFi */
-void daNpc_Co1_c::anmNum_toResID_prl(int) {
-    /* Nonmatching */
+s32 daNpc_Co1_c::anmNum_toResID_prl(int i_idx) {
+    return a_bck_resID_prl_tbl[i_idx];
 }
 
-/* 0000090C-00000920       .text btpNum_toResID__11daNpc_Co1_cFi */
-void daNpc_Co1_c::btpNum_toResID(int) {
-    /* Nonmatching */
+s32 daNpc_Co1_c::btpNum_toResID(int i_idx) {
+    return a_btp_resID_tbl[i_idx];
 }
 
-/* 00000920-00000A30       .text setBtp__11daNpc_Co1_cFbi */
-void daNpc_Co1_c::setBtp(bool, int) {
-    /* Nonmatching */
+BOOL daNpc_Co1_c::setBtp(bool i_inherit, int i_texNum)
+{
+    J3DModelData* modelData = mpMorf->getModel()->getModelData();
+    int btpNum = btpNum_toResID(i_texNum);
+    J3DAnmTexPattern* btpRes = (J3DAnmTexPattern*)dComIfG_getObjectIDRes("Co", (u16)btpNum);
+    mpBtpRes = btpRes;
+    JUT_ASSERT(0x1CE, mpBtpRes != 0);
+
+    int initRes = mBtpAnm.init(modelData, mpBtpRes, TRUE, J3DFrameCtrl::EMode_LOOP, 1.0f, 0, -1, i_inherit, FALSE);
+    int notRes = 1 - initRes;
+    u32 result = notRes ? 0 : 1;
+    if ((u8)result) {
+        mBtpFrame = 0;
+        mBtpTimer = 0;
+    }
+    return result;
 }
 
-/* 00000A30-00000B30       .text setBtk__11daNpc_Co1_cFb */
-void daNpc_Co1_c::setBtk(bool) {
-    /* Nonmatching */
+BOOL daNpc_Co1_c::setBtk(bool i_inherit)
+{
+    J3DModelData* modelData = mpPrlMorf->getModel()->getModelData();
+    J3DAnmTextureSRTKey* btkRes = (J3DAnmTextureSRTKey*)dComIfG_getObjectIDRes("Co", dRes_ID_CO_BTK_CO_PEAL_e);
+    mpBtkRes = btkRes;
+    JUT_ASSERT(0x1EA, mpBtkRes != 0);
+
+    int initRes = mBtkAnm.init(modelData, mpBtkRes, TRUE, J3DFrameCtrl::EMode_LOOP, 1.0f, 0, -1, i_inherit, FALSE);
+    int notRes = 1 - initRes;
+    u32 result = notRes ? 0 : 1;
+    if ((u8)result) {
+        mBtkFrame = 0;
+    }
+    return result;
 }
 
-/* 00000B30-00000B58       .text iniTexPttrnAnm__11daNpc_Co1_cFb */
-void daNpc_Co1_c::iniTexPttrnAnm(bool) {
-    /* Nonmatching */
+
+
+BOOL daNpc_Co1_c::iniTexPttrnAnm(bool i_inherit) {
+    return setBtp(i_inherit, mTexPatternNum);
 }
 
-/* 00000B58-00000C44       .text plyTexPttrnAnm__11daNpc_Co1_cFv */
 void daNpc_Co1_c::plyTexPttrnAnm() {
-    /* Nonmatching */
+    mBtkFrame++;
+    if (mBtkFrame >= mpBtkRes->getFrameMax()) {
+        mBtkFrame = 0;
+    }
+
+    if (mTexPatternNum == 6 || mTexPatternNum == 5 || cLib_calcTimer(&mBtpTimer) == 0) {
+        mBtpFrame++;
+        if (mBtpFrame >= mpBtpRes->getFrameMax()) {
+            if (mTexPatternNum == 6 || mTexPatternNum == 5) {
+                mBtpFrame = mpBtpRes->getFrameMax();
+            } else {
+                mBtpTimer = cM_rndF(60.0f) + 30.0f;
+                mBtpFrame = 0;
+            }
+        }
+    }
 }
 
-/* 00000C44-00000C80       .text setAnm_tex__11daNpc_Co1_cFSc */
-void daNpc_Co1_c::setAnm_tex(signed char) {
-    /* Nonmatching */
+void daNpc_Co1_c::setAnm_tex(signed char i_idx) {
+    if (mTexPatternNum != i_idx) {
+        mTexPatternNum = i_idx;
+        iniTexPttrnAnm(TRUE);
+    }
 }
 
-/* 00000C80-00000D64       .text setAnm_anm__11daNpc_Co1_cFPQ211daNpc_Co1_c9anm_prm_c */
-void daNpc_Co1_c::setAnm_anm(daNpc_Co1_c::anm_prm_c*) {
-    /* Nonmatching */
+BOOL daNpc_Co1_c::setAnm_anm(anm_prm_c* i_anm) {
+    if (mCurrAnmNum == i_anm->mBckResIndex) {
+        return TRUE;
+    }
+
+    mCurrAnmNum = i_anm->mBckResIndex;
+    int bckRes = anmNum_toResID(mCurrAnmNum);
+    dNpc_setAnmIDRes(mpMorf, i_anm->mLoopMode, i_anm->mMorf, i_anm->mSpeed, bckRes, -1, "Co");
+
+    int prlBckRes = anmNum_toResID_prl(mCurrAnmNum);
+    dNpc_setAnmIDRes(mpPrlMorf, i_anm->mLoopMode, 0.0f, 0.0f, prlBckRes, -1, "Co");
+
+    mPrevMorfFrame = 0.0f;
+    mAnmLoaded = FALSE;
+    mMorfEnd = FALSE;
+    return TRUE;
 }
 
-/* 00000D64-00000DD0       .text setAnm_NUM__11daNpc_Co1_cFii */
-void daNpc_Co1_c::setAnm_NUM(int, int) {
-    /* Nonmatching */
+void daNpc_Co1_c::setAnm_NUM(int i_idx, int i_texFlag) {
+    if (i_texFlag != 0) {
+        setAnm_tex(a_anm_tbl1[i_idx].mResIndex);
+    }
+    setAnm_anm(&a_anm_tbl1[i_idx]);
 }
 
-/* 00000DD0-00000E50       .text setAnm__11daNpc_Co1_cFv */
-void daNpc_Co1_c::setAnm() {
-    /* Nonmatching */
+BOOL daNpc_Co1_c::setAnm() {
+    if (a_anm_tbl2[mAnmTagIndex].mResIndex >= 0) {
+        setAnm_tex(a_anm_tbl2[mAnmTagIndex].mResIndex);
+    }
+    if (a_anm_tbl2[mAnmTagIndex].mBckResIndex >= 0) {
+        setAnm_anm(&a_anm_tbl2[mAnmTagIndex]);
+    }
+    return TRUE;
 }
 
-/* 00000E50-00000E54       .text chg_anmTag__11daNpc_Co1_cFv */
+daNpc_Co1_c::anm_prm_c a_anm_tbl1[12] = {
+    { 0, 0, 0, 0, 8.0f, 1.0f, 2 }, { 1, 4, 0, 0, 8.0f, 1.0f, 2 },
+    { 2, 6, 0, 0, 8.0f, 1.0f, 0 }, { 3, 5, 0, 0, 8.0f, 1.0f, 0 },
+    { 4, 4, 0, 0, 8.0f, 1.0f, 2 }, { 5, 0, 0, 0, 8.0f, 1.0f, 2 },
+    { 6, 3, 0, 0, 8.0f, 1.0f, 2 }, { 7, 4, 0, 0, 8.0f, 1.0f, 2 },
+    { 8, 0, 0, 0, 8.0f, 1.0f, 0 },     { 9, 5, 0, 0, 8.0f, -1.0f, 0 },
+    { 10, 6, 0, 0, 8.0f, -1.0f, 0 }, { 7, 0, 0, 0, 8.0f, 1.0f, 2 },
+};
+
+daNpc_Co1_c::anm_prm_c a_anm_tbl2[8] = {
+    { -1, 0, 0, 0, 0.0f, 0.0f, -1 }, { 1, 4, 0, 0, 8.0f, 1.0f, 2 },
+    { -1, 0, 0, 0, 0.0f, 0.0f, -1 }, { 3, 5, 0, 0, 8.0f, 1.0f, 0 },
+    { 7, 0, 0, 0, 8.0f, 1.0f, 2 }, { -1, 0, 0, 0, 0.0f, 0.0f, -1 },
+    { 4, 4, 0, 0, 8.0f, 1.0f, 2 }, { 10, 6, 0, 0, 8.0f, -1.0f, 0 },
+};
+
 void daNpc_Co1_c::chg_anmTag() {
-    /* Nonmatching */
 }
 
-/* 00000E54-00000E58       .text control_anmTag__11daNpc_Co1_cFv */
 void daNpc_Co1_c::control_anmTag() {
-    /* Nonmatching */
 }
 
-/* 00000E58-00000EF8       .text chg_anmAtr__11daNpc_Co1_cFUc */
-void daNpc_Co1_c::chg_anmAtr(unsigned char) {
-    /* Nonmatching */
+void daNpc_Co1_c::chg_anmAtr(unsigned char i_atr) {
+    if (i_atr >= ARRAY_SIZE(a_anm_tbl3) || i_atr == mCurrAnmAtr) {
+        return;
+    }
+    mActionIndex = 1;
+    switch (i_atr) {
+    case 3:
+    case 4:
+    case 5:
+    case 7:
+    case 11:
+        mActionIndex = 0;
+        break;
+    case 13:
+        set_target(1);
+        break;
+    }
+    mCurrAnmAtr = i_atr;
+    setAnm_ATR(TRUE);
 }
 
-/* 00000EF8-00000FF4       .text control_anmAtr__11daNpc_Co1_cFv */
 void daNpc_Co1_c::control_anmAtr() {
-    /* Nonmatching */
+    switch (mCurrAnmAtr) {
+    case 0:
+    case 1:
+    case 4:
+    case 5:
+    case 6:
+    case 10:
+    case 11:
+    case 12:
+    case 13:
+        break;
+    case 2:
+        if (mMorfEnd) {
+            setAnm_NUM(7, TRUE);
+            mCurrAnmAtr = 6;
+        }
+        break;
+    case 3:
+        if (mMorfEnd) {
+            setAnm_NUM(4, TRUE);
+            mCurrAnmAtr = 10;
+        }
+        break;
+    case 7:
+        if (mMorfEnd) {
+            setAnm_NUM(6, TRUE);
+            mCurrAnmAtr = 5;
+        }
+        break;
+    case 8:
+        if (mMorfEnd) {
+            setAnm_NUM(7, TRUE);
+            mCurrAnmAtr = 6;
+        }
+        break;
+    case 9:
+        if (mMorfEnd) {
+            setAnm_NUM(1, TRUE);
+            mCurrAnmAtr = 1;
+        }
+        break;
+    }
 }
 
-/* 00000FF4-0000105C       .text setAnm_ATR__11daNpc_Co1_cFi */
-void daNpc_Co1_c::setAnm_ATR(int) {
-    /* Nonmatching */
+daNpc_Co1_c::anm_prm_c a_anm_tbl3[14] = {
+    { 0, 0, 0, 0, 8.0f, 1.0f, 2 }, { 1, 4, 0, 0, 8.0f, 1.0f, 2 },
+    { 3, 5, 0, 0, 8.0f, 1.0f, 0 }, { 8, 0, 0, 0, 8.0f, 1.0f, 0 },
+    { 5, 0, 0, 0, 8.0f, 1.0f, 2 }, { 6, 3, 0, 0, 8.0f, 1.0f, 2 },
+    { 7, 4, 0, 0, 8.0f, 1.0f, 2 }, { 2, 6, 0, 0, 8.0f, 1.0f, 0 },
+    { 10, 6, 0, 0, 8.0f, -1.0f, 0 }, { 9, 5, 0, 0, 8.0f, -1.0f, 0 },
+    { 4, 4, 0, 0, 8.0f, 1.0f, 2 }, { 5, 4, 0, 0, 8.0f, 1.0f, 2 },
+    { 5, 0, 0, 0, 8.0f, 1.0f, 2 }, { 6, 3, 0, 0, 8.0f, 1.0f, 2 },
+};
+
+void daNpc_Co1_c::setAnm_ATR(int i_updateTex) {
+    if (i_updateTex != 0) {
+        setAnm_tex(a_anm_tbl3[mCurrAnmAtr].mResIndex);
+    }
+    setAnm_anm(&a_anm_tbl3[mCurrAnmAtr]);
 }
 
-/* 0000105C-00001120       .text anmAtr__11daNpc_Co1_cFUs */
-void daNpc_Co1_c::anmAtr(unsigned short) {
-    /* Nonmatching */
+void daNpc_Co1_c::anmAtr(u16 i_msgStatus) {
+    switch (i_msgStatus) {
+    case fopMsgStts_MSG_TYPING_e: {
+        if (mMsgAttrCount == 0) {
+            mCurrAnmAtr = 0xFF;
+            chg_anmAtr(dComIfGp_getMesgAnimeAttrInfo());
+            ++mMsgAttrCount;
+        }
+        u8 tag = dComIfGp_getMesgAnimeTagInfo();
+        dComIfGp_clearMesgAnimeTagInfo();
+        if (tag != 0xFF && mCurrAnmTag != tag) {
+            mCurrAnmTag = tag;
+            chg_anmTag();
+        }
+        break;
+    }
+    case fopMsgStts_MSG_DISPLAYED_e:
+        mMsgAttrCount = 0;
+        break;
+    }
+    control_anmTag();
+    control_anmAtr();
 }
 
-/* 00001120-000011B8       .text eventOrder__11daNpc_Co1_cFv */
 void daNpc_Co1_c::eventOrder() {
-    /* Nonmatching */
+    s8 state = mEventState;
+    if (state == 1 || state == 2) {
+        eventInfo.onCondition(dEvtCnd_CANTALK_e);
+        eventInfo.onCondition(dEvtCnd_CANTALKITEM_e);
+        if (mEventState == 1) {
+            fopAcM_orderSpeakEvent(this);
+        }
+    } else if (state >= 3) {
+        mEvtIdxSel = state - 3;
+        s16 evtIdx = mEventIdx[mEvtIdxSel];
+        fopAcM_orderOtherEventId(this, evtIdx, EVT_NO_EVENT, EVT_NO_TARGET, 0, 1);
+    }
 }
 
-/* 000011B8-00001288       .text checkOrder__11daNpc_Co1_cFv */
 void daNpc_Co1_c::checkOrder() {
-    /* Nonmatching */
+    if (eventInfo.checkCommandDemoAccrpt()) {
+        if (dComIfGp_evmng_startCheck(mEventIdx[mEvtIdxSel])) {
+            switch (mEvtIdxSel) {
+            case 0:
+                break;
+            case 1:
+                actor_status &= ~fopAcStts_UNK4000_e;
+                break;
+            case 2:
+                mActionIndex = 0;
+                break;
+            default:
+                break;
+            }
+            mEventState = 0;
+        }
+    } else if (eventInfo.checkCommandTalk()) {
+        if (mEventState == 1 || mEventState == 2) {
+            mEventState = 0;
+            mHide = TRUE;
+        }
+    }
 }
 
-/* 00001288-000013AC       .text setCollision_SP___11daNpc_Co1_cFv */
 void daNpc_Co1_c::setCollision_SP_() {
-    /* Nonmatching */
+    if (mHide) return;
+
+    cXyz pos;
+    f32 radius, height;
+    if (mCurrAnmNum == 1) {
+        mDoMtx_stack_c::transS(current.pos);
+        mDoMtx_stack_c::YrotM(current.angle.y);
+        cXyz off(0.0f, 0.0f, -20.0f);
+        radius = 70.0f;
+        height = 60.0f;
+        MTXMultVec(mDoMtx_stack_c::get(), &off, &pos);
+    } else {
+        pos.set(current.pos.x, current.pos.y, current.pos.z);
+        radius = 40.0f;
+        height = 90.0f;
+    }
+
+    mCyl.SetC(pos);
+    mCyl.SetR(radius);
+    mCyl.SetH(height);
+    dComIfG_Ccsp()->Set(&mCyl);
 }
 
-/* 000013AC-000014B8       .text set_target__11daNpc_Co1_cFi */
-void daNpc_Co1_c::set_target(int) {
-    /* Nonmatching */
+void daNpc_Co1_c::set_target(int i_type) {
+    switch (i_type) {
+    case 0:
+        mActionIndex = 0;
+        break;
+    case 1: {
+        cXyz vec = dNpc_playerEyePos(-20.0f);
+        f32 dist = fopAcM_searchPlayerDistance(this);
+        s16 angle = fopAcM_searchPlayerAngleY(this);
+        angle -= BAM_45DEG;
+        mDoMtx_stack_c::transS(current.pos.x, vec.y, current.pos.z);
+        mDoMtx_stack_c::YrotM(angle);
+        vec.x = 0.0f;
+        vec.y = 0.0f;
+        vec.z = dist;
+        MTXMultVec(mDoMtx_stack_c::get(), &vec, &mEventPos);
+        mActionIndex = 2;
+        break;
+    }
+    }
 }
 
-/* 000014B8-00001554       .text chk_talk__11daNpc_Co1_cFv */
-void daNpc_Co1_c::chk_talk() {
-    /* Nonmatching */
+
+BOOL daNpc_Co1_c::chk_talk() {
+    BOOL ret = TRUE;
+    mGetItem = dItemNo_NONE_e;
+    if (dComIfGp_event_chkTalkXY()) {
+        if (dComIfGp_evmng_ChkPresentEnd()) {
+            mGetItem = dComIfGp_event_getPreItemNo();
+        } else {
+            ret = 0;
+        }
+    }
+    return ret;
 }
 
-/* 00001554-00001594       .text chk_partsNotMove__11daNpc_Co1_cFv */
-void daNpc_Co1_c::chk_partsNotMove() {
-    /* Nonmatching */
+BOOL daNpc_Co1_c::chk_partsNotMove() {
+    BOOL ret = FALSE;
+    if (mPrevJntHeadX == m_jnt.getHead_y() &&
+        mPrevJntBackboneX == m_jnt.getBackbone_y() &&
+        mPrevAngleY == current.angle.y) {
+        ret = TRUE;
+    }
+    return ret;
 }
 
-/* 00001594-00001734       .text lookBack__11daNpc_Co1_cFv */
 void daNpc_Co1_c::lookBack() {
-    /* Nonmatching */
+    mPrevJntHeadX = m_jnt.getHead_y();
+    mPrevJntBackboneX = m_jnt.getBackbone_y();
+    mPrevAngleY = current.angle.y;
+
+    cXyz dstPos;
+    cXyz srcPos = current.pos;
+    srcPos.y = eyePos.y;
+    dstPos.set(0.0f, 0.0f, 0.0f);
+    cXyz* dstPtr = NULL;
+    s16 targetY = current.angle.y;
+    bool headOnlyFollow = mInitDone;
+
+    switch (mActionIndex) {
+    case 1:
+        dstPos = dNpc_playerEyePos(-20.0f);
+        dstPtr = &dstPos;
+        srcPos = current.pos;
+        srcPos.y = eyePos.y;
+        break;
+    case 2:
+        dstPos = mEventPos;
+        dstPtr = &dstPos;
+        srcPos = current.pos;
+        srcPos.y = eyePos.y;
+        break;
+    case 3:
+        targetY = mDesiredYRot;
+        break;
+    }
+
+    cLib_addCalcAngleS2(&mHeadAngle, l_HIO.mNpc.mMaxTurnVel, 4, BAM_11DEG);
+    if (!m_jnt.trnChk()) {
+        mHeadAngle = 0;
+    }
+
+    m_jnt.lookAtTarget(&current.angle.y, dstPtr, srcPos, targetY, mHeadAngle, headOnlyFollow);
 }
 
-/* 00001734-000017EC       .text next_msgStatus__11daNpc_Co1_cFPUl */
-void daNpc_Co1_c::next_msgStatus(unsigned long*) {
-    /* Nonmatching */
+
+u16 daNpc_Co1_c::next_msgStatus(u32* pMsgNo) {
+    u16 ret = fopMsgStts_MSG_CONTINUES_e;
+    switch (*pMsgNo) {
+        case MSG_CO_HAS_LETTER: *pMsgNo = MSG_CO_GIVE_LETTER; break;
+        case MSG_CO_GIVE_LETTER: *pMsgNo = MSG_CO_GAVE_LETTER; break;
+        case MSG_CO_LETTER_PASSED: *pMsgNo = MSG_CO_LETTER_PASSED_1; break;
+        case MSG_CO_LETTER_PASSED_1: *pMsgNo = MSG_CO_LETTER_PASSED_2; break;
+        case MSG_CO_LETTER_PASSED_2: *pMsgNo = MSG_CO_LETTER_PASSED_3; break;
+        case MSG_CO_LETTER_PASSED_3: *pMsgNo = MSG_CO_LETTER_PASSED_4; break;
+        case MSG_CO_LETTER_PASSED_4: *pMsgNo = MSG_CO_LETTER_PASSED_5; break;
+        case MSG_CO_LETTER_PASSED_5: *pMsgNo = MSG_CO_LETTER_PASSED_6; break;
+        case MSG_CO_LETTER_PASSED_6: *pMsgNo = MSG_CO_LETTER_DONE; break;
+        case MSG_CO_DELIVERED_START: *pMsgNo = MSG_CO_DELIVERED_END; break;
+        case MSG_CO_DELIVERED_END: *pMsgNo = MSG_CO_ENDING; break;
+    default: ret = fopMsgStts_MSG_ENDS_e; break;
+    }
+    return ret;
 }
 
-/* 000017EC-00001894       .text getMsg_CO1_0__11daNpc_Co1_cFv */
-void daNpc_Co1_c::getMsg_CO1_0() {
-    /* Nonmatching */
+u32 daNpc_Co1_c::getMsg_CO1_0() {
+    if (mGetItem == dItemNo_FATHER_LETTER_e) {
+        return MSG_CO_GOT_LETTER;
+    }
+    if (mGetItem != dItemNo_NONE_e) {
+        return MSG_CO_GOT_ITEM;
+    }
+
+    if (mHasLetter) {
+        return MSG_CO_HAS_LETTER;
+    }
+
+    if (dNpc_chkLetterPassed()) {
+        if (dComIfGs_isEventBit(EVTBIT_PRL_FLW_DONE)) {
+            return MSG_CO_DELIVERED_START;
+        }
+        return MSG_CO_LETTER_PASSED;
+    }
+
+    if (dComIfGs_isEventBit(EVTBIT_GREETED)) {
+        return MSG_CO_ALREADY_MET;
+    }
+    return MSG_CO_GREETING;
 }
 
-/* 00001894-000018D0       .text getMsg__11daNpc_Co1_cFv */
-void daNpc_Co1_c::getMsg() {
-    /* Nonmatching */
+u32 daNpc_Co1_c::getMsg() {
+    u32 ret = 0;
+    switch (mInitStep) {
+    case 0:
+        ret = getMsg_CO1_0();
+        break;
+    }
+    return ret;
 }
 
-/* 000018D0-00001950       .text chkAttention__11daNpc_Co1_cFv */
-void daNpc_Co1_c::chkAttention() {
-    /* Nonmatching */
+BOOL daNpc_Co1_c::chkAttention() {
+    dAttention_c* attention = &dComIfGp_getAttention();
+    if (attention->LockonTruth()) {
+        return this == attention->LockonTarget(0) ? 1 : 0;
+    } else {
+        return this == attention->ActionTarget(0) ? 1 : 0;
+    }
 }
 
-/* 00001950-00001A44       .text setAttention__11daNpc_Co1_cFb */
-void daNpc_Co1_c::setAttention(bool) {
-    /* Nonmatching */
+void daNpc_Co1_c::setAttention(bool i_forceUpdate) {
+    if (mCurrAnmNum == 1) {
+        mDoMtx_stack_c::transS(current.pos);
+        mDoMtx_stack_c::YrotM(current.angle.y);
+        cXyz off(0.0f, 60.0f, -50.0f);
+        MTXMultVec(mDoMtx_stack_c::get(), &off, &attention_info.position);
+    } else {
+        attention_info.position.set(current.pos.x, current.pos.y + l_HIO.mNpc.mAttnYOff, current.pos.z);
+    }
+
+    if (mAttnScratch || i_forceUpdate) {
+        eyePos.set(mHeadPos.x, mHeadPos.y, mHeadPos.z);
+    }
 }
 
-/* 00001A44-00001A60       .text charDecide__11daNpc_Co1_cFi */
-void daNpc_Co1_c::charDecide(int) {
-    /* Nonmatching */
+BOOL daNpc_Co1_c::charDecide(int i_type) {
+    mType = 0;
+    mInitStep = -1;
+    mInitStep = 0;
+    return TRUE;
 }
 
-/* 00001A60-00001A9C       .text eInit_MDR___11daNpc_Co1_cFv */
+
+
 void daNpc_Co1_c::eInit_MDR_() {
-    /* Nonmatching */
+    setAnm_NUM(10, TRUE);
+    mActionIndex = 0;
 }
 
-/* 00001A9C-00001AC4       .text eInit_RED_LTR___11daNpc_Co1_cFv */
 void daNpc_Co1_c::eInit_RED_LTR_() {
-    /* Nonmatching */
+    setAnm_NUM(8, TRUE);
 }
 
-/* 00001AC4-00001B50       .text event_actionInit__11daNpc_Co1_cFi */
-void daNpc_Co1_c::event_actionInit(int) {
-    /* Nonmatching */
+void daNpc_Co1_c::event_actionInit(int i_staffIdx) {
+    int* actNo = dComIfGp_evmng_getMyIntegerP(i_staffIdx, "ActNo");
+    if (actNo != NULL) {
+        mEventActNo = *actNo;
+        switch (mEventActNo) {
+        case 0:
+            eInit_MDR_();
+            break;
+        case 1:
+            eInit_RED_LTR_();
+            break;
+        }
+    }
 }
 
-/* 00001B50-00001BA8       .text eMove_MDR___11daNpc_Co1_cFv */
-void daNpc_Co1_c::eMove_MDR_() {
-    /* Nonmatching */
+BOOL daNpc_Co1_c::eMove_MDR_() {
+    f32 frame = mpMorf->getFrame();
+    s32 frameInt = (s32)frame;
+    u32 ret = frameInt ? 0 : 1;
+    if ((u8)ret) {
+        setAnm_NUM(11, TRUE);
+    }
+    return ret;
 }
 
-/* 00001BA8-00001C34       .text eMove_RED_LTR___11daNpc_Co1_cFv */
-void daNpc_Co1_c::eMove_RED_LTR_() {
-    /* Nonmatching */
+
+BOOL daNpc_Co1_c::eMove_RED_LTR_() {
+    BOOL ret = FALSE;
+    if (mMorfEnd) {
+        switch (mCurrAnmNum) {
+        case 8:
+            setAnm_NUM(4, TRUE);
+            break;
+        case 4:
+            mNextAnmNum = 7;
+            setStt(2);
+            ret = TRUE;
+            break;
+        default:
+            setAnm_NUM(8, TRUE);
+            break;
+        }
+    }
+    return ret;
 }
 
-/* 00001C34-00001C84       .text event_action__11daNpc_Co1_cFv */
-void daNpc_Co1_c::event_action() {
-    /* Nonmatching */
+BOOL daNpc_Co1_c::event_action() {
+    switch (mEventActNo) {
+    case 0:
+        return eMove_MDR_();
+    case 1:
+        return eMove_RED_LTR_();
+    default:
+        return TRUE;
+    }
 }
 
-/* 00001C84-00001D70       .text privateCut__11daNpc_Co1_cFi */
-void daNpc_Co1_c::privateCut(int) {
-    /* Nonmatching */
+void daNpc_Co1_c::privateCut(int staffIdx) {
+    if (staffIdx == -1) return;
+
+    static const char* a_cut_tbl[] = {"ACTION"};
+
+    int actIdx = dComIfGp_evmng_getMyActIdx(staffIdx, (char**)a_cut_tbl, 1, TRUE, 0);
+    mCurActIdx = actIdx;
+
+    if (mCurActIdx == -1) {
+        dComIfGp_evmng_cutEnd(staffIdx);
+        return;
+    }
+
+    if (dComIfGp_evmng_getIsAddvance(staffIdx)) {
+        switch (mCurActIdx) {
+        case 0:
+            event_actionInit(staffIdx);
+            break;
+        }
+    }
+
+    u32 done;
+    switch (mCurActIdx) {
+    case 0:
+        done = event_action();
+        break;
+    default:
+        done = TRUE;
+        break;
+    }
+
+    u32 doneByte = done;
+    if ((doneByte << 24) >> 24) {
+        dComIfGp_evmng_cutEnd(staffIdx);
+    }
 }
 
-/* 00001D70-00001D90       .text endEvent__11daNpc_Co1_cFv */
+
 void daNpc_Co1_c::endEvent() {
-    /* Nonmatching */
+    dComIfGp_event_reset();
+    mCurrAnmAtr = 0xFF;
 }
 
-/* 00001D90-00001DC8       .text isEventEntry__11daNpc_Co1_cFv */
-void daNpc_Co1_c::isEventEntry() {
-    /* Nonmatching */
+s32 daNpc_Co1_c::isEventEntry() {
+    return dComIfGp_evmng_getMyStaffId(mDemoEventCut.getActorName());
 }
 
-/* 00001DC8-00001EC0       .text event_proc__11daNpc_Co1_cFi */
-void daNpc_Co1_c::event_proc(int) {
-    /* Nonmatching */
+void daNpc_Co1_c::event_proc(int staffIdx) {
+    s16 evtIdx = mEventIdx[mEvtIdxSel];
+    if (dComIfGp_evmng_endCheck(evtIdx)) {
+        switch (mEvtIdxSel) {
+        case 0:
+            dComIfGs_onEventBit(EVTBIT_PRL_FLW_DONE);
+            setStt(4);
+            break;
+        case 1:
+            dComIfGs_onEventBit(EVTBIT_CONTACT_DONE);
+            break;
+        case 2:
+            mEventState = 1;
+            break;
+        default:
+            break;
+        }
+        endEvent();
+    } else {
+        if (!mDemoEventCut.cutProc()) {
+            privateCut(staffIdx);
+        }
+        lookBack();
+    }
 }
 
-/* 00001EC0-00001F6C       .text set_action__11daNpc_Co1_cFM11daNpc_Co1_cFPCvPvPv_iPv */
-void daNpc_Co1_c::set_action(int (daNpc_Co1_c::*)(void*), void*) {
-    /* Nonmatching */
+BOOL daNpc_Co1_c::set_action(ActionFunc i_action, void* i_param) {
+    if (mCurrActionFunc != i_action) {
+        if (mCurrActionFunc != NULL) {
+            mActionState = 9;
+            (this->*mCurrActionFunc)(i_param);
+        }
+        mCurrActionFunc = i_action;
+        mActionState = 0;
+        (this->*mCurrActionFunc)(i_param);
+    }
+    return TRUE;
 }
 
-/* 00001F6C-00001FD4       .text setStt__11daNpc_Co1_cFSc */
-void daNpc_Co1_c::setStt(signed char) {
-    /* Nonmatching */
+void daNpc_Co1_c::setStt(signed char i_stt) {
+    mTimer = 0;
+    mAnmTagIndex = i_stt;
+    switch (mAnmTagIndex) {
+    case 0:
+    case 1:
+        break;
+    case 2:
+        mCurrAnmAtr = 0xFF;
+        mActionIndex = 1;
+        break;
+    case 7:
+        mActionIndex = 0;
+        break;
+    }
+    setAnm();
 }
 
-/* 00001FD4-0000205C       .text wait_1__11daNpc_Co1_cFv */
-void daNpc_Co1_c::wait_1() {
-    /* Nonmatching */
+BOOL daNpc_Co1_c::wait_1() {
+    if (mEventState == 1 || mEventState >= 3) {
+        return TRUE;
+    }
+
+    if (mHide) {
+        u8 talked = chk_talk();
+        if (talked) {
+            mNextAnmNum = 4;
+            setStt(3);
+        }
+        return TRUE;
+    }
+
+    mEventState = 2;
+    return TRUE;
 }
 
-/* 0000205C-00002114       .text wait_2__11daNpc_Co1_cFv */
-void daNpc_Co1_c::wait_2() {
-    /* Nonmatching */
+BOOL daNpc_Co1_c::wait_2() {
+    if (mHide) {
+        u8 talked = chk_talk();
+        if (talked) {
+            if (dNpc_chkLetterPassed()) {
+                mNextAnmNum = 7;
+            } else {
+                mNextAnmNum = 4;
+            }
+            setStt(2);
+        }
+        return TRUE;
+    }
+
+    mEventState = 2;
+
+    if (mAttnFlag) {
+        mTimer = 60;
+    }
+
+    if (cLib_calcTimer(&mTimer) != 0) {
+        mActionIndex = 1;
+    } else {
+        mActionIndex = 0;
+    }
+
+    return TRUE;
 }
 
-/* 00002114-00002150       .text wakeup__11daNpc_Co1_cFv */
-void daNpc_Co1_c::wakeup() {
-    /* Nonmatching */
+BOOL daNpc_Co1_c::wakeup() {
+    if (mMorfEnd) {
+        mNextAnmNum = 4;
+        setStt(2);
+    }
+    return TRUE;
 }
 
-/* 00002150-0000234C       .text talk_1__11daNpc_Co1_cFv */
-void daNpc_Co1_c::talk_1() {
-    /* Nonmatching */
+BOOL daNpc_Co1_c::talk_1() {
+    u8 partsNotMove = chk_partsNotMove();
+
+    if (mEventState == 1 || mEventState >= 3) {
+        return TRUE;
+    }
+
+    if (dNpc_chkLetterPassed() && !mHasLetter && !dComIfGs_isEventBit(EVTBIT_PRL_FLW_DONE)) {
+        if (mEventState != 3) {
+            mGetItem = dItemNo_NONE_e;
+            mHide = FALSE;
+            endEvent();
+            mEventState = 3;
+        }
+        return TRUE;
+    }
+
+    talk(1);
+
+    if (mpCurrMsg != NULL) {
+        switch (mpCurrMsg->mStatus) {
+        case fopMsgStts_MSG_DESTROYED_e:
+            switch (mCurrMsgNo) {
+            case MSG_CO_GREETING:
+                dComIfGs_onEventBit(EVTBIT_GREETED);
+                break;
+            case MSG_CO_LETTER_DONE:
+                dComIfGs_onEventBit(EVTBIT_PRL_FLW_DONE);
+                break;
+            case MSG_CO_GAVE_LETTER:
+                mHasLetter = FALSE;
+                break;
+            }
+            if (mGetItem == dItemNo_FATHER_LETTER_e) {
+                mEventState = 5;
+                dComIfGp_evmng_CancelPresent();
+                dComIfGs_setReserveItemEmpty();
+                endEvent();
+                mHasLetter = TRUE;
+            } else {
+                setStt(mNextAnmNum);
+                if (mNextAnmNum != 7) {
+                    mHide = FALSE;
+                    endEvent();
+                }
+            }
+            mGetItem = dItemNo_NONE_e;
+            mTimer = 60;
+            break;
+        case fopMsgStts_BOX_OPENING_e:
+        case fopMsgStts_MSG_TYPING_e:
+            if (mCurrMsgNo == MSG_CO_ENDING) {
+                mActionIndex = 0;
+            }
+            break;
+        }
+    }
+
+    return partsNotMove;
 }
 
-/* 0000234C-000023BC       .text toru_1__11daNpc_Co1_cFv */
-void daNpc_Co1_c::toru_1() {
-    /* Nonmatching */
+BOOL daNpc_Co1_c::toru_1() {
+    if (mHide) {
+        if (mGetItem == dItemNo_FATHER_LETTER_e) {
+            mGetItem = dItemNo_NONE_e;
+            setAnm_NUM(8, TRUE);
+        }
+        if (mMorfEnd) {
+            setStt(6);
+        }
+    }
+    return FALSE;
 }
 
-/* 000023BC-000023F8       .text read_1__11daNpc_Co1_cFv */
-void daNpc_Co1_c::read_1() {
-    /* Nonmatching */
+BOOL daNpc_Co1_c::read_1() {
+    if (mMorfEnd) {
+        mNextAnmNum = 7;
+        setStt(2);
+    }
+    return FALSE;
 }
 
-/* 000023F8-00002458       .text modoru__11daNpc_Co1_cFv */
-void daNpc_Co1_c::modoru() {
-    /* Nonmatching */
+BOOL daNpc_Co1_c::modoru() {
+    if ((s32)mpMorf->getFrame() == 0) { // (s32) cast forces fctiwz float-to-int conversion
+        setStt(4);
+        mHide = FALSE;
+        endEvent();
+    }
+    return TRUE;
 }
 
-/* 00002458-000025DC       .text wait_action1__11daNpc_Co1_cFPv */
-void daNpc_Co1_c::wait_action1(void*) {
-    /* Nonmatching */
+BOOL daNpc_Co1_c::wait_action1(void*) {
+    s8 state = mActionState;
+    switch (state) {
+    case 0:
+        if (dNpc_chkLetterPassed()) {
+            setStt(4);
+        } else {
+            if (!dComIfGs_isEventBit(EVTBIT_CONTACT_DONE)) {
+                mEventState = 4;
+            }
+            setStt(1);
+        }
+
+        mLight.mPos = current.pos;
+        mLight.mPower = 0.0f;
+        dKy_plight_set(&mLight);
+
+        mActionState++;
+        break;
+    case 1:
+    case 2:
+    case 3:
+        mAttnFlag = chkAttention();
+
+        switch (mAnmTagIndex) {
+        case 1:
+            mAttnScratch = wait_1();
+            break;
+        case 2:
+        case 3:
+            mAttnScratch = talk_1();
+            break;
+        case 4:
+            mAttnScratch = wakeup();
+            break;
+        case 5:
+            mAttnScratch = wait_2();
+            break;
+        case 6:
+            mAttnScratch = toru_1();
+            break;
+        case 7:
+            mAttnScratch = read_1();
+            break;
+        case 0:
+            mAttnScratch = modoru();
+            break;
+        }
+
+        lookBack();
+        break;
+    case 9:
+        break;
+    }
+
+    return TRUE;
 }
 
-/* 000025DC-0000271C       .text demo__11daNpc_Co1_cFv */
-void daNpc_Co1_c::demo() {
-    /* Nonmatching */
+
+BOOL daNpc_Co1_c::demo() {
+    if (demoActorID == 0) {
+        if (mDemo) {
+            mDemo = false;
+        }
+    } else {
+        mDemo = true;
+
+        dDemo_actor_c* demoActor = dComIfGp_demo_getActor(demoActorID);
+
+        if (mpBtpRes != NULL) {
+            mBtpFrame++;
+            if (mBtpFrame >= mpBtpRes->getFrameMax()) {
+                mBtpFrame = mpBtpRes->getFrameMax();
+            }
+        }
+        J3DAnmTexPattern* btpData = demoActor->getP_BtpData("Co");
+        if (btpData != NULL) {
+            mpBtpRes = btpData;
+            J3DModelData* modelData = mpMorf->getModel()->getModelData();
+            if (mBtpAnm.init(modelData, mpBtpRes, TRUE, J3DFrameCtrl::EMode_LOOP, 1.0f, 0, -1, TRUE, FALSE)) {
+                mTexPatternNum = 7;
+                mBtpFrame = 0;
+            }
+        }
+
+#if VERSION != 0
+        dDemo_setDemoData(this, 0x6A, mpMorf, "Co", 0, NULL, 0, 0);
+#else
+        dDemo_setDemoData(this, 0x6A, mpMorf, "Co", 0, NULL);
+#endif
+    }
+    return mDemo;
 }
 
-/* 0000271C-000027AC       .text shadowDraw__11daNpc_Co1_cFv */
 void daNpc_Co1_c::shadowDraw() {
-    /* Nonmatching */
+    cXyz pos(current.pos.x, current.pos.y + 150.0f, current.pos.z);
+    J3DModel* model = mpMorf->getModel();
+
+    mShadowIdx = dComIfGd_setShadow(mShadowIdx, 1, model, &pos, 800.0f, 40.0f,
+                                     current.pos.y, mObjAcch.GetGroundH(),
+                                     mObjAcch.m_gnd, &tevStr, 0, 1.0f);
 }
 
-/* 000027AC-0000295C       .text _draw__11daNpc_Co1_cFv */
+static const u32 a_gx_tev_color[] = {
+    0xFF000080,
+    0x0000FF80,
+    0x00FF0080,
+};
+
 BOOL daNpc_Co1_c::_draw() {
-    /* Nonmatching */
+    J3DModel* mainModel = mpMorf->getModel();
+    J3DModelData* mainModelData = mainModel->getModelData();
+    J3DModel* prlModel = mpPrlMorf->getModel();
+    J3DModelData* prlModelData = prlModel->getModelData();
+
+    if (mInitFlags || mDemoFlags) return TRUE;
+
+    g_env_light.settingTevStruct(TEV_TYPE_ACTOR, &current.pos, &tevStr);
+
+    dKy_tevstr_c* tr = &tevStr;
+    u32 alpha = l_HIO.mNpc.mAlpha & 0xFF;
+    s32 invAlpha = 255 - alpha;
+    f32 calc = (f32)invAlpha * mOscillation;
+    s32 iCalc = (s32)calc;
+    tr->mLightObj.mInfo.mColor.r = (iCalc & 0xFF) + (u8)alpha;
+
+    g_env_light.setLightTevColorType(mainModel, tr);
+
+    mBtpAnm.entry(mainModelData, mBtpFrame);
+    mpMorf->entryDL();
+    mainModelData->getMaterialTable().removeTexNoAnimator(mBtpAnm.getBtpAnm());
+
+    g_env_light.setLightTevColorType(prlModel, &tevStr);
+
+    mBtkAnm.entry(prlModelData, mBtkFrame);
+    mpPrlMorf->entryDL();
+    prlModelData->getMaterialTable().removeTexMtxAnimator(mBtkAnm.getBtkAnm());
+
+    if (mDrawHandR) {
+        g_env_light.setLightTevColorType(mpItmModel, &tevStr);
+        mDoExt_modelEntryDL(mpItmModel);
+    }
+
+    shadowDraw();
+    dSnap_RegistFig(DSNAP_TYPE_UNK8B, this, 1.0f, 1.0f, 1.0f);
+
+    return TRUE;
 }
 
-/* 0000295C-00002B08       .text _execute__11daNpc_Co1_cFv */
+
 BOOL daNpc_Co1_c::_execute() {
-    /* Nonmatching */
+    if (!mExecStarted) {
+        mBkPos = current.pos;
+        mBkAngleX = current.angle.x;
+        mBkAngleY = current.angle.y;
+        mBkAngleZ = current.angle.z;
+        mExecStarted = TRUE;
+    }
+
+    m_jnt.setParam(
+        l_HIO.mNpc.mMaxBackboneX, l_HIO.mNpc.mMaxBackboneY,
+        l_HIO.mNpc.mMinBackboneX, l_HIO.mNpc.mMinBackboneY,
+        l_HIO.mNpc.mMaxHeadX, l_HIO.mNpc.mMaxHeadY,
+        l_HIO.mNpc.mMinHeadX, l_HIO.mNpc.mMinHeadY,
+        l_HIO.mNpc.mMaxTurnStep
+    );
+
+    if (mInitFlags) {
+        if (demoActorID == 0) {
+            return TRUE;
+        }
+    }
+
+    mLookFlags = 0;
+    mInitFlags = 0;
+
+    checkOrder();
+
+    u32 demoResult = demo();
+    if (((demoResult << 24) >> 24) == 0) {
+        int staffId = -1;
+        if (dComIfGp_event_runCheck()) {
+            if (!eventInfo.checkCommandTalk()) {
+                staffId = isEventEntry();
+            }
+        }
+
+        if (staffId >= 0) {
+            event_proc(staffId);
+        } else {
+            (this->*mCurrActionFunc)(NULL);
+        }
+
+        if (!mLookFlags) {
+            fopAcM_posMoveF(this, mStts.GetCCMoveP());
+        }
+
+        if (!mNoPosMove) {
+            shape_angle = current.angle;
+        }
+    }
+
+    eventOrder();
+    setMtx(FALSE);
+
+    if (!mDemo) {
+        setCollision_SP_();
+    }
+
+    return TRUE;
 }
 
-/* 00002B08-00002B6C       .text _delete__11daNpc_Co1_cFv */
+
 BOOL daNpc_Co1_c::_delete() {
-    /* Nonmatching */
+    dComIfG_resDelete(&mPhs, "Co");
+    dKy_plight_cut(&mLight);
+    if (heap != NULL && mpMorf != NULL) {
+        mpMorf->stopZelAnime();
+    }
+    return TRUE;
 }
 
-/* 00002B6C-00002B8C       .text CheckCreateHeap__FP10fopAc_ac_c */
-static BOOL CheckCreateHeap(fopAc_ac_c*) {
-    /* Nonmatching */
+
+
+
+
+static BOOL CheckCreateHeap(fopAc_ac_c* actor) {
+    return ((daNpc_Co1_c*)actor)->CreateHeap();
 }
 
-/* 00002B8C-00002CAC       .text _create__11daNpc_Co1_cFv */
 cPhs_State daNpc_Co1_c::_create() {
-    /* Nonmatching */
+    fopAcM_ct_Retail(this, daNpc_Co1_c);
+
+    cPhs_State resLoad = dComIfG_resLoad(&mPhs, "Co");
+    if (resLoad != cPhs_COMPLEATE_e) {
+        return resLoad;
+    }
+
+    if (!(charDecide(fopAcM_GetParam(this) & CHAR_TYPE_MASK) & 0xFF)) {
+        return cPhs_ERROR_e;
+    }
+
+    enum { HEAP_SIZE = 0x272E0 };
+    static int a_size_tbl[] = { HEAP_SIZE };
+
+    if (!fopAcM_entrySolidHeap(this, CheckCreateHeap, a_size_tbl[mType])) {
+        return cPhs_ERROR_e;
+    }
+
+    fopAcM_SetMtx(this, mpMorf->getModel()->getBaseTRMtx());
+    fopAcM_setCullSizeBox(this, -40.0f, -20.0f, -100.0f, 40.0f, 100.0f, 60.0f);
+
+    return (createInit() & 0xFF) ? resLoad : cPhs_ERROR_e;
 }
 
-/* 00003150-000033C0       .text create_Anm__11daNpc_Co1_cFv */
-void daNpc_Co1_c::create_Anm() {
-    /* Nonmatching */
+
+J3DModelData* daNpc_Co1_c::create_Anm() {
+    J3DModelData* a_mdl_dat = (J3DModelData*)dComIfG_getObjectIDRes("Co", dRes_ID_CO_BDL_CO_e);
+    JUT_ASSERT(0x81F, a_mdl_dat != 0);
+
+    mDoExt_McaMorf* morf = new mDoExt_McaMorf(
+        a_mdl_dat, NULL, NULL,
+        (J3DAnmTransform*)dComIfG_getObjectIDRes("Co", dRes_ID_CO_BCK_CO_WAIT01_e),
+        J3DFrameCtrl::EMode_LOOP, 1.0f, 0, -1, 1, NULL,
+        0x80000, 0x11020022
+    );
+
+    mpMorf = morf;
+    if (mpMorf == NULL) {
+        return NULL;
+    }
+
+    if (mpMorf->getModel() == NULL) {
+        mpMorf = NULL;
+        return NULL;
+    }
+
+    m_hed_jnt_num = a_mdl_dat->getJointName()->getIndex("head");
+    JUT_ASSERT(0x833, m_hed_jnt_num >= 0);
+
+    m_bbone_jnt_num = a_mdl_dat->getJointName()->getIndex("backbone");
+    JUT_ASSERT(0x836, m_bbone_jnt_num >= 0);
+
+    m_hnd_R_jnt_num = a_mdl_dat->getJointName()->getIndex("handR");
+    JUT_ASSERT(0x839, m_hnd_R_jnt_num >= 0);
+
+    return a_mdl_dat;
 }
 
-/* 000033C0-00003578       .text create_prl_Anm__11daNpc_Co1_cFv */
-void daNpc_Co1_c::create_prl_Anm() {
-    /* Nonmatching */
+J3DModelData* daNpc_Co1_c::create_prl_Anm() {
+    J3DModelData* a_mdl_dat = (J3DModelData*)dComIfG_getObjectIDRes("Co", dRes_ID_CO_BDL_CO_PEAL_e);
+    JUT_ASSERT(0x848, a_mdl_dat != 0);
+
+    mDoExt_McaMorf* morf = new mDoExt_McaMorf(
+        a_mdl_dat, NULL, NULL,
+        (J3DAnmTransform*)dComIfG_getObjectIDRes("Co", dRes_ID_CO_BCK_COPEAL_WAIT01_e),
+        J3DFrameCtrl::EMode_LOOP, 1.0f, 0, -1, 1, NULL,
+        0x80000, 0x15021222
+    );
+
+    mpPrlMorf = morf;
+    if (mpPrlMorf == NULL) {
+        return NULL;
+    }
+
+    if (mpPrlMorf->getModel() == NULL) {
+        mpPrlMorf = NULL;
+        return NULL;
+    }
+
+    m_prl_jnt_num = a_mdl_dat->getJointName()->getIndex("co_pearl");
+    JUT_ASSERT(0x85C, m_prl_jnt_num >= 0);
+
+    return a_mdl_dat;
 }
 
-/* 00003578-00003634       .text create_itm_Mdl__11daNpc_Co1_cFv */
-void daNpc_Co1_c::create_itm_Mdl() {
-    /* Nonmatching */
+BOOL daNpc_Co1_c::create_itm_Mdl() {
+    mpItmModel = NULL;
+
+    J3DModelData* a_mdl_dat = (J3DModelData*)dComIfG_getObjectIDRes("Co", dRes_ID_CO_BDL_CO_LETTER_e);
+    JUT_ASSERT(0x86E, a_mdl_dat != 0);
+
+    mpItmModel = mDoExt_J3DModel__create(a_mdl_dat, 0x80000, 0x11000002);
+    return TRUE;
 }
 
-/* 00003634-000037C8       .text CreateHeap__11daNpc_Co1_cFv */
-void daNpc_Co1_c::CreateHeap() {
-    /* Nonmatching */
+BOOL daNpc_Co1_c::CreateHeap() {
+    J3DModelData* modelData = create_Anm();
+    if (modelData == NULL) {
+        return FALSE;
+    }
+
+    mTexPatternNum = 6;
+
+    {
+        u32 texResult = iniTexPttrnAnm(FALSE);
+        if ((texResult << 24) >> 24 == 0) {
+            mpMorf = NULL;
+            return FALSE;
+        }
+    }
+
+    if (create_prl_Anm() == NULL) {
+        mpMorf = NULL;
+        return FALSE;
+    }
+
+    {
+        u32 btkResult = setBtk(FALSE);
+        if ((btkResult << 24) >> 24 == 0) {
+            mpMorf = NULL;
+            mpPrlMorf = NULL;
+            return FALSE;
+        }
+    }
+
+    {
+        u32 itmResult = create_itm_Mdl();
+        if ((itmResult << 24) >> 24 == 0) {
+            goto error;
+        }
+    }
+
+    for (u16 i = 0; i < modelData->getJointNum(); i++) {
+        if (i == m_hed_jnt_num || i == m_bbone_jnt_num) {
+            J3DNode* node = mpMorf->getModel()->getModelData()->getJointNodePointer(i);
+            node->setCallBack(nodeCallBack_Co1);
+        }
+    }
+
+    mpMorf->getModel()->setUserArea((u32)this);
+
+    mAcchCir.SetWall(30.0f, 40.0f);
+    mObjAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1, &mAcchCir, fopAcM_GetSpeed_p(this), NULL, NULL);
+
+    return TRUE;
+
+error:
+    mpMorf = NULL;
+    mpPrlMorf = NULL;
+    return FALSE;
 }
 
-/* 000037C8-000037E8       .text daNpc_Co1_Create__FP10fopAc_ac_c */
+
 static cPhs_State daNpc_Co1_Create(fopAc_ac_c* i_this) {
     return ((daNpc_Co1_c*)i_this)->_create();
 }
 
-/* 000037E8-00003808       .text daNpc_Co1_Delete__FP11daNpc_Co1_c */
 static BOOL daNpc_Co1_Delete(daNpc_Co1_c* i_this) {
-    return ((daNpc_Co1_c*)i_this)->_delete();
+    return i_this->_delete();
 }
 
-/* 00003808-00003828       .text daNpc_Co1_Execute__FP11daNpc_Co1_c */
 static BOOL daNpc_Co1_Execute(daNpc_Co1_c* i_this) {
-    return ((daNpc_Co1_c*)i_this)->_execute();
+    return i_this->_execute();
 }
 
-/* 00003828-00003848       .text daNpc_Co1_Draw__FP11daNpc_Co1_c */
 static BOOL daNpc_Co1_Draw(daNpc_Co1_c* i_this) {
-    return ((daNpc_Co1_c*)i_this)->_draw();
+    return i_this->_draw();
 }
 
-/* 00003848-00003850       .text daNpc_Co1_IsDelete__FP11daNpc_Co1_c */
 static BOOL daNpc_Co1_IsDelete(daNpc_Co1_c*) {
     return TRUE;
 }


### PR DESCRIPTION
d_a_npc_co1 (Co, D4W1): full transcription adapted from closed-unmerged PR #993, all 67 functions matching per objdiff.

Flipped to `Equivalent` (weak data): the rel emits extra weak vtables from shared headers (res/Object/Co.h enums, dItemNo_*, fopAcM_ct_Retail) vs the original's weak set — same shape as d_a_obj_ikada (#1152). 416 files OK in verify build at the pinned commit; CI expected green x4.

Transcription commit: 1341ce79 (on our main); flip: 717ce068.