### PR TITLE
d_a_kt OK

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1556,7 +1556,7 @@ config.libs = [
     ActorRel(Matching,    "d_a_kn"),
     ActorRel(Matching,    "d_a_kokiie"),
     ActorRel(Matching,    "d_a_ks"),
-    ActorRel(NonMatching, "d_a_kt"), # regalloc
+    ActorRel(Equivalent,  "d_a_kt"), # regalloc (kotori_move)
     ActorRel(Matching,    "d_a_mflft"),
     ActorRel(MatchingFor("GZLE01", "GZLP01"),    "d_a_npc_cb1"),
     ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"), "d_a_npc_md"),


### PR DESCRIPTION
d_a_kt: flip to `Equivalent` # regalloc — 22/23 functions ≥99.9%; `kotori_move` at 99.64% is pure register allocation (label+register-normalized dtk disasm: only diff is a rodata-anchor symbol name, all apparent r20/r23/r26 swaps are pure renaming). Source already merged upstream (c2a559b4, byte-identical) — this PR is the flip that activates the matching link, same class as d_a_ship (#1158).

416 files OK in the verify build at the pinned commit (explicit ok-target gate); CI expected green x4.