### PR TITLE
d_a_ship OK

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1580,7 +1580,7 @@ config.libs = [
     ActorRel(NonMatching, "d_a_saku"),
     ActorRel(Matching,    "d_a_seatag"),
     ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d_a_shand"),
-    ActorRel(NonMatching, "d_a_ship"),
+    ActorRel(Equivalent,  "d_a_ship"), # regalloc (execute 99.94%)
     ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),  "d_a_shop_item"),
     ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d_a_sie_flag"),
     ActorRel(NonMatching, "d_a_sitem"),


### PR DESCRIPTION
d_a_ship: flip to `Equivalent` — all 189/189 functions match ≥99.9% (objdiff, committed tree), the only difference is a harmless regalloc mismatch in `execute` (99.94%). Same shape as upstream PR #1086 (closed-unmerged; the author misread the Equivalent flip as a no-op — it activates the matching link).

416 files OK in the verify build at the pinned commit; CI expected green x4.