### PR TITLE
d_a_kb OK

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1632,7 +1632,7 @@ config.libs = [
     ActorRel(Matching,    "d_a_goal_flag"),
     ActorRel(NonMatching, "d_a_gy"),
     ActorRel(NonMatching, "d_a_icelift"),
-    ActorRel(NonMatching, "d_a_kb"),
+    ActorRel(Equivalent,  "d_a_kb"), # regalloc (useHeapInit)
     ActorRel(NonMatching, "d_a_kddoor"),
     ActorRel(Matching,    "d_a_kita"),
     ActorRel(NonMatching, "d_a_klft"),


### PR DESCRIPTION
d_a_kb: flip to `Equivalent` # regalloc — 88/89 functions ≥99.9%; `useHeapInit` at 99.8% is pure register allocation (179/179 instructions register-normalized identical). Source already merged upstream (#1040 partial); this flip activates the matching link, same class as d_a_ship (#1158)/d_a_kt (#1160).

416 files OK in the verify build at the pinned commit (explicit ok-target gate); CI expected green x4.