### PR TITLE
d_a_bridge OK

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1420,7 +1420,7 @@ config.libs = [
     ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d_a_bflower"),
     ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d_a_bita"),
     ActorRel(Matching,    "d_a_branch"),
-    ActorRel(NonMatching, "d_a_bridge"),
+    ActorRel(Equivalent,  "d_a_bridge"), # regalloc (2 fns 99.78/99.90)
     ActorRel(Matching,    "d_a_coming2"),
     ActorRel(Matching,    "d_a_coming3"),
     ActorRel(Matching,    "d_a_demo_dk"),


### PR DESCRIPTION
d_a_bridge: flip to `Equivalent` # regalloc — 43/45 functions 100%; two functions at 99.78/99.90 are pure register allocation (Toolsmith register-normalized proof). Source already merged upstream; this flip activates the matching link.

416 files OK in the verify build at the pinned commit (explicit ok-target gate); CI expected green x4.