### PR TITLE
d_a_bmdfoot OK

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1606,7 +1606,7 @@ config.libs = [
     ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d_a_bk"),
     ActorRel(NonMatching, "d_a_bl"),
     ActorRel(Matching,    "d_a_bmd"),
-    ActorRel(NonMatching, "d_a_bmdfoot"),
+    ActorRel(Equivalent,  "d_a_bmdfoot"), # regalloc (attack_1)
     ActorRel(Matching,    "d_a_bmdhand"),
     ActorRel(NonMatching, "d_a_bo"),
     ActorRel(Matching,    "d_a_boss_item"),


### PR DESCRIPTION
d_a_bmdfoot: flip to `Equivalent` # regalloc — 58/59 functions ≥99.9%; `attack_1` at 98.26% is pure register allocation (Toolsmith register-normalized proof). Source already merged upstream (#882 + #971); this flip activates the matching link.

416 files OK in the verify build at the pinned commit (explicit ok-target gate); CI expected green x4.