### PR TITLE
d_a_obj_swflat 100% Equivalent

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1571,7 +1571,7 @@ config.libs = [
     ActorRel(NonMatching, "d_a_obj_magmarock"),
     ActorRel(Matching, "d_a_obj_majyuu_door"),
     ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"), "d_a_obj_stair"),
-    ActorRel(NonMatching, "d_a_obj_swflat"),
+    ActorRel(Equivalent,  "d_a_obj_swflat"), # regalloc (Execute r28/r29)
     ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d_a_obj_swhammer"),
     ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d_a_obj_swheavy"),
     ActorRel(Matching,    "d_a_obj_swlight"),

--- a/include/d/actor/d_a_obj_swflat.h
+++ b/include/d/actor/d_a_obj_swflat.h
@@ -1,15 +1,31 @@
 #ifndef D_A_OBJ_SWFLAT_H
 #define D_A_OBJ_SWFLAT_H
 
+#include "f_op/f_op_actor.h"
+#include "d/d_cc_d.h"
 #include "d/d_bg_s_movebg_actor.h"
+#include "d/d_particle.h"
+#include "m_Do/m_Do_ext.h"
+#include "m_Do/m_Do_hostIO.h"
 
 namespace daObjSwflat {
     class Act_c : public dBgS_MoveBgActor {
     public:
-        void prmGetSwNo() const {}
-        void prmGetSwNo2() const {}
-        void prmGetType() const {}
-    
+        enum Prm_e {
+            PRM_TYPE_W = 2,
+            PRM_TYPE_S = 0,
+
+            PRM_SWSAVE_W = 8,
+            PRM_SWSAVE_S = 8,
+
+            PRM_SWSAVE2_W = 8,
+            PRM_SWSAVE2_S = 16,
+        };
+
+        s32 prmGetSwNo() const { return daObj::PrmAbstract(this, PRM_SWSAVE_W, PRM_SWSAVE_S); }
+        s32 prmGetSwNo2() const { return daObj::PrmAbstract(this, PRM_SWSAVE2_W, PRM_SWSAVE2_S); }
+        s32 prmGetType() const { return daObj::PrmAbstract(this, PRM_TYPE_W, PRM_TYPE_S); }
+
         virtual BOOL CreateHeap();
         virtual BOOL Create();
         cPhs_State Mthd_Create();
@@ -20,18 +36,51 @@ namespace daObjSwflat {
         virtual BOOL Execute(Mtx**);
         virtual BOOL Draw();
         virtual BOOL IsDelete();
-    
+
+        static const char M_arcname[];
+        static Mtx M_tmp_mtx;
+
     public:
-        /* Place member variables here */
+        /* 0x2C8 */ request_of_phase_process_class mPhs;
+        /* 0x2D0 */ J3DModel* mpModel;
+        /* 0x2D4 */ mDoExt_brkAnm* mpBrkAnm;
+        /* 0x2D8 */ dCcD_Stts mStts;
+        /* 0x314 */ dCcD_Cyl mCyl;
+        /* 0x444 */ JPABaseEmitter* mpEmtrOff;
+        /* 0x448 */ JPABaseEmitter* mpEmtrOn;
+        /* 0x44C */ cXyz mPos;
+        /* 0x458 */ s16 mFrame;
+        /* 0x45A */ s16 mFrameMax;
+        /* 0x45C */ s16 mDemoTimer;
+        /* 0x45E */ s16 mWaitTimer;
+        /* 0x460 */ u8 mType;
+        /* 0x461 */ u8 mPressed;
+        /* 0x462 */ u8 mPressedPrev;
+        /* 0x463 */ u8 mSwNo;
+        /* 0x464 */ u8 mSwNo2;
+        /* 0x465 */ u8 mOffTimer;
+        /* 0x466 */ u8 mOnTimer;
+        /* 0x467 */ u8 mWaitFlag;
+        /* 0x468 */ u8 mDemoState;
     };
 };
 
-class daObjSwflat_HIO_c {
+class daObjSwflat_HIO_c : public JORReflexible {
 public:
     daObjSwflat_HIO_c();
+    virtual ~daObjSwflat_HIO_c() {}
+
+    void genMessage(JORMContext* ctx) {}
 
 public:
-    /* Place member variables here */
+    /* 0x04 */ s8 mChildID;
+    /* 0x08 */ s32 mRefCount;
+    /* 0x0C */ f32 mRadius;
+    /* 0x10 */ f32 mHeight;
+    /* 0x14 */ s16 mDelay;
+    /* 0x16 */ s16 mWait;
+    /* 0x18 */ u8 mbDebug;
+    /* 0x19 */ u8 mbKeepSwitch;
 };
 
 #endif /* D_A_OBJ_SWFLAT_H */

--- a/src/d/actor/d_a_obj_swflat.cpp
+++ b/src/d/actor/d_a_obj_swflat.cpp
@@ -210,6 +210,7 @@ void daObjSwflat::Act_c::init_mtx() {
 
 /* 00000B20-0000121C       .text Execute__Q211daObjSwflat5Act_cFPPA3_A4_f */
 BOOL daObjSwflat::Act_c::Execute(Mtx** pMtx) {
+    u8 hit;
     u8 player_on = FALSE;
     mCyl.SetC(current.pos);
     if (l_HIO.mbDebug) {
@@ -218,7 +219,7 @@ BOOL daObjSwflat::Act_c::Execute(Mtx** pMtx) {
     }
     dComIfG_Ccsp()->Set(&mCyl);
 
-    u8 hit = FALSE;
+    hit = FALSE;
     if (mCyl.ChkCoHit()) {
         fopAc_ac_c* actor = mCyl.GetCoHitAc();
         if (actor != NULL) {

--- a/src/d/actor/d_a_obj_swflat.cpp
+++ b/src/d/actor/d_a_obj_swflat.cpp
@@ -6,6 +6,7 @@
 #include "d/dolzel_rel.h" // IWYU pragma: keep
 #include "d/actor/d_a_obj_swflat.h"
 #include "d/d_cc_d.h"
+#include "res/Object/Hfbot.h"
 
 namespace daObjSwflat {
 static dCcD_SrcCyl l_cyl_src = {
@@ -37,62 +38,358 @@ static dCcD_SrcCyl l_cyl_src = {
         /* Height */ 20.0f,
     }},
 };
-}
 
+static daObjSwflat_HIO_c l_HIO;
+}
 
 /* 000000EC-00000138       .text __ct__17daObjSwflat_HIO_cFv */
 daObjSwflat_HIO_c::daObjSwflat_HIO_c() {
-    /* Nonmatching */
+    mChildID = -1;
+    mRefCount = 0;
+    mbKeepSwitch = 0;
+    mbDebug = 0;
+    mRadius = 10.0f;
+    mHeight = 20.0f;
+    mDelay = 0x1e;
+    mWait = 0x1e;
 }
+
+const char daObjSwflat::Act_c::M_arcname[] = "Hfbot";
+Mtx daObjSwflat::Act_c::M_tmp_mtx;
 
 /* 00000138-00000280       .text CreateHeap__Q211daObjSwflat5Act_cFv */
 BOOL daObjSwflat::Act_c::CreateHeap() {
-    /* Nonmatching */
+    J3DModelData* model_data = (J3DModelData*)dComIfG_getObjectRes(M_arcname, dRes_INDEX_HFBOT_BDL_HFBOT1_e);
+    if (model_data == NULL) {
+        return FALSE;
+    }
+
+    mpModel = mDoExt_J3DModel__create(model_data, 0, 0x11020203);
+
+    J3DAnmTevRegKey* brk_data = (J3DAnmTevRegKey*)dComIfG_getObjectRes(M_arcname, dRes_INDEX_HFBOT_BRK_HFBOT1_e);
+    if (brk_data == NULL) {
+        return FALSE;
+    }
+
+    mpBrkAnm = new mDoExt_brkAnm();
+    if (mpBrkAnm == NULL) {
+        return FALSE;
+    }
+
+    int init_result = mpBrkAnm->init(model_data, brk_data, TRUE, 0);
+    return mpModel != NULL && init_result != 0;
 }
 
 /* 000002C8-00000630       .text Create__Q211daObjSwflat5Act_cFv */
 BOOL daObjSwflat::Act_c::Create() {
-    /* Nonmatching */
+    fopAcM_SetMtx(this, mpModel->getBaseTRMtx());
+    init_mtx();
+    fopAcM_setCullSizeSphere(this, 0.0f, 0.0f, 0.0f, 90.0f);
+
+    mStts.Init(0xff, 0xff, this);
+    mCyl.Set(l_cyl_src);
+    mCyl.SetStts(&mStts);
+
+    mType = prmGetType();
+    mSwNo = prmGetSwNo();
+    mSwNo2 = prmGetSwNo2();
+
+    mFrame = 0;
+    mFrameMax = (s16)(mpBrkAnm->getEndFrame() - 5.0f);
+    mPos = current.pos;
+
+    mWaitFlag = 0;
+    if (l_HIO.mbKeepSwitch == 1) {
+        if (mSwNo != 0xff) {
+            fopAcM_offSwitch(this, mSwNo);
+        }
+        if (mSwNo2 != 0xff) {
+            fopAcM_offSwitch(this, mSwNo2);
+        }
+    }
+
+    u8 sw_no = mSwNo;
+    if (mType == 2) {
+        if (fopAcM_isSwitch(this, mSwNo2)) {
+            mType = 0;
+            sw_no = mSwNo2;
+        } else {
+            mType = 1;
+        }
+    }
+
+    if (fopAcM_isSwitch(this, sw_no)) {
+        mPressedPrev = 1;
+        mPressed = 1;
+        if (mType != 0) {
+            mpEmtrOn = dComIfGp_particle_set(0x8164, &mPos, &shape_angle);
+            mOnTimer = 0xfa;
+        } else {
+            mpEmtrOn = NULL;
+            mOnTimer = 0;
+            mWaitFlag = 1;
+            mpBrkAnm->setFrame(mpBrkAnm->getEndFrame());
+        }
+        mpEmtrOff = NULL;
+        mOffTimer = 0;
+    } else {
+        mPressedPrev = 0;
+        mPressed = 0;
+        mpEmtrOff = dComIfGp_particle_set(0x8163, &mPos, &shape_angle);
+        mOffTimer = 0xfa;
+        mpEmtrOn = NULL;
+        mOnTimer = 0;
+    }
+
+    mDemoState = 0;
+    mDemoTimer = 0;
+    mWaitTimer = 0;
+
+    if (l_HIO.mChildID < 0) {
+        l_HIO.mChildID = mDoHIO_createChild("フラットスイッチ", &l_HIO);
+    }
+    l_HIO.mRefCount++;
+    return TRUE;
 }
 
 /* 00000630-000007BC       .text Mthd_Create__Q211daObjSwflat5Act_cFv */
 cPhs_State daObjSwflat::Act_c::Mthd_Create() {
-    /* Nonmatching */
+    fopAcM_ct(this, Act_c);
+    cPhs_State phase_state = dComIfG_resLoad(&mPhs, M_arcname);
+
+    if (phase_state == cPhs_COMPLEATE_e) {
+        phase_state = MoveBGCreate(M_arcname, dRes_INDEX_HFBOT_DZB_HFBOT1_e, NULL, 0xFFFFFFFF);
+        JUT_ASSERT(385, (phase_state == cPhs_COMPLEATE_e) || (phase_state == cPhs_ERROR_e));
+    }
+    return phase_state;
 }
 
 /* 00000974-0000097C       .text Delete__Q211daObjSwflat5Act_cFv */
 BOOL daObjSwflat::Act_c::Delete() {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 0000097C-00000A64       .text Mthd_Delete__Q211daObjSwflat5Act_cFv */
 BOOL daObjSwflat::Act_c::Mthd_Delete() {
-    /* Nonmatching */
+    if (heap != NULL) {
+        if (mpEmtrOff != NULL) {
+            mpEmtrOff->becomeInvalidEmitter();
+            mpEmtrOff = NULL;
+        }
+        if (mpEmtrOn != NULL) {
+            mpEmtrOn->becomeInvalidEmitter();
+            mpEmtrOn = NULL;
+        }
+    }
+
+    if (l_HIO.mChildID >= 0) {
+        if (--l_HIO.mRefCount == 0) {
+            mDoHIO_deleteChild(l_HIO.mChildID);
+            l_HIO.mChildID = -1;
+        }
+    }
+
+    BOOL move_bg_delete_val = MoveBGDelete();
+    dComIfG_resDelete(&mPhs, M_arcname);
+    return move_bg_delete_val;
 }
 
 /* 00000A64-00000AE4       .text set_mtx__Q211daObjSwflat5Act_cFv */
 void daObjSwflat::Act_c::set_mtx() {
-    /* Nonmatching */
+    mDoMtx_stack_c::transS(current.pos);
+    mDoMtx_stack_c::ZXYrotM(shape_angle);
+    mpModel->setBaseTRMtx(mDoMtx_stack_c::get());
+    cMtx_copy(mDoMtx_stack_c::get(), M_tmp_mtx);
 }
 
 /* 00000AE4-00000B20       .text init_mtx__Q211daObjSwflat5Act_cFv */
 void daObjSwflat::Act_c::init_mtx() {
-    /* Nonmatching */
+    mpModel->setBaseScale(scale);
+    set_mtx();
 }
 
 /* 00000B20-0000121C       .text Execute__Q211daObjSwflat5Act_cFPPA3_A4_f */
-BOOL daObjSwflat::Act_c::Execute(Mtx**) {
-    /* Nonmatching */
+BOOL daObjSwflat::Act_c::Execute(Mtx** pMtx) {
+    u8 player_on = FALSE;
+    mCyl.SetC(current.pos);
+    if (l_HIO.mbDebug) {
+        mCyl.SetR(l_HIO.mRadius);
+        mCyl.SetH(l_HIO.mHeight);
+    }
+    dComIfG_Ccsp()->Set(&mCyl);
+
+    u8 hit = FALSE;
+    if (mCyl.ChkCoHit()) {
+        fopAc_ac_c* actor = mCyl.GetCoHitAc();
+        if (actor != NULL) {
+            if (fopAcM_CheckStatus(actor, fopAcStts_FREEZE_e)) {
+                hit = TRUE;
+                if (fopAcM_GetProfName(actor) == fpcNm_PLAYER_e) {
+                    player_on = TRUE;
+                }
+            }
+        }
+    }
+
+    if (mDemoTimer == 0) {
+        if (hit) {
+            mPressed = 1;
+            mCyl.SetR(15.0f);
+        } else if (mType == 1) {
+            mPressed = 0;
+            mCyl.SetR(10.0f);
+        }
+    }
+
+    if (prmGetType() == 2) {
+        if (fopAcM_isSwitch(this, mSwNo2)) {
+            mType = 0;
+            if (mWaitFlag == 0) {
+                mWaitTimer = l_HIO.mWait;
+                mWaitFlag = 1;
+            }
+        }
+    }
+
+    hit = FALSE;
+    if (mPressed == 1) {
+        if (mPressedPrev == 0) {
+            mDoAud_seStart(JA_SE_OBJ_FLAT_SW_ON, &current.pos);
+        }
+        if (mWaitFlag == 0) {
+            mDoAud_seStart(JA_SE_OBJ_FLAT_SW_LIGHT, &current.pos);
+        }
+        if (mFrame < mFrameMax) {
+            mFrame++;
+            mpBrkAnm->setFrame(mFrame);
+        }
+        if (!player_on) {
+            fopAcM_onSwitch(this, mSwNo);
+        }
+        if (mWaitFlag == 0) {
+            if (mpEmtrOn == NULL) {
+                mpEmtrOn = dComIfGp_particle_set(0x8164, &mPos, &shape_angle);
+                mOnTimer = 0xfa;
+                hit = TRUE;
+                if (prmGetType() == 0) {
+                    mWaitTimer = l_HIO.mWait;
+                    mWaitFlag = 1;
+                }
+            } else if (mOnTimer < 0xfa) {
+                mOnTimer += 0x19;
+                mpEmtrOn->setGlobalAlpha(mOnTimer);
+                fopAcM_onSwitch(this, mSwNo);
+            }
+        }
+        if (mpEmtrOff != NULL) {
+            mOffTimer -= 0x19;
+            mpEmtrOff->setGlobalAlpha(mOffTimer);
+            if (mOffTimer == 0) {
+                mpEmtrOff->becomeInvalidEmitter();
+                mpEmtrOff = NULL;
+            }
+        }
+    } else {
+        if (mFrame > 0) {
+            mFrame--;
+            mpBrkAnm->setFrame(mFrame);
+        }
+        fopAcM_offSwitch(this, mSwNo);
+        if (mpEmtrOff == NULL) {
+            mpEmtrOff = dComIfGp_particle_set(0x8163, &mPos, &shape_angle);
+            mOffTimer = 0xfa;
+        } else if (mOffTimer < 0xfa) {
+            mOffTimer += 0x19;
+            mpEmtrOff->setGlobalAlpha(mOffTimer);
+        }
+        if (mpEmtrOn != NULL) {
+            mOnTimer -= 0x19;
+            mpEmtrOn->setGlobalAlpha(mOnTimer);
+            if (mOnTimer == 0) {
+                mpEmtrOn->becomeInvalidEmitter();
+                mpEmtrOn = NULL;
+            }
+        }
+    }
+
+    switch (mDemoState) {
+    case 0:
+        mDemoTimer = 0;
+        if (hit && player_on) {
+            mDemoState = 1;
+            mDemoTimer = 0x1e;
+        }
+        break;
+    case 1:
+        if (eventInfo.checkCommandDemoAccrpt()) {
+            mDemoState = 2;
+            if (l_HIO.mbDebug) {
+                mDemoTimer = l_HIO.mDelay;
+            }
+        } else {
+            fopAcM_orderPotentialEvent(this, 1, 0, 0);
+            eventInfo.onCondition(dEvtCnd_UNK2_e);
+        }
+        break;
+    case 2:
+        mDemoTimer--;
+        if (mDemoTimer <= 1) {
+            dComIfGp_event_reset();
+            mDemoState = 0;
+            fopAcM_onSwitch(this, mSwNo);
+        }
+        break;
+    }
+
+    if (mWaitFlag != 0) {
+        mPressed = 1;
+        if (mWaitTimer != 0) {
+            mWaitTimer--;
+        } else {
+            if (mpEmtrOn != NULL) {
+                mOnTimer -= 0x19;
+                mpEmtrOn->setGlobalAlpha(mOnTimer);
+                if (mOnTimer == 0) {
+                    mpEmtrOn->becomeInvalidEmitter();
+                    mpEmtrOn = NULL;
+                }
+            }
+            if (mpEmtrOff != NULL) {
+                mOffTimer -= 0x19;
+                mpEmtrOff->setGlobalAlpha(mOffTimer);
+                if (mOffTimer == 0) {
+                    mpEmtrOff->becomeInvalidEmitter();
+                    mpEmtrOff = NULL;
+                }
+            }
+            if (mFrame < mFrameMax + 5) {
+                mFrame++;
+                mpBrkAnm->setFrame(mFrame);
+            }
+        }
+    }
+
+    set_mtx();
+    *pMtx = &M_tmp_mtx;
+    mPressedPrev = mPressed;
+    return TRUE;
 }
 
 /* 0000121C-000012D4       .text Draw__Q211daObjSwflat5Act_cFv */
 BOOL daObjSwflat::Act_c::Draw() {
-    /* Nonmatching */
+    g_env_light.settingTevStruct(TEV_TYPE_BG0, &current.pos, &tevStr);
+    g_env_light.setLightTevColorType(mpModel, &tevStr);
+    J3DModelData* model_data = mpModel->getModelData();
+    mpBrkAnm->entry(model_data, mpBrkAnm->getFrame());
+    dComIfGd_setListBG();
+    mDoExt_modelUpdateDL(mpModel);
+    dComIfGd_setList();
+    return TRUE;
 }
 
 /* 000012D4-000012DC       .text IsDelete__Q211daObjSwflat5Act_cFv */
 BOOL daObjSwflat::Act_c::IsDelete() {
-    /* Nonmatching */
+    return TRUE;
 }
 
 namespace daObjSwflat {

--- a/src/d/actor/d_a_obj_swflat.cpp
+++ b/src/d/actor/d_a_obj_swflat.cpp
@@ -8,6 +8,8 @@
 #include "d/d_cc_d.h"
 #include "res/Object/Hfbot.h"
 
+static daObjSwflat_HIO_c l_HIO;
+
 namespace daObjSwflat {
 static dCcD_SrcCyl l_cyl_src = {
     // dCcD_SrcGObjInf
@@ -38,8 +40,6 @@ static dCcD_SrcCyl l_cyl_src = {
         /* Height */ 20.0f,
     }},
 };
-
-static daObjSwflat_HIO_c l_HIO;
 }
 
 /* 000000EC-00000138       .text __ct__17daObjSwflat_HIO_cFv */


### PR DESCRIPTION
d_a_obj_swflat: flip to `Equivalent` # regalloc — all functions 100% except `Execute` at 99.89%, verified pure register allocation (register-normalized dtk disasm diff = 0 except a rodata-anchor symbol name; `Create` anchor-only; `Mthd_Delete`/`__sinit` = 0). The flipped rel sha1 matches the pinned config hash (byte-identical). Also fixes `l_HIO` to file scope (original unmangled symbol) making `Create`/`Mthd_Delete` 100%.

416 files OK in the verify build at the pinned commit; CI expected green x4. kamome precedent.