### PR TITLE
Debug build improvements

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -365,6 +365,9 @@ NonMatching = False               # Object does not match and should not be link
 Equivalent = config.non_matching  # Object should be linked when configured with --non-matching
 
 
+DEBUG_ONLY = args.debug
+
+
 # Object is only matching for specific versions
 def MatchingFor(*versions):
     return config.version in versions
@@ -587,6 +590,11 @@ config.libs = [
             Object(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d/d_salvage.cpp"),
             Object(Matching,    "d/d_snap.cpp"),
             Object(Matching,    "d/d_point_wind.cpp"),
+            Object(DEBUG_ONLY,  "d/d_debug_viewer.cpp"),
+            Object(DEBUG_ONLY,  "d/d_debug_pad.cpp"),
+            # Object(DEBUG_ONLY,  "d/d_debug_camera.cpp"),
+            # Object(DEBUG_ONLY,  "d/d_event_debug.cpp"),
+            # Object(DEBUG_ONLY,  "d/d_kankyo_debug.cpp"),
             Object(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),  "d/actor/d_a_agb.cpp"),
             Object(Matching,    "d/actor/d_a_arrow.cpp"),
             Object(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d/actor/d_a_bg.cpp"),
@@ -1241,6 +1249,7 @@ config.libs = [
             Object(NonMatching, "dolphin/gx/GXBump.c"),
             Object(NonMatching, "dolphin/gx/GXTev.c"),
             Object(NonMatching, "dolphin/gx/GXPixel.c"),
+            Object(DEBUG_ONLY,  "dolphin/gx/GXDraw.c"),
             Object(Matching,    "dolphin/gx/GXStubs.c"),
             Object(Matching,    "dolphin/gx/GXDisplayList.c"),
             Object(NonMatching, "dolphin/gx/GXTransform.c", extra_cflags=["-fp_contract off"]),
@@ -1907,19 +1916,30 @@ if config_path.exists():
 
 # Optional callback to adjust link order. This can be used to add, remove, or reorder objects.
 # This is called once per module, with the module ID and the current link order.
-#
-# For example, this adds "dummy.c" to the end of the DOL link order if configured with --non-matching.
-# "dummy.c" *must* be configured as a Matching (or Equivalent) object in order to be linked.
 def link_order_callback(module_id: int, objects: List[str]) -> List[str]:
     # Don't modify the link order for matching builds
     if not config.non_matching:
         return objects
-    if module_id == 0:  # DOL
-        return objects + ["dummy.c"]
+    
+    if args.debug and module_id == 0: # Debug DOL
+        # Insert debug-only objects.
+        objects.insert(objects.index("d/actor/d_a_agb.cpp"), "d/d_debug_viewer.cpp")
+        objects.insert(objects.index("d/actor/d_a_agb.cpp"), "d/d_debug_pad.cpp")
+        # objects.insert(objects.index("d/actor/d_a_agb.cpp"), "d/d_debug_camera.cpp")
+        # objects.insert(objects.index("d/actor/d_a_agb.cpp"), "d/d_event_debug.cpp")
+        # objects.insert(objects.index("d/actor/d_a_agb.cpp"), "d/d_kankyo_debug.cpp")
+        objects.insert(objects.index("dolphin/gx/GXPixel.c"), "dolphin/gx/GXDraw.c")
+    
+    # Example of adding new files for modding:
+    # This adds "dummy.c" to the end of the DOL link order if configured with --non-matching.
+    # "dummy.c" *must* be configured as a Matching (or Equivalent) object in order to be linked.
+    # if module_id == 0:  # DOL
+    #     return objects + ["dummy.c"]
+    
     return objects
 
 # Uncomment to enable the link order callback.
-# config.link_order_callback = link_order_callback
+config.link_order_callback = link_order_callback
 
 
 # Optional extra categories for progress tracking

--- a/include/JSystem/J3DGraphAnimator/J3DMaterialAnm.h
+++ b/include/JSystem/J3DGraphAnimator/J3DMaterialAnm.h
@@ -81,7 +81,10 @@ public:
     void setAnmIndex(u16 index) { mAnmIndex = index; }
     bool getAnmFlag() const { return mAnmFlag; }
     void setAnmFlag(bool flag) { mAnmFlag = flag; }
-    void setAnmTransform(J3DAnmTextureSRTKey* transform) { mAnmTransform = transform; }
+    void setAnmTransform(J3DAnmTextureSRTKey* transform) {
+        J3D_ASSERT(0, transform != NULL, "Error : null pointer.");
+        mAnmTransform = transform;
+    }
     void calc(J3DTextureSRTInfo* pSRTInfo) const;
 
 private:

--- a/include/JSystem/JUtility/JUTDbPrint.h
+++ b/include/JSystem/JUtility/JUTDbPrint.h
@@ -30,6 +30,8 @@ public:
     void setVisible(bool visible) { mVisible = visible; }
     JUTFont* getFont() const { return mFont; }
 
+    void setCharColor(JUtility::TColor color) { mColor = color; };
+
     static JUTDbPrint* sDebugPrint;
 
 private:

--- a/include/SSystem/SComponent/c_cc_d.h
+++ b/include/SSystem/SComponent/c_cc_d.h
@@ -15,6 +15,7 @@ class cCcD_TriAttr;
 class cCcD_AabAttr;
 class cCcD_CylAttr;
 class cCcD_SphAttr;
+typedef struct _GXColor GXColor;
 
 enum cCcD_AtSPrm_e {
     /* 0x01 */ cCcD_AtSPrm_Set_e = 0x01,
@@ -590,6 +591,9 @@ public:
     virtual cCcD_GObjInf* GetGObjInf() { return NULL; }
     virtual cCcD_ShapeAttr const* GetShapeAttr() const { return NULL; }
     virtual cCcD_ShapeAttr* GetShapeAttr() { return NULL; }
+#ifdef DEBUG
+    virtual void Draw(GXColor const&) {}
+#endif
     void ct() {
         mFlags = 0;
     }

--- a/include/SSystem/SComponent/c_cc_s.h
+++ b/include/SSystem/SComponent/c_cc_s.h
@@ -20,6 +20,12 @@ public:
     /* 0x2804 */ int mObjTgCount;
     /* 0x2808 */ int mObjCoCount;
     /* 0x280C */ int mObjCount;
+#if DEBUG
+    int mObjAtDrawCount;
+    int mObjTgDrawCount;
+    int mObjCoDrawCount;
+    int mObjDrawCount;
+#endif
     /* 0x2810 */ cCcD_DivideArea mDivideArea;
     /* 0x2850 vtable */
 
@@ -63,6 +69,8 @@ public:
     virtual void SetCoGCorrectProc(cCcD_Obj*, cCcD_Obj*);
 };  // Size = 0x2850
 
+#if !DEBUG
 STATIC_ASSERT(sizeof(cCcS) == 0x2854);
+#endif
 
 #endif /* C_CC_S_H */

--- a/include/SSystem/SComponent/c_m3d.h
+++ b/include/SSystem/SComponent/c_m3d.h
@@ -165,4 +165,8 @@ inline f32 cM3d_LenSq(const Vec* a, const Vec* b) {
     return VECSquareDistance(a, b);
 }
 
+#ifdef DEBUG
+bool cM3d_UpMtx(const Vec& param_1, Mtx param_2);
+#endif
+
 #endif

--- a/include/d/d_cc_d.h
+++ b/include/d/d_cc_d.h
@@ -513,6 +513,9 @@ public:
     void MoveCTg(cXyz&);
     virtual ~dCcD_Cyl() {}
     dCcD_Cyl() {}
+#ifdef DEBUG
+    virtual void Draw(GXColor const&);
+#endif
 };  // Size = 0x130
 
 STATIC_ASSERT(sizeof(dCcD_Cyl) == 0x130);
@@ -525,6 +528,9 @@ public:
 
     dCcD_Sph() {}
     void Set(dCcD_SrcSph const&);
+#ifdef DEBUG
+    virtual void Draw(GXColor const&);
+#endif
     void StartCAt(cXyz&);
     void MoveCAt(cXyz&);
     virtual cCcD_ShapeAttr* GetShapeAttr() { return (cCcD_ShapeAttr*)this; }
@@ -546,6 +552,9 @@ public:
     void CalcTgVec();
     virtual ~dCcD_Cps() {}
     dCcD_Cps() {}
+#ifdef DEBUG
+    virtual void Draw(GXColor const&);
+#endif
 };  // Size = 0x138
 
 // Triangle
@@ -558,6 +567,9 @@ public:
     virtual cCcD_ShapeAttr* GetShapeAttr() { return this; }
     virtual ~dCcD_Tri() {}
     dCcD_Tri() {}
+#ifdef DEBUG
+    virtual void Draw(GXColor const&);
+#endif
 };  // Size: 0x150
 
 dCcD_GObjInf* dCcD_GetGObjInf(cCcD_Obj* param_0);

--- a/include/d/d_cc_s.h
+++ b/include/d/d_cc_s.h
@@ -62,6 +62,8 @@ public:
     /* 0x2854 */ dCcMassS_Mng mMass_Mng;
 };  // Size = 0x29F4
 
+#if !DEBUG
 STATIC_ASSERT(sizeof(dCcS) == 0x29F4);
+#endif
 
 #endif /* D_CC_D_CC_S_H */

--- a/include/d/d_com_inf_game.h
+++ b/include/d/d_com_inf_game.h
@@ -911,6 +911,9 @@ public:
     /* 0x1BFC0 */ dRes_control_c mResControl;
     /* 0x1D1C0 */ u8 field_0x1d1c0;
     /* 0x1D1C1 */ u8 mBrightness;
+#ifdef DEBUG
+    u8 mIsDebugMode;
+#endif
 };
 
 #if VERSION > VERSION_JPN
@@ -4413,6 +4416,14 @@ inline void dComIfG_TimerStop(int timer) {
 
 inline u8 dComIfG_getBrightness() { return g_dComIfG_gameInfo.mBrightness; }
 inline void dComIfG_setBrightness(u8 v) { g_dComIfG_gameInfo.mBrightness = v; }
+
+inline BOOL dComIfG_isDebugMode() {
+#ifdef DEBUG
+    return g_dComIfG_gameInfo.mIsDebugMode;
+#else
+    return FALSE;
+#endif
+}
 
 class scene_class;
 BOOL dComIfG_resetToOpening(scene_class* i_scene);

--- a/include/d/d_debug_pad.h
+++ b/include/d/d_debug_pad.h
@@ -1,0 +1,34 @@
+#ifndef D_DEBUG_PAD_H
+#define D_DEBUG_PAD_H
+
+#include "JSystem/JUtility/TColor.h"
+
+class dDebugPad_c {
+public:
+    enum Mode_e {
+        MODE_CAMERA_e,
+        MODE_LIGHT_e,
+        MODE_WINDTEST_e,
+        MODE_SDCARD_e,
+
+        MODE_MAX_e,
+    };
+
+    dDebugPad_c();
+
+    bool Active() { return mIsActive; }
+    bool Update();
+    bool Report(int, int, JUtility::TColor, const char*, ...);
+    bool Enable(s32);
+    bool Trigger();
+
+    static const char mode_name[MODE_MAX_e][9];
+
+    /* 0x0 */ bool mIsActive;
+    /* 0x1 */ u8 mTrigger;
+    /* 0x4 */ s32 mMode;
+};
+
+extern dDebugPad_c dDebugPad;
+
+#endif

--- a/include/d/d_debug_viewer.h
+++ b/include/d/d_debug_viewer.h
@@ -1,0 +1,126 @@
+#ifndef D_DEBUG_VIEWER_H
+#define D_DEBUG_VIEWER_H
+
+#include "dolphin/gx/GX.h"
+#include "JSystem/J3DGraphBase/J3DSys.h"
+#include "SSystem/SComponent/c_xyz.h"
+#include "SSystem/SComponent/c_sxyz.h"
+
+class J3DPacket;
+
+J3DPacket* dDbVw_setDrawPacketList(J3DPacket* i_packet, int i_bufferType);
+void dDbVw_deleteDrawPacketList();
+
+void dDbVw_drawCube8p(int i_bufferType, cXyz* i_points, const GXColor& i_color);
+void dDbVw_drawCube(int i_bufferType, cXyz& i_pos, cXyz& i_size, csXyz& i_angle, const GXColor& i_color);
+void dDbVw_drawTriangle(int i_bufferType, cXyz* i_points, const GXColor& i_color, u8 i_clipZ);
+void dDbVw_drawQuad(int i_bufferType, cXyz* i_points, const GXColor& i_color, u8 i_clipZ);
+void dDbVw_drawQuad(int i_bufferType, cXyz* param_1, cXyz* param_2, cXyz* i_pos, s16 i_rotY, const GXColor& i_color, u8 i_clipZ);
+void dDbVw_drawLine(int i_bufferType, cXyz& i_start, cXyz& i_end, const GXColor& i_color, u8 i_clipZ, u8 i_width);
+void dDbVw_drawArrow(int i_bufferType, cXyz& i_pos, cXyz& param_2, const GXColor& i_color, u8 i_clipZ, u8 i_width);
+void dDbVw_drawPoint(int i_bufferType, cXyz& i_pos, const GXColor& i_color, u8 i_clipZ, u8 i_width);
+void dDbVw_drawCircle(int i_bufferType, cXyz& i_pos, f32 i_radius, const GXColor& i_color, u8 i_clipZ, u8 i_width);
+void dDbVw_drawSphere(int i_bufferType, cXyz& i_pos, f32 i_size, const GXColor& i_color, u8 i_clipZ);
+void dDbVw_drawCylinder(int i_bufferType, cXyz& i_pos, f32 i_radius, f32 i_height, const GXColor& i_color, u8 i_clipZ);
+void dDbVw_drawCylinderM(int i_bufferType, Mtx i_mtx, const GXColor& i_color, u8 i_clipZ);
+void dDbVw_drawCube8pXlu(cXyz* i_points, const GXColor& i_color);
+
+inline void dDbVw_drawCube8pOpa(cXyz* i_points, const GXColor& i_color) {
+    dDbVw_drawCube8p(J3DSysDrawBuf_Opa, i_points, i_color);
+}
+
+inline void dDbVw_drawCube8pXlu(cXyz* i_points, const GXColor& i_color) {
+    dDbVw_drawCube8p(J3DSysDrawBuf_Xlu, i_points, i_color);
+}
+
+inline void dDbVw_drawCubeOpa(cXyz& i_pos, cXyz& i_size, csXyz& i_angle, const GXColor& i_color) {
+    dDbVw_drawCube(J3DSysDrawBuf_Opa, i_pos, i_size, i_angle, i_color);
+}
+
+inline void dDbVw_drawCubeXlu(cXyz& i_pos, cXyz& i_size, csXyz& i_angle, const GXColor& i_color) {
+    dDbVw_drawCube(J3DSysDrawBuf_Xlu, i_pos, i_size, i_angle, i_color);
+}
+
+inline void dDbVw_drawTriangleOpa(cXyz* i_points, const GXColor& i_color, u8 i_clipZ) {
+    dDbVw_drawTriangle(J3DSysDrawBuf_Opa, i_points, i_color, i_clipZ);
+}
+
+inline void dDbVw_drawTriangleXlu(cXyz* i_points, const GXColor& i_color, u8 i_clipZ) {
+    dDbVw_drawTriangle(J3DSysDrawBuf_Xlu, i_points, i_color, i_clipZ);
+}
+
+inline void dDbVw_drawQuadOpa(cXyz* i_points, const GXColor& i_color, u8 i_clipZ) {
+    dDbVw_drawQuad(J3DSysDrawBuf_Opa, i_points, i_color, i_clipZ);
+}
+
+inline void dDbVw_drawQuadXlu(cXyz* i_points, const GXColor& i_color, u8 i_clipZ) {
+    dDbVw_drawQuad(J3DSysDrawBuf_Xlu, i_points, i_color, i_clipZ);
+}
+
+inline void dDbVw_drawQuadOpa(cXyz* param_1, cXyz* param_2, cXyz* i_pos, s16 i_rotY, const GXColor& i_color, u8 i_clipZ) {
+    dDbVw_drawQuad(J3DSysDrawBuf_Opa, param_1, param_2, i_pos, i_rotY, i_color, i_clipZ);
+}
+
+inline void dDbVw_drawQuadXlu(cXyz* param_1, cXyz* param_2, cXyz* i_pos, s16 i_rotY, const GXColor& i_color, u8 i_clipZ) {
+    dDbVw_drawQuad(J3DSysDrawBuf_Xlu, param_1, param_2, i_pos, i_rotY, i_color, i_clipZ);
+}
+
+inline void dDbVw_drawLineOpa(cXyz& i_start, cXyz& i_end, const GXColor& i_color, u8 i_clipZ, u8 i_width) {
+    dDbVw_drawLine(J3DSysDrawBuf_Opa, i_start, i_end, i_color, i_clipZ, i_width);
+}
+
+inline void dDbVw_drawLineXlu(cXyz& i_start, cXyz& i_end, const GXColor& i_color, u8 i_clipZ, u8 i_width) {
+    dDbVw_drawLine(J3DSysDrawBuf_Xlu, i_start, i_end, i_color, i_clipZ, i_width);
+}
+
+inline void dDbVw_drawArrowOpa(cXyz& i_pos, cXyz& param_2, const GXColor& i_color, u8 i_clipZ, u8 i_width) {
+    dDbVw_drawArrow(J3DSysDrawBuf_Opa, i_pos, param_2, i_color, i_clipZ, i_width);
+}
+
+inline void dDbVw_drawArrowXlu(cXyz& i_pos, cXyz& param_2, const GXColor& i_color, u8 i_clipZ, u8 i_width) {
+    dDbVw_drawArrow(J3DSysDrawBuf_Xlu, i_pos, param_2, i_color, i_clipZ, i_width);
+}
+
+inline void dDbVw_drawPointOpa(cXyz& i_pos, const GXColor& i_color, u8 i_clipZ, u8 i_width) {
+    dDbVw_drawPoint(J3DSysDrawBuf_Opa, i_pos, i_color, i_clipZ, i_width);
+}
+
+inline void dDbVw_drawPointXlu(cXyz& i_pos, const GXColor& i_color, u8 i_clipZ, u8 i_width) {
+    dDbVw_drawPoint(J3DSysDrawBuf_Xlu, i_pos, i_color, i_clipZ, i_width);
+}
+
+inline void dDbVw_drawCircleOpa(cXyz& i_pos, f32 i_radius, const GXColor& i_color, u8 i_clipZ, u8 i_width) {
+    dDbVw_drawCircle(J3DSysDrawBuf_Opa, i_pos, i_radius, i_color, i_clipZ, i_width);
+}
+
+inline void dDbVw_drawCircleXlu(cXyz& i_pos, f32 i_radius, const GXColor& i_color, u8 i_clipZ, u8 i_width) {
+    dDbVw_drawCircle(J3DSysDrawBuf_Xlu, i_pos, i_radius, i_color, i_clipZ, i_width);
+}
+
+inline void dDbVw_drawSphereOpa(cXyz& i_pos, f32 i_size, const GXColor& i_color, u8 i_clipZ) {
+    dDbVw_drawSphere(J3DSysDrawBuf_Opa, i_pos, i_size, i_color, i_clipZ);
+}
+
+inline void dDbVw_drawSphereXlu(cXyz& i_pos, f32 i_size, const GXColor& i_color, u8 i_clipZ) {
+    dDbVw_drawSphere(J3DSysDrawBuf_Xlu, i_pos, i_size, i_color, i_clipZ);
+}
+
+inline void dDbVw_drawCylinderOpa(cXyz& i_pos, f32 i_radius, f32 i_height, const GXColor& i_color, u8 i_clipZ) {
+    dDbVw_drawCylinder(J3DSysDrawBuf_Opa, i_pos, i_radius, i_height, i_color, i_clipZ);
+}
+
+inline void dDbVw_drawCylinderXlu(cXyz& i_pos, f32 i_radius, f32 i_height, const GXColor& i_color, u8 i_clipZ) {
+    dDbVw_drawCylinder(J3DSysDrawBuf_Xlu, i_pos, i_radius, i_height, i_color, i_clipZ);
+}
+
+inline void dDbVw_drawCylinderMOpa(Mtx i_mtx, const GXColor& i_color, u8 i_clipZ) {
+    dDbVw_drawCylinderM(J3DSysDrawBuf_Opa, i_mtx, i_color, i_clipZ);
+}
+
+inline void dDbVw_drawCylinderMXlu(Mtx i_mtx, const GXColor& i_color, u8 i_clipZ) {
+    dDbVw_drawCylinderM(J3DSysDrawBuf_Xlu, i_mtx, i_color, i_clipZ);
+}
+
+int dDbVw_Report(int x, int y, char const* string, ...);
+
+#endif /* D_DEBUG_VIEWER_H */

--- a/include/dolphin/gx/GX.h
+++ b/include/dolphin/gx/GX.h
@@ -17,6 +17,7 @@
 #include "dolphin/gx/GXTev.h" // IWYU pragma: export
 #include "dolphin/gx/GXTexture.h" // IWYU pragma: export
 #include "dolphin/gx/GXTransform.h" // IWYU pragma: export
+#include "dolphin/gx/GXDraw.h" // IWYU pragma: export
 
 #include "dolphin/os/OSUtil.h"
 

--- a/include/dolphin/gx/GXDraw.h
+++ b/include/dolphin/gx/GXDraw.h
@@ -8,6 +8,14 @@ extern "C" {
 #endif
 
 void GXDrawCylinder(u8 numEdges);
+void GXDrawTorus(f32 rc, u8 numc, u8 numt);
+void GXDrawSphere(u8 numMajor, u8 numMinor);
+void GXDrawCube(void);
+void GXDrawDodeca(void);
+void GXDrawOctahedron(void);
+void GXDrawIcosahedron(void);
+void GXDrawSphere1(u8 depth);
+u32 GXGenNormalTable(u8 depth, f32* table);
 
 #ifdef __cplusplus
 };

--- a/include/dolphin/os/OS.h
+++ b/include/dolphin/os/OS.h
@@ -25,6 +25,7 @@
 #include "dolphin/os/OSSync.h" // IWYU pragma: export
 #include "dolphin/os/OSThread.h" // IWYU pragma: export
 #include "dolphin/os/OSTime.h" // IWYU pragma: export
+#include "dolphin/os/OSStopwatch.h" // IWYU pragma: export
 #include "dolphin/os/OSUtil.h" // IWYU pragma: export
 
 #ifdef __cplusplus

--- a/include/dolphin/os/OSStopwatch.h
+++ b/include/dolphin/os/OSStopwatch.h
@@ -1,0 +1,21 @@
+#ifndef OSSTOPWATCH_H
+#define OSSTOPWATCH_H
+
+struct OSStopwatch {
+    char * name;
+    long long total;
+    unsigned long hits;
+    long long min;
+    long long max;
+    long long last;
+    int running;
+};
+
+void OSInitStopwatch(struct OSStopwatch * sw, char * name);
+void OSStartStopwatch(struct OSStopwatch * sw);
+void OSStopStopwatch(struct OSStopwatch * sw);
+long long OSCheckStopwatch(struct OSStopwatch * sw);
+void OSResetStopwatch(struct OSStopwatch * sw);
+void OSDumpStopwatch(struct OSStopwatch * sw);
+
+#endif /* OSSTOPWATCH_H */

--- a/include/m_Do/m_Do_controller_pad.h
+++ b/include/m_Do/m_Do_controller_pad.h
@@ -4,6 +4,9 @@
 #include "JSystem/JUtility/JUTGamePad.h"
 #include "SSystem/SComponent/c_API_controller_pad.h"
 
+// Controller Ports 1 - 4
+enum { PAD_1, PAD_2, PAD_3, PAD_4 };
+
 extern JUTGamePad* g_mDoCPd_gamePad[4];
 extern interface_of_controller_pad g_mDoCPd_cpadInfo[4];
 

--- a/include/m_Do/m_Do_ext.h
+++ b/include/m_Do/m_Do_ext.h
@@ -6,6 +6,7 @@
 #include "JSystem/J3DGraphAnimator/J3DModel.h"
 #include "JSystem/JUtility/JUTFont.h"
 #include "JAZelAudio/JAIZelAnime.h"
+#include "SSystem/SComponent/c_sxyz.h"
 #include "d/d_kankyo.h"
 
 class JKRArchive;
@@ -655,18 +656,147 @@ private:
     /* 0x38 */ mDoExt_3Dline_c* mpLines;
 };
 
-// The following classes only appear in the debug maps and seem unused:
-// mDoExt_ArrowPacket
-// mDoExt_circlePacket
-// mDoExt_cube8pPacket
-// mDoExt_cubePacket
-// mDoExt_cylinderMPacket
-// mDoExt_cylinderPacket
-// mDoExt_linePacket
-// mDoExt_pointPacket
-// mDoExt_quadPacket
-// mDoExt_spherePacket
-// mDoExt_trianglePacket
+class mDoExt_cube8pPacket : public J3DPacket {
+public:
+    mDoExt_cube8pPacket(cXyz* i_points, const GXColor& i_color);
+
+    virtual void draw();
+    virtual ~mDoExt_cube8pPacket() {}
+
+    /* 0x10 */ cXyz mPoints[8];
+    /* 0x70 */ GXColor mColor;
+};
+
+class mDoExt_cubePacket : public J3DPacket {
+public:
+    mDoExt_cubePacket(cXyz& i_position, cXyz& i_size, csXyz& i_angle, const GXColor& i_color);
+
+    virtual void draw();
+    virtual ~mDoExt_cubePacket() {}
+
+    /* 0x10 */ cXyz mPosition;
+    /* 0x1C */ cXyz mSize;
+    /* 0x28 */ csXyz mAngle;
+    /* 0x2E */ GXColor mColor;
+};
+
+class mDoExt_trianglePacket : public J3DPacket {
+public:
+    mDoExt_trianglePacket(cXyz* i_points, const GXColor& i_color, u8 i_clipZ);
+
+    virtual void draw();
+    virtual ~mDoExt_trianglePacket() {}
+
+    /* 0x10 */ cXyz mPoints[3];
+    /* 0x34 */ GXColor mColor;
+    /* 0x38 */ u8 mClipZ;
+};
+
+class mDoExt_quadPacket : public J3DPacket {
+public:
+    mDoExt_quadPacket(cXyz* i_points, const GXColor& i_color, u8 i_clipZ);
+
+    virtual void draw();
+    virtual ~mDoExt_quadPacket() {}
+
+    /* 0x10 */ cXyz mPoints[4];
+    /* 0x40 */ GXColor mColor;
+    /* 0x44 */ u8 mClipZ;
+};
+
+class mDoExt_linePacket : public J3DPacket {
+public:
+    mDoExt_linePacket(cXyz& i_start, cXyz& i_end, const GXColor& i_color, u8 i_clipZ, u8 i_width);
+
+    virtual void draw();
+    virtual ~mDoExt_linePacket() {}
+
+    /* 0x10 */ cXyz mStart;
+    /* 0x1C */ cXyz mEnd;
+    /* 0x28 */ GXColor mColor;
+    /* 0x2C */ u8 mClipZ;
+    /* 0x2D */ u8 mWidth;
+};
+
+class mDoExt_ArrowPacket : public J3DPacket {
+public:
+    mDoExt_ArrowPacket(cXyz& i_position, cXyz& param_1, const GXColor& i_color, u8 i_clipZ, u8 i_lineWidth);
+
+    virtual void draw();
+    virtual ~mDoExt_ArrowPacket() {}
+
+    /* 0x10 */ cXyz mStart;
+    /* 0x1C */ cXyz mEnd;
+    /* 0x28 */ GXColor mColor;
+    /* 0x2C */ u8 mClipZ;
+    /* 0x2D */ u8 mLineWidth;
+};
+
+class mDoExt_pointPacket : public J3DPacket {
+public:
+    mDoExt_pointPacket(cXyz& i_position, const GXColor& i_color, u8 i_clipZ, u8 i_lineWidth);
+
+    virtual void draw();
+    virtual ~mDoExt_pointPacket() {}
+
+    /* 0x10 */ cXyz mPosition;
+    /* 0x1C */ GXColor mColor;
+    /* 0x20 */ u8 mClipZ;
+    /* 0x21 */ u8 mLineWidth;
+};
+
+class mDoExt_circlePacket : public J3DPacket {
+public:
+    mDoExt_circlePacket(cXyz& i_position, f32 i_radius, const GXColor& i_color, u8 i_clipZ, u8 i_lineWidth);
+
+    virtual void draw();
+    virtual ~mDoExt_circlePacket() {}
+
+    /* 0x10 */ cXyz mPosition;
+    /* 0x1C */ f32 mRadius;
+    /* 0x20 */ GXColor mColor;
+    /* 0x24 */ u8 mClipZ;
+    /* 0x25 */ u8 mLineWidth;
+};
+
+class mDoExt_spherePacket : public J3DPacket {
+public:
+    mDoExt_spherePacket(cXyz& i_position, f32 i_size, const GXColor& i_color, u8 i_clipZ);
+
+    virtual void draw();
+    virtual ~mDoExt_spherePacket() {}
+
+    /* 0x10 */ cXyz mPosition;
+    /* 0x1C */ f32 mSize;
+    /* 0x20 */ GXColor mColor;
+    /* 0x24 */ u8 mClipZ;
+};
+
+class mDoExt_cylinderPacket : public J3DPacket {
+public:
+    mDoExt_cylinderPacket(cXyz& i_position, f32 i_radius, f32 i_height, const GXColor& i_color, u8 i_clipZ);
+
+    virtual void draw();
+    virtual ~mDoExt_cylinderPacket() {}
+
+    /* 0x10 */ cXyz mPosition;
+    /* 0x1C */ f32 mRadius;
+    /* 0x20 */ f32 mHeight;
+    /* 0x24 */ GXColor mColor;
+    /* 0x28 */ u8 mClipZ;
+};
+
+class mDoExt_cylinderMPacket : public J3DPacket {
+public:
+    mDoExt_cylinderMPacket(Mtx i_mtx, const GXColor& i_color, u8 i_clipZ);
+
+    virtual void draw();
+    virtual ~mDoExt_cylinderMPacket() {}
+
+    /* 0x10 */ Mtx mMatrix;
+    /* 0x40 */ GXColor mColor;
+    /* 0x44 */ u8 mClipZ;
+};
 
 inline void mDoExt_bckAnmRemove(J3DModelData* i_modelData) {
     i_modelData->getJointNodePointer(0)->setMtxCalc(NULL);

--- a/src/SSystem/SComponent/c_m3d.cpp
+++ b/src/SSystem/SComponent/c_m3d.cpp
@@ -2284,6 +2284,14 @@ int cM3d_UpMtx_Base(const Vec& param_0, const Vec& param_1, Mtx m) {
     return 1;
 }
 
+#ifdef DEBUG
+static Vec base_y = {0.0f, 1.0f, 0.0f};
+
+bool cM3d_UpMtx(const Vec& param_1, Mtx param_2) {
+    return cM3d_UpMtx_Base(base_y, param_1, param_2);
+}
+#endif
+
 /* 8025172C-80251758       .text cM3d_PlaneCrossLineProcWork__FfffffffPfPf */
 void cM3d_PlaneCrossLineProcWork(f32 v0, f32 v1, f32 v2, f32 v3, f32 v4, f32 v5, f32 v6, f32* p0, f32* p1) {
     *p0 = (v1 * v6 - v3 * v5) / v4;

--- a/src/d/actor/d_a_obj_canon.cpp
+++ b/src/d/actor/d_a_obj_canon.cpp
@@ -189,10 +189,11 @@ bool daObj_Canon_c::checkTgHit() {
     }
 
     if(cLib_calcTimer(&field_0x440) == 0) {
+        cXyz hitPos;
         CcAtInfo atInfo;
         atInfo.pParticlePos = NULL;
         cCcD_Obj* tg = mSph.GetTgHitObj();
-        cXyz hitPos = *mSph.GetTgHitPosP();
+        hitPos = *mSph.GetTgHitPosP();
         atInfo.mpObj = mSph.GetTgHitObj();
         if (tg == NULL) {
             return false;
@@ -335,7 +336,7 @@ void daObj_Canon_c::modeWait() {
                         temp += tmp;
                     }
 
-                    s16 temp2 = fopAcM_searchActorAngleY(this, daPy_getPlayerActorClass());
+                    s16 temp2 = fopAcM_searchPlayerAngleY(this);
 
                     field_0x2CC.x -= temp * cM_ssin(temp2);
                     field_0x2CC.z -= temp * cM_scos(temp2);
@@ -384,7 +385,7 @@ void daObj_Canon_c::modeDeleteInit() {
     setEffect(dPa_name::ID_IT_SN_MJTAIHOU_SENKO00);
     setEffect(dPa_name::ID_IT_JN_MJTAIHOU_SMOKE01);
 
-    fopAcM_OffStatus(this, fopAcStts_SHOWMAP_e | 0x1F);
+    fopAcM_ClearStatusMap(this);
 }
 
 /* 00001174-00001178       .text modeDelete__13daObj_Canon_cFv */
@@ -395,7 +396,7 @@ void daObj_Canon_c::modeDelete() {
 /* 00001178-00001194       .text modeSwWaitInit__13daObj_Canon_cFv */
 void daObj_Canon_c::modeSwWaitInit() {
     field_0x46C = 120.0f;
-    fopAcM_OffStatus(this, fopAcStts_SHOWMAP_e | 0x1F);
+    fopAcM_ClearStatusMap(this);
 }
 
 /* 00001194-000011F4       .text modeSwWait__13daObj_Canon_cFv */
@@ -485,12 +486,12 @@ bool daObj_Canon_c::_execute() {
     temp.x = l_HIO.field_0x14;
     temp.y = l_HIO.field_0x18 * scale.x;
     temp.z = l_HIO.field_0x1C;
-    mDoMtx_multVec(mpModel->getAnmMtx(WALLBOM_JNT_SHOT_e), &temp, &field_0x450);
+    cMtx_multVec(mpModel->getAnmMtx(WALLBOM_JNT_SHOT_e), &temp, &field_0x450);
     Vec temp2 = {0.0f, 0.0f, 0.0f};
     temp2.x = REG12_F(0);
     temp2.y = (REG12_F(1) + 60.0f) * scale.x;
     temp2.z = REG12_F(2);
-    mDoMtx_multVec(mpModel->getAnmMtx(WALLBOM_JNT_SHOT_e), &temp2, &field_0x45C);
+    cMtx_multVec(mpModel->getAnmMtx(WALLBOM_JNT_SHOT_e), &temp2, &field_0x45C);
 
     if(field_0x470.getEmitter()) {
         if(cLib_calcTimer(&field_0x484) == 0) {

--- a/src/d/actor/d_a_obj_jump.cpp
+++ b/src/d/actor/d_a_obj_jump.cpp
@@ -110,7 +110,7 @@ BOOL daObjJump::Act_c::Create() {
     }
 #if VERSION > VERSION_DEMO
     if (mType == Type_SPRING_ON_BOX_e) {
-        actor_status &= ~0x3F;
+        fopAcM_ClearStatusMap(this);
         gbaName = 0;
     }
 #endif

--- a/src/d/d_cc_d.cpp
+++ b/src/d/d_cc_d.cpp
@@ -4,9 +4,11 @@
 //
 
 #include "d/d_cc_d.h"
+#include "d/d_debug_viewer.h"
 #include "f_op/f_op_actor_mng.h"
 #include "dolphin/types.h"
 #include "JSystem/JUtility/JUTAssert.h"
+#include "m_Do/m_Do_mtx.h"
 
 /* 800AB2AC-800AB328       .text GetAc__22dCcD_GAtTgCoCommonBaseFv */
 fopAc_ac_c* dCcD_GAtTgCoCommonBase::GetAc() {
@@ -273,16 +275,57 @@ void dCcD_Cps::Set(const dCcD_SrcCps& src) {
     cCcD_CpsAttr::Set(src.mCpsAttr);
 }
 
+#ifdef DEBUG
+void dCcD_Cps::Draw(const GXColor& color) {
+    Mtx auStack_68;
+    Mtx auStack_98;
+    Mtx auStack_c8;
+    
+    MTXIdentity(auStack_68);
+
+    cXyz cStack_d8;
+    CalcVec(&cStack_d8);
+    cMtx_trans(auStack_98, GetStartP()->x, GetStartP()->y, GetStartP()->z);
+    cM3d_UpMtx(cStack_d8, auStack_c8);
+    cMtx_concat(auStack_98, auStack_c8, auStack_68);
+    cMtx_scale(auStack_98, GetR(), 0.5f * GetLen(), GetR());
+    cMtx_concat(auStack_68, auStack_98, auStack_68);
+    cMtx_trans(auStack_98, 0.0f, 1.0f, 0.0f);
+    cMtx_concat(auStack_68, auStack_98, auStack_68);
+    cMtx_XrotS(auStack_98, 0x4000);
+    cMtx_concat(auStack_68, auStack_98, auStack_68);
+    dDbVw_drawCylinderMXlu(auStack_68, color, 1);
+    dDbVw_drawSphereXlu(*GetStartP(), GetR(), color, 1);
+    dDbVw_drawSphereXlu(*GetEndP(), GetR(), color, 1);
+}
+#endif
+
 /* 800ABD34-800ABD54       .text Set__8dCcD_TriFRC11dCcD_SrcTri */
 void dCcD_Tri::Set(const dCcD_SrcTri& src) {
     dCcD_GObjInf::Set(src.mObjInf);
 }
+
+#if DEBUG
+void dCcD_Tri::Draw(const GXColor& color) {
+    cXyz cStack_34[3];
+    cStack_34[0] = mA;
+    cStack_34[1] = mB;
+    cStack_34[2] = mC;
+    dDbVw_drawTriangleXlu(cStack_34, color, 1);
+}
+#endif
 
 /* 800ABD54-800ABDCC       .text Set__8dCcD_CylFRC11dCcD_SrcCyl */
 void dCcD_Cyl::Set(const dCcD_SrcCyl& src) {
     dCcD_GObjInf::Set(src.mObjInf);
     cCcD_CylAttr::Set(src.mCylAttr);
 }
+
+#if DEBUG
+void dCcD_Cyl::Draw(const GXColor& color) {
+    dDbVw_drawCylinderXlu(*GetCP(), GetR(), GetH(), color, 1);
+}
+#endif
 
 /* 800ABDCC-800ABE18       .text StartCAt__8dCcD_CylFR4cXyz */
 void dCcD_Cyl::StartCAt(cXyz& pos) {
@@ -300,8 +343,8 @@ void dCcD_Cyl::StartCTg(cXyz& pos) {
 
 /* 800ABE64-800ABEE0       .text MoveCAtTg__8dCcD_CylFR4cXyz */
 void dCcD_Cyl::MoveCAtTg(cXyz& pos) {
-    cXyz& center = GetC();
-    cXyz vel = pos - center;
+    const cXyz* center = GetCP();
+    cXyz vel = pos - *center;
     SetAtVec(vel);
     SetTgVec(vel);
     SetC(pos);
@@ -309,16 +352,16 @@ void dCcD_Cyl::MoveCAtTg(cXyz& pos) {
 
 /* 800ABEE0-800ABF50       .text MoveCAt__8dCcD_CylFR4cXyz */
 void dCcD_Cyl::MoveCAt(cXyz& pos) {
-    cXyz& center = GetC();
-    cXyz vel = pos - center;
+    const cXyz* center = GetCP();
+    cXyz vel = pos - *center;
     SetAtVec(vel);
     SetC(pos);
 }
 
 /* 800ABF50-800ABFC0       .text MoveCTg__8dCcD_CylFR4cXyz */
 void dCcD_Cyl::MoveCTg(cXyz& pos) {
-    cXyz& center = GetC();
-    cXyz vel = pos - center;
+    const cXyz* center = GetCP();
+    cXyz vel = pos - *center;
     SetTgVec(vel);
     SetC(pos);
 }
@@ -328,6 +371,12 @@ void dCcD_Sph::Set(const dCcD_SrcSph& src) {
     dCcD_GObjInf::Set(src.mObjInf);
     cCcD_SphAttr::Set(src.mSphAttr);
 }
+
+#ifdef DEBUG
+void dCcD_Sph::Draw(const GXColor& color) {
+    dDbVw_drawSphereXlu(*GetCP(), GetR(), color, 1);
+}
+#endif
 
 /* 800AC02C-800AC078       .text StartCAt__8dCcD_SphFR4cXyz */
 void dCcD_Sph::StartCAt(cXyz& pos) {

--- a/src/d/d_cc_s.cpp
+++ b/src/d/d_cc_s.cpp
@@ -6,6 +6,67 @@
 #include "d/d_cc_s.h"
 #include "d/d_cc_d.h"
 #include "d/d_com_inf_game.h"
+#include "m_Do/m_Do_hostIO.h"
+
+#if DEBUG
+class dCcS_HIO : public JORReflexible {
+public:
+    enum flags_e {
+        FLAG_CAM_COL_DISP_e   = 0x1, // TP only?
+        FLAG_AT_ON_e          = 0x2,
+        FLAG_TG_ON_e          = 0x4,
+        FLAG_CO_ON_e          = 0x8,
+        FLAG_DRAW_CLEAR_OFF_e = 0x10,
+        FLAG_COUNTER_e        = 0x20,
+        FLAG_MOVE_OFF_e       = 0x40,
+        FLAG_MASS_OFF_e       = 0x80,
+        FLAG_MOVE_TIMER_e     = 0x100,
+        FLAG_MASS_TIMER_e     = 0x200,
+        FLAG_MASS_COUNTER_e   = 0x400,
+        FLAG_ALL_MASS_TIMER_e = 0x800,
+    };
+
+    dCcS_HIO() {
+        m_flags = 0;
+        m_shield_range = 0x4000;
+    }
+
+    virtual ~dCcS_HIO();
+
+    void genMessage(JORMContext*);
+
+    BOOL ChkMoveTimer() { return m_flags & FLAG_MOVE_TIMER_e; }
+    BOOL ChkMoveOff() { return m_flags & FLAG_MOVE_OFF_e; }
+    BOOL ChkAllMassTimer() { return m_flags & FLAG_ALL_MASS_TIMER_e; }
+    BOOL ChkDrawClearOff() { return m_flags & FLAG_DRAW_CLEAR_OFF_e; }
+    BOOL ChkCounter() { return m_flags & FLAG_COUNTER_e; }
+    BOOL CheckCoOn() { return m_flags & FLAG_CO_ON_e; }
+    BOOL CheckTgOn() { return m_flags & FLAG_TG_ON_e; }
+    BOOL CheckAtOn() { return m_flags & FLAG_AT_ON_e; }
+    BOOL ChkMassCounter() { return m_flags & FLAG_MASS_COUNTER_e; }
+    BOOL ChkMassOff() { return m_flags & FLAG_MASS_OFF_e; }
+    BOOL ChkMassTimer() { return m_flags & FLAG_MASS_TIMER_e; }
+
+    s16 GetShFrontRange() { return m_shield_range; }
+
+    /* 0x4 */ s8 id;
+    /* 0x6 */ u16 m_flags;
+    /* 0x8 */ s16 m_shield_range;
+};
+
+dCcS_HIO::~dCcS_HIO() {}
+
+void dCcS_HIO::genMessage(JORMContext* mctx) {
+    UNUSED(mctx);
+}
+
+static OSStopwatch s_move_timer;
+static OSStopwatch s_mass_timer;
+
+static dCcS_HIO s_Hio;
+
+int g_mass_counter;
+#endif
 
 /* 800AD5B0-800AD5E4       .text Ct__4dCcSFv */
 void dCcS::Ct() {
@@ -460,8 +521,71 @@ void dCcS::Move() {
 
 /* 800AE83C-800AE878       .text Draw__4dCcSFv */
 void dCcS::Draw() {
+    #if DEBUG
+    if (s_Hio.ChkMassCounter()) {
+        OSReport("Mass Counter %d\n", g_mass_counter);
+        g_mass_counter = 0;
+    }
+
+    if (s_Hio.CheckAtOn()) {
+        for (int i = 0; i < mObjAtDrawCount; i++) {
+            if (mpObjAt[i] != NULL && mpObjAt[i]->ChkAtSet()) {
+                dCcD_GObjInf* gobj = (dCcD_GObjInf*)mpObjAt[i]->GetGObjInf();
+                if (gobj->ChkAtHit()) {
+                    GXColor color = {0xFF, 0, 0, 0xB4};
+                    mpObjAt[i]->Draw(color);
+                } else {
+                    GXColor color = {0xFF, 0, 0, 0x50};
+                    mpObjAt[i]->Draw(color);
+                }
+            }
+        }
+    }
+
+    if (s_Hio.CheckTgOn()) {
+        for (int i = 0; i < mObjTgDrawCount; i++) {
+            if (mpObjTg[i] != NULL && mpObjTg[i]->ChkTgSet()) {
+                dCcD_GObjInf* gobj = (dCcD_GObjInf*)mpObjTg[i]->GetGObjInf();
+                if (gobj->ChkTgHit()) {
+                    GXColor color = {0, 0xFF, 0, 0xB4};
+                    mpObjTg[i]->Draw(color);
+                } else {
+                    GXColor color = {0, 0xFF, 0, 0x50};
+                    mpObjTg[i]->Draw(color);
+                }
+            }
+        }
+    }
+
+    if (s_Hio.CheckCoOn()) {
+        for (int i = 0; i < mObjCoDrawCount; i++) {
+            if (mpObjCo[i] != NULL && mpObjCo[i]->ChkCoSet()) {
+                dCcD_GObjInf* gobj = (dCcD_GObjInf*)mpObjCo[i]->GetGObjInf();
+                if (gobj->ChkCoHit()) {
+                    GXColor color = {0xFF, 0xFF, 0xFF, 0xB4};
+                    mpObjCo[i]->Draw(color);
+                } else {
+                    GXColor color = {0xFF, 0xFF, 0xFF, 0x50};
+                    mpObjCo[i]->Draw(color);
+                }
+            }
+        }
+    }
+
+    if (s_Hio.ChkCounter()) {
+        OSReport("At:%d,Tg:%d,Co:%d\n", mObjAtDrawCount, mObjTgDrawCount, mObjCoDrawCount);
+    }
+    #endif
+
     DrawAfter();
-    DrawClear();
+    
+    #if DEBUG
+    if (!s_Hio.ChkDrawClearOff())
+    #endif
+    {
+        DrawClear();
+    }
+    
     mMass_Mng.Clear();
 }
 

--- a/src/d/d_debug_pad.cpp
+++ b/src/d/d_debug_pad.cpp
@@ -1,0 +1,95 @@
+// Debug-only file. This file is known to have existed for TWW based on the debug maps.
+// The contents of this are copied from the TP debug build decomp and may or may not match the actual TWW debug build.
+
+#include "d/d_debug_pad.h"
+#include "m_Do/m_Do_controller_pad.h"
+#include "JSystem/JUtility/JUTDbPrint.h"
+#include "JSystem/JUtility/JUTReport.h"
+#include "f_ap/f_ap_game.h"
+#include "stdio.h"
+#include "stdarg.h"
+
+dDebugPad_c::dDebugPad_c() {
+    mIsActive = false;
+    mMode = MODE_CAMERA_e;
+    mTrigger = false;
+}
+
+const char dDebugPad_c::mode_name[MODE_MAX_e][9] = {
+    "CAMERA",
+    "BsLight",
+    "WindTest",
+    "SDCARD",
+};
+
+bool dDebugPad_c::Update() {
+    mTrigger = false;
+
+    if (CPad_CHECK_TRIG_START(PAD_3)) {
+        mIsActive = mIsActive ? false : true;
+        mTrigger = true;
+    }
+
+    if (mIsActive) {
+        if (CPad_CHECK_TRIG_Z(PAD_3)) {
+            mMode = (mMode + 1) % MODE_MAX_e;
+        }
+
+        int x = 10;
+        int y = 40;
+        int line_height = 15;
+        JUtility::TColor sp40(0xC8, 0x80, 0xFF, 0xC0);
+        JUtility::TColor sp3C(0xFF, 0xC0, 0xC0, 0xFF);
+
+        Report(x, y, sp40, "+-DEBUG-PAD-+");
+
+        int i;
+        for (i = 0; i < MODE_MAX_e; i++) {
+            y += line_height;
+
+            if (i == mMode) {
+                Report(x, y, sp40, "|           |");
+                Report(x, y, sp3C, "  @%-8s  ", mode_name[i]);
+            } else {
+                Report(x, y, sp40, "|  %-8s |", mode_name[i]);
+            }
+        }
+
+        for (i = 0; i < 1; i++) {
+            y += line_height;
+            Report(x, y, sp40, "|           |");
+        }
+
+        y += line_height;
+        Report(x, y, sp40, "+-----------+");
+    }
+
+    return mIsActive;
+}
+
+bool dDebugPad_c::Report(int x, int y, JUtility::TColor color, const char* message, ...) {
+    char buffer[256];
+
+    static JUtility::TColor ShadowDarkColor(0, 0, 0, 0x80);
+
+    if (mIsActive) {
+        va_list list;
+        va_start(list, message);
+        vsnprintf(buffer, sizeof(buffer), message, list);
+        va_end(list);
+    
+        JUTDbPrint::getManager()->flush();
+        JUTDbPrint::getManager()->setCharColor(ShadowDarkColor);
+        JUTReport(x + 2, y + 2, buffer);
+        JUTDbPrint::getManager()->flush();
+        JUTDbPrint::getManager()->setCharColor(color);
+        JUTReport(x, y, buffer);
+        JUTDbPrint::getManager()->flush();
+        JUTDbPrint::getManager()->setCharColor(g_HIO.mColor);
+        return true;
+    }
+
+    return false;
+}
+
+dDebugPad_c dDebugPad;

--- a/src/d/d_debug_viewer.cpp
+++ b/src/d/d_debug_viewer.cpp
@@ -1,0 +1,156 @@
+// Debug-only file. This file is known to have existed for TWW based on the debug maps.
+// The contents of this are copied from the TP debug build decomp and may or may not match the actual TWW debug build.
+
+#include "d/dolzel.h" // IWYU pragma: keep
+
+#include "d/d_debug_viewer.h"
+#include "d/d_debug_pad.h"
+#include "d/d_com_inf_game.h"
+#include "f_ap/f_ap_game.h"
+#include "JSystem/J3DGraphBase/J3DDrawBuffer.h"
+#include "JSystem/JUtility/JUTDbPrint.h"
+#include "JSystem/JUtility/JUTReport.h"
+#include "stdio.h"
+
+J3DPacket* l_drawPacketList[1000];
+int l_drawPacketListNum;
+
+J3DPacket* dDbVw_setDrawPacketList(J3DPacket* i_packet, int i_bufferType) {
+    if (i_packet == NULL) {
+        return NULL;
+    }
+
+    if (l_drawPacketListNum >= 1000) {
+        delete (void*)i_packet;
+        return NULL;
+    }
+
+    l_drawPacketList[l_drawPacketListNum++] = i_packet;
+    j3dSys.getDrawBuffer(i_bufferType)->entryImm(i_packet, 0);
+    return i_packet;
+}
+
+void dDbVw_deleteDrawPacketList() {
+    for (int i = 0; i < l_drawPacketListNum; i++) {
+        delete (void*)l_drawPacketList[i];
+    }
+
+    l_drawPacketListNum = 0;
+}
+
+void dDbVw_drawCube8p(int i_bufferType, cXyz* i_points, const GXColor& i_color) {
+    mDoExt_cube8pPacket* packet = new mDoExt_cube8pPacket(i_points, i_color);
+    dDbVw_setDrawPacketList(packet, i_bufferType);
+}
+
+void dDbVw_drawCube(int i_bufferType, cXyz& i_pos, cXyz& i_size, csXyz& i_angle, const GXColor& i_color) {
+    mDoExt_cubePacket* packet = new mDoExt_cubePacket(i_pos, i_size, i_angle, i_color);
+    dDbVw_setDrawPacketList(packet, i_bufferType);
+}
+
+void dDbVw_drawTriangle(int i_bufferType, cXyz* i_points, const GXColor& i_color, u8 i_clipZ) {
+    mDoExt_trianglePacket* packet = new mDoExt_trianglePacket(i_points, i_color, i_clipZ);
+    dDbVw_setDrawPacketList(packet, i_bufferType);
+}
+
+void dDbVw_drawQuad(int i_bufferType, cXyz* i_points, const GXColor& i_color, u8 i_clipZ) {
+    mDoExt_quadPacket* packet = new mDoExt_quadPacket(i_points, i_color, i_clipZ);
+    dDbVw_setDrawPacketList(packet, i_bufferType);
+}
+
+void dDbVw_drawQuad(int i_bufferType, cXyz* param_1, cXyz* param_2, cXyz* i_pos, s16 i_rotY, const GXColor& i_color, u8 i_clipZ) {
+    cXyz points[4];
+
+    points[0] = *param_1;
+    points[2] = *param_2;
+
+    points[1].x = param_2->x;
+    points[1].y = param_1->y;
+    points[1].z = param_1->z;
+
+    points[3].x = param_1->x;
+    points[3].y = param_1->y;
+    points[3].z = param_2->z;
+
+    mDoMtx_stack_c::transS(*i_pos);
+    mDoMtx_stack_c::YrotM(i_rotY);
+
+    for (int i = 0; i < 4; i++) {
+        mDoMtx_stack_c::multVec(&points[i], &points[i]);
+    }
+
+    mDoExt_quadPacket* packet = new mDoExt_quadPacket(points, i_color, i_clipZ);
+    dDbVw_setDrawPacketList(packet, i_bufferType);
+}
+
+void dDbVw_drawLine(int i_bufferType, cXyz& i_start, cXyz& i_end, const GXColor& i_color, u8 i_clipZ, u8 i_width) {
+    mDoExt_linePacket* packet = new mDoExt_linePacket(i_start, i_end, i_color, i_clipZ, i_width);
+    dDbVw_setDrawPacketList(packet, i_bufferType);
+}
+
+void dDbVw_drawArrow(int i_bufferType, cXyz& i_pos, cXyz& param_2, const GXColor& i_color, u8 i_clipZ, u8 i_width) {
+    mDoExt_ArrowPacket* packet = new mDoExt_ArrowPacket(i_pos, param_2, i_color, i_clipZ, i_width);
+    dDbVw_setDrawPacketList(packet, i_bufferType);
+}
+
+void dDbVw_drawPoint(int i_bufferType, cXyz& i_pos, const GXColor& i_color, u8 i_clipZ, u8 i_width) {
+    mDoExt_pointPacket* packet = new mDoExt_pointPacket(i_pos, i_color, i_clipZ, i_width);
+    dDbVw_setDrawPacketList(packet, i_bufferType);
+}
+
+void dDbVw_drawCircle(int i_bufferType, cXyz& i_pos, f32 i_radius, const GXColor& i_color, u8 i_clipZ, u8 i_width) {
+    mDoExt_circlePacket* packet = new mDoExt_circlePacket(i_pos, i_radius, i_color, i_clipZ, i_width);
+    dDbVw_setDrawPacketList(packet, i_bufferType);
+}
+
+void dDbVw_drawSphere(int i_bufferType, cXyz& i_pos, f32 i_size, const GXColor& i_color, u8 i_clipZ) {
+    mDoExt_spherePacket* packet = new mDoExt_spherePacket(i_pos, i_size, i_color, i_clipZ);
+    dDbVw_setDrawPacketList(packet, i_bufferType);
+}
+
+void dDbVw_drawCylinder(int i_bufferType, cXyz& i_pos, f32 i_radius, f32 i_height, const GXColor& i_color, u8 i_clipZ) {
+    mDoExt_cylinderPacket* packet = new mDoExt_cylinderPacket(i_pos, i_radius, i_height, i_color, i_clipZ);
+    dDbVw_setDrawPacketList(packet, i_bufferType);
+}
+
+void dDbVw_drawCylinderM(int i_bufferType, Mtx i_mtx, const GXColor& i_color, u8 i_clipZ) {
+    mDoExt_cylinderMPacket* packet = new mDoExt_cylinderMPacket(i_mtx, i_color, i_clipZ);
+    dDbVw_setDrawPacketList(packet, i_bufferType);
+}
+
+static bool reportOK() {
+    return !dComIfG_isDebugMode() && !dDebugPad.Active();
+}
+
+static JUtility::TColor ShadowDarkColor(0, 0, 0, 0x80);
+static JUtility::TColor ShadowLightColor(0xFF, 0xFF, 0xFF, 0x80);
+
+int dDbVw_Report(int x, int y, char const* string, ...) {
+    UNUSED(string);
+    char buffer[256];
+
+    if (reportOK()) {
+        va_list list;
+        va_start(list, string);
+        vsnprintf(buffer, sizeof(buffer), string, list);
+        va_end(list);
+    
+        JUTDbPrint::getManager()->flush();
+
+        if (g_HIO.mColor & 0xF0F0F000) {
+            JUTDbPrint::getManager()->setCharColor(ShadowDarkColor);
+        } else {
+            JUTDbPrint::getManager()->setCharColor(ShadowLightColor);
+        }
+
+        JUTReport(x + 2, y + 2, buffer);
+        JUTDbPrint::getManager()->flush();
+    
+        JUTDbPrint::getManager()->setCharColor(g_HIO.mColor);
+        JUTReport(x, y, buffer);
+        JUTDbPrint::getManager()->flush();
+        return 1;
+    }
+
+    return 0;
+}

--- a/src/dolphin/gx/GXDraw.c
+++ b/src/dolphin/gx/GXDraw.c
@@ -70,3 +70,51 @@ void GXDrawCylinder(u8 numEdges) {
 
     RestoreVertState();
 }
+
+void GXDrawSphere(u8 numMajor, u8 numMinor) {
+    GXAttrType ttype;
+    f32 radius = 1.0f;
+    f32 majorStep = 3.1415927f / numMajor;
+    f32 minorStep = 6.2831855f / numMinor;
+    s32 i, j;
+    f32 a, b;
+    f32 r0, r1;
+    f32 z0, z1;
+    f32 c;
+
+    GXGetVtxDesc(GX_VA_TEX0, &ttype);
+    GetVertState();
+
+    if (ttype != GX_NONE) {
+        GXSetVtxDesc(GX_VA_TEX0, GX_DIRECT);
+        GXSetVtxAttrFmt(GX_VTXFMT3, GX_VA_TEX0, GX_TEX_ST, GX_RGBA6, 0);
+    }
+
+    for (i = 0; i < numMajor; i++) {
+        a = i * majorStep;
+        b = a + majorStep;
+        r0 = radius * sinf(a);
+        r1 = radius * sinf(b);
+        z0 = radius * cosf(a);
+        z1 = radius * cosf(b);
+        GXBegin(GX_TRIANGLESTRIP, GX_VTXFMT3, (numMinor + 1) * 2);
+        for (j = 0; j <= numMinor; j++) {
+            f32 x, y;
+            c = j * minorStep;
+            x = cosf(c);
+            y = sinf(c);
+            GXPosition3f32(x * r1, y * r1, z1);
+            GXNormal3f32((x * r1) / radius, (y * r1) / radius, z1 / radius);
+            if (ttype != GX_NONE) {
+                GXTexCoord2f32((f32)j / (f32)numMinor, (f32)(i + 1) / (f32)numMajor);
+            }
+            GXPosition3f32(x * r0, y * r0, z0);
+            GXNormal3f32((x * r0) / radius, (y * r0) / radius, z0 / radius);
+            if (ttype != GX_NONE) {
+                GXTexCoord2f32((f32)j / (f32)numMinor, (f32)i / (f32)numMajor);
+            }
+        }
+        GXEnd();
+    }
+    RestoreVertState();
+}

--- a/src/m_Do/m_Do_ext.cpp
+++ b/src/m_Do/m_Do_ext.cpp
@@ -2540,6 +2540,547 @@ void mDoExt_3DlineMatSortPacket::draw() {
 #endif
 }
 
+#if DEBUG
+mDoExt_cube8pPacket::mDoExt_cube8pPacket(cXyz* i_points, const GXColor& i_color) {
+    cXyz* pnt_array = mPoints;
+
+    for (int i = 0; i < 8; i++) {
+        *(pnt_array)++ = *(i_points)++;
+    }
+
+    DCStoreRangeNoSync(mPoints, sizeof(cXyz) * 8);
+    mColor = i_color;
+}
+
+void drawCube(MtxP mtx, cXyz* pos, const GXColor& color) {
+    GXSetArray(GX_VA_POS, pos, sizeof(cXyz));
+    GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_POS, GX_POS_XYZ, GX_F32, 0);
+    GXClearVtxDesc();
+    GXSetVtxDesc(GX_VA_POS, GX_INDEX8);
+    GXSetNumChans(1);
+    GXSetChanCtrl(GX_COLOR0, GX_DISABLE, GX_SRC_REG, GX_SRC_REG, GX_LIGHT_NULL, GX_DF_CLAMP,
+                  GX_AF_NONE);
+    GXSetNumTexGens(0);
+    GXSetNumTevStages(1);
+    GXSetTevColor(GX_TEVREG0, color);
+    GXSetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD_NULL, GX_TEXMAP_NULL, GX_COLOR0A0);
+    GXSetTevColorIn(GX_TEVSTAGE0, GX_CC_ZERO, GX_CC_ZERO, GX_CC_ZERO, GX_CC_C0);
+    GXSetTevColorOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_ENABLE, GX_TEVPREV);
+    GXSetTevAlphaIn(GX_TEVSTAGE0, GX_CA_ZERO, GX_CA_ZERO, GX_CA_ZERO, GX_CA_A0);
+    GXSetTevAlphaOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_ENABLE, GX_TEVPREV);
+    GXSetZMode(GX_ENABLE, GX_LEQUAL, GX_ENABLE);
+    GXSetBlendMode(GX_BM_BLEND, GX_BL_SRC_ALPHA, GX_BL_INV_SRC_ALPHA, GX_LO_CLEAR);
+    GXSetAlphaCompare(GX_ALWAYS, 0, GX_AOP_OR, GX_ALWAYS, 0);
+    GXSetCullMode(GX_CULL_BACK);
+    GXSetClipMode(GX_CLIP_ENABLE);
+    GXLoadPosMtxImm(mtx, 0);
+    GXSetCurrentMtx(0);
+
+    GXBegin(GX_TRIANGLESTRIP, GX_VTXFMT0, 14);
+    GXPosition1x8(4);
+    GXPosition1x8(6);
+    GXPosition1x8(5);
+    GXPosition1x8(7);
+    GXPosition1x8(3);
+    GXPosition1x8(6);
+    GXPosition1x8(2);
+    GXPosition1x8(4);
+    GXPosition1x8(0);
+    GXPosition1x8(5);
+    GXPosition1x8(1);
+    GXPosition1x8(3);
+    GXPosition1x8(0);
+    GXPosition1x8(2);
+    GXEnd();
+}
+
+void mDoExt_cube8pPacket::draw() {
+    drawCube(j3dSys.getViewMtx(), mPoints, mColor);
+}
+
+mDoExt_cubePacket::mDoExt_cubePacket(cXyz& i_position, cXyz& i_size, csXyz& i_angle, const GXColor& i_color) {
+    mPosition = i_position;
+    mSize = i_size;
+    mAngle = i_angle;
+    mColor = i_color;
+}
+
+void mDoExt_cubePacket::draw() {
+    static cXyz l_pos[8] = {
+        cXyz(-1.0f, 1.0f, -1.0f), cXyz(1.0f, 1.0f, -1.0f),   cXyz(-1.0f, 1.0f, 1.0f),
+        cXyz(1.0f, 1.0f, 1.0f),   cXyz(-1.0f, -1.0f, -1.0f), cXyz(1.0f, -1.0f, -1.0f),
+        cXyz(-1.0f, -1.0f, 1.0f), cXyz(1.0f, -1.0f, 1.0f),
+    };
+
+    mDoMtx_stack_c::transS(mPosition.x, mPosition.y, mPosition.z);
+    mDoMtx_stack_c::XYZrotM(mAngle.x, mAngle.y, mAngle.z);
+    mDoMtx_stack_c::scaleM(mSize.x, mSize.y, mSize.z);
+    mDoMtx_stack_c::revConcat(j3dSys.getViewMtx());
+    drawCube(mDoMtx_stack_c::get(), l_pos, mColor);
+}
+
+mDoExt_quadPacket::mDoExt_quadPacket(cXyz* i_points, const GXColor& i_color, u8 i_clipZ) {
+    cXyz* pnt_array = mPoints;
+
+    for (int i = 0; i < 4; i++) {
+        *(pnt_array)++ = *(i_points)++;
+    }
+
+    DCStoreRangeNoSync(mPoints, sizeof(cXyz) * 4);
+    mColor = i_color;
+    mClipZ = i_clipZ;
+}
+
+void mDoExt_quadPacket::draw() {
+    GXSetArray(GX_VA_POS, mPoints, sizeof(cXyz));
+    GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_POS, GX_POS_XYZ, GX_F32, 0);
+    GXClearVtxDesc();
+    GXSetVtxDesc(GX_VA_POS, GX_INDEX8);
+    GXSetNumChans(1);
+    GXSetChanCtrl(GX_COLOR0, GX_DISABLE, GX_SRC_REG, GX_SRC_REG, GX_LIGHT_NULL, GX_DF_CLAMP,
+                  GX_AF_NONE);
+    GXSetNumTexGens(0);
+    GXSetNumTevStages(1);
+    GXSetTevColor(GX_TEVREG0, mColor);
+    GXSetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD_NULL, GX_TEXMAP_NULL, GX_COLOR0A0);
+    GXSetTevColorIn(GX_TEVSTAGE0, GX_CC_ZERO, GX_CC_ZERO, GX_CC_ZERO, GX_CC_C0);
+    GXSetTevColorOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_ENABLE, GX_TEVPREV);
+    GXSetTevAlphaIn(GX_TEVSTAGE0, GX_CA_ZERO, GX_CA_ZERO, GX_CA_ZERO, GX_CA_A0);
+    GXSetTevAlphaOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_ENABLE, GX_TEVPREV);
+
+    if (mClipZ) {
+        GXSetZMode(GX_ENABLE, GX_LEQUAL, GX_ENABLE);
+    } else {
+        GXSetZMode(GX_DISABLE, GX_LEQUAL, GX_DISABLE);
+    }
+
+    GXSetBlendMode(GX_BM_BLEND, GX_BL_SRC_ALPHA, GX_BL_INV_SRC_ALPHA, GX_LO_CLEAR);
+    GXSetAlphaCompare(GX_ALWAYS, 0, GX_AOP_OR, GX_ALWAYS, 0);
+    GXSetCullMode(GX_CULL_BACK);
+    GXSetClipMode(GX_CLIP_ENABLE);
+    GXLoadPosMtxImm(j3dSys.getViewMtx(), 0);
+    GXSetCurrentMtx(0);
+
+    GXBegin(GX_QUADS, GX_VTXFMT0, 4);
+    GXPosition1x8(0);
+    GXPosition1x8(1);
+    GXPosition1x8(2);
+    GXPosition1x8(3);
+    GXEnd();
+}
+
+mDoExt_trianglePacket::mDoExt_trianglePacket(cXyz* i_points, const GXColor& i_color, u8 i_clipZ) {
+    cXyz* pnt_array = mPoints;
+
+    for (int i = 0; i < 3; i++) {
+        *(pnt_array)++ = *(i_points)++;
+    }
+
+    DCStoreRangeNoSync(mPoints, sizeof(cXyz) * 3);
+    mColor = i_color;
+    mClipZ = i_clipZ;
+}
+
+void mDoExt_trianglePacket::draw() {
+    j3dSys.reinitGX();
+
+    GXSetArray(GX_VA_POS, mPoints, sizeof(cXyz));
+    GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_POS, GX_POS_XYZ, GX_F32, 0);
+    GXClearVtxDesc();
+    GXSetVtxDesc(GX_VA_POS, GX_INDEX8);
+    GXLoadPosMtxImm(j3dSys.getViewMtx(), 0);
+    GXSetCurrentMtx(0);
+    GXSetNumChans(1);
+    GXSetChanCtrl(GX_COLOR0, GX_DISABLE, GX_SRC_REG, GX_SRC_REG, GX_LIGHT_NULL, GX_DF_CLAMP, GX_AF_NONE);
+    GXSetNumTexGens(0);
+    GXSetNumTevStages(1);
+    GXSetTevColor(GX_TEVREG0, mColor);
+    GXSetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD_NULL, GX_TEXMAP_NULL, GX_COLOR0A0);
+    GXSetTevColorIn(GX_TEVSTAGE0, GX_CC_ZERO, GX_CC_ZERO, GX_CC_ZERO, GX_CC_C0);
+    GXSetTevColorOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_ENABLE, GX_TEVPREV);
+    GXSetTevAlphaIn(GX_TEVSTAGE0, GX_CA_ZERO, GX_CA_ZERO, GX_CA_ZERO, GX_CA_A0);
+    GXSetTevAlphaOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_ENABLE, GX_TEVPREV);
+    GXSetZCompLoc(GX_ENABLE);
+
+    if (mClipZ) {
+        GXSetZMode(GX_ENABLE, GX_LEQUAL, GX_ENABLE);
+    } else {
+        GXSetZMode(GX_DISABLE, GX_LEQUAL, GX_DISABLE);
+    }
+
+    GXSetBlendMode(GX_BM_BLEND, GX_BL_SRC_ALPHA, GX_BL_INV_SRC_ALPHA, GX_LO_CLEAR);
+    GXSetAlphaCompare(GX_ALWAYS, 0, GX_AOP_OR, GX_ALWAYS, 0);
+    GXSetFog(GX_FOG_NONE, 0.0f, 0.0f, 0.0f, 0.0f, g_clearColor);
+    GXSetFogRangeAdj(GX_DISABLE, 0, NULL);
+    GXSetCullMode(GX_CULL_NONE);
+    GXSetDither(GX_ENABLE);
+    GXSetClipMode(GX_CLIP_ENABLE);
+    GXSetNumIndStages(0);
+
+    GXBegin(GX_TRIANGLES, GX_VTXFMT0, 3);
+    GXPosition1x8(0);
+    GXPosition1x8(1);
+    GXPosition1x8(2);
+    GXEnd();
+
+    J3DShape::resetVcdVatCache();
+}
+
+mDoExt_linePacket::mDoExt_linePacket(cXyz& i_start, cXyz& i_end, const GXColor& i_color, u8 i_clipZ, u8 i_width) {
+    mStart = i_start;
+    mEnd = i_end;
+    mColor = i_color;
+    mClipZ = i_clipZ;
+    mWidth = i_width;
+}
+
+void mDoExt_linePacket::draw() {
+    j3dSys.reinitGX();
+
+    GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_POS, GX_POS_XYZ, GX_F32, 0);
+    GXClearVtxDesc();
+    GXSetVtxDesc(GX_VA_POS, GX_DIRECT);
+    GXLoadPosMtxImm(j3dSys.getViewMtx(), 0);
+    GXSetCurrentMtx(0);
+    GXSetNumChans(1);
+    GXSetChanCtrl(GX_COLOR0, GX_DISABLE, GX_SRC_REG, GX_SRC_REG, GX_LIGHT_NULL, GX_DF_CLAMP, GX_AF_NONE);
+    GXSetNumTexGens(0);
+    GXSetNumTevStages(1);
+    GXSetTevColor(GX_TEVREG0, mColor);
+    GXSetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD_NULL, GX_TEXMAP_NULL, GX_COLOR0A0);
+    GXSetTevColorIn(GX_TEVSTAGE0, GX_CC_ZERO, GX_CC_ZERO, GX_CC_ZERO, GX_CC_C0);
+    GXSetTevColorOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_ENABLE, GX_TEVPREV);
+    GXSetTevAlphaIn(GX_TEVSTAGE0, GX_CA_ZERO, GX_CA_ZERO, GX_CA_ZERO, GX_CA_A0);
+    GXSetTevAlphaOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_ENABLE, GX_TEVPREV);
+    GXSetZCompLoc(GX_ENABLE);
+
+    if (mClipZ) {
+        GXSetZMode(GX_ENABLE, GX_LEQUAL, GX_ENABLE);
+    } else {
+        GXSetZMode(GX_DISABLE, GX_LEQUAL, GX_DISABLE);
+    }
+
+    GXSetBlendMode(GX_BM_BLEND, GX_BL_SRC_ALPHA, GX_BL_INV_SRC_ALPHA, GX_LO_CLEAR);
+    GXSetAlphaCompare(GX_ALWAYS, 0, GX_AOP_OR, GX_ALWAYS, 0);
+    GXSetFog(GX_FOG_NONE, 0.0f, 0.0f, 0.0f, 0.0f, g_clearColor);
+    GXSetFogRangeAdj(GX_DISABLE, 0, NULL);
+    GXSetCullMode(GX_CULL_NONE);
+    GXSetDither(GX_ENABLE);
+    GXSetClipMode(GX_CLIP_ENABLE);
+    GXSetNumIndStages(0);
+    GXSetLineWidth(mWidth, GX_TO_ZERO);
+
+    GXBegin(GX_LINES, GX_VTXFMT0, 2);
+    GXPosition3f32(mStart.x, mStart.y, mStart.z);
+    GXPosition3f32(mEnd.x, mEnd.y, mEnd.z);
+    GXEnd();
+
+    J3DShape::resetVcdVatCache();
+}
+
+mDoExt_ArrowPacket::mDoExt_ArrowPacket(cXyz& i_position, cXyz& param_1, const GXColor& i_color, u8 i_clipZ, u8 i_lineWidth) {
+    mStart = i_position;
+    mEnd = param_1;
+    mColor = i_color;
+    mClipZ = i_clipZ;
+    mLineWidth = i_lineWidth;
+}
+
+void mDoExt_ArrowPacket::draw() {
+    Mtx sp28;
+    cXyz sp18;
+
+    GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_POS, GX_POS_XYZ, GX_F32, 0);
+    GXClearVtxDesc();
+    GXSetVtxDesc(GX_VA_POS, GX_DIRECT);
+    GXSetNumChans(1);
+    GXSetChanCtrl(GX_COLOR0, GX_DISABLE, GX_SRC_REG, GX_SRC_REG, GX_LIGHT_NULL, GX_DF_CLAMP, GX_AF_NONE);
+    GXSetNumTexGens(0);
+    GXSetNumTevStages(1);
+    GXSetTevColor(GX_TEVREG0, mColor);
+    GXSetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD_NULL, GX_TEXMAP_NULL, GX_COLOR0A0);
+    GXSetTevColorIn(GX_TEVSTAGE0, GX_CC_ZERO, GX_CC_ZERO, GX_CC_ZERO, GX_CC_C0);
+    GXSetTevColorOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_ENABLE, GX_TEVPREV);
+    GXSetTevAlphaIn(GX_TEVSTAGE0, GX_CA_ZERO, GX_CA_ZERO, GX_CA_ZERO, GX_CA_A0);
+    GXSetTevAlphaOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_ENABLE, GX_TEVPREV);
+
+    if (mClipZ) {
+        GXSetZMode(GX_ENABLE, GX_LEQUAL, GX_ENABLE);
+    } else {
+        GXSetZMode(GX_DISABLE, GX_LEQUAL, GX_DISABLE);
+    }
+
+    GXSetBlendMode(GX_BM_BLEND, GX_BL_SRC_ALPHA, GX_BL_INV_SRC_ALPHA, GX_LO_CLEAR);
+    GXSetAlphaCompare(GX_ALWAYS, 0, GX_AOP_OR, GX_ALWAYS, 0);
+    GXSetCullMode(GX_CULL_NONE);
+    GXSetClipMode(GX_CLIP_ENABLE);
+    GXSetLineWidth(mLineWidth, GX_TO_ZERO);
+
+    sp18 = mEnd - mStart;
+    MtxTrans(mStart.x, mStart.y, mStart.z, 0);
+    cMtx_YrotM(*calc_mtx, sp18.atan2sX_Z());
+    cMtx_XrotM(*calc_mtx, cM_atan2s(JMAFastSqrt(SQUARE(sp18.x) + SQUARE(sp18.z)), sp18.y));
+    cMtx_concat(j3dSys.getViewMtx(), *calc_mtx, sp28);
+
+    GXLoadPosMtxImm(sp28, 0);
+    GXSetCurrentMtx(0);
+
+    GXBegin(GX_LINES, GX_VTXFMT0, 2);
+    GXPosition3f32(0.0f, 0.0f, 0.0f);
+    GXPosition3f32(0.0f, sp18.abs(), 0.0f);
+    GXEnd();
+
+    f32 var_f29 = sp18.abs();
+    f32 var_f31 = var_f29 * 0.1f;
+    f32 var_f30 = var_f29 * 0.8f;
+
+    GXBegin(GX_TRIANGLEFAN, GX_VTXFMT0, 6);
+    GXPosition3f32(0.0f, var_f29, 0.0f);
+    GXPosition3f32(0.0f, var_f30, var_f31);
+    GXPosition3f32(var_f31, var_f30, 0.0f);
+    GXPosition3f32(0.0f, var_f30, -var_f31);
+    GXPosition3f32(-var_f31, var_f30, 0.0f);
+    GXPosition3f32(0.0f, var_f30, var_f31);
+    GXEnd();
+}
+
+mDoExt_pointPacket::mDoExt_pointPacket(cXyz& i_position, const GXColor& i_color, u8 i_clipZ, u8 i_lineWidth) {
+    mPosition = i_position;
+    mColor = i_color;
+    mClipZ = i_clipZ;
+    mLineWidth = i_lineWidth;
+}
+
+void mDoExt_pointPacket::draw() {
+    j3dSys.reinitGX();
+
+    GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_POS, GX_POS_XYZ, GX_F32, 0);
+    GXClearVtxDesc();
+    GXSetVtxDesc(GX_VA_POS, GX_DIRECT);
+    GXSetNumChans(1);
+    GXSetChanCtrl(GX_COLOR0, GX_DISABLE, GX_SRC_REG, GX_SRC_REG, GX_LIGHT_NULL, GX_DF_CLAMP, GX_AF_NONE);
+    GXSetNumTexGens(0);
+    GXSetNumTevStages(1);
+    GXSetTevColor(GX_TEVREG0, mColor);
+    GXSetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD_NULL, GX_TEXMAP_NULL, GX_COLOR0A0);
+    GXSetTevColorIn(GX_TEVSTAGE0, GX_CC_ZERO, GX_CC_ZERO, GX_CC_ZERO, GX_CC_C0);
+    GXSetTevColorOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_ENABLE, GX_TEVPREV);
+    GXSetTevAlphaIn(GX_TEVSTAGE0, GX_CA_ZERO, GX_CA_ZERO, GX_CA_ZERO, GX_CA_A0);
+    GXSetTevAlphaOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_ENABLE, GX_TEVPREV);
+
+    if (mClipZ) {
+        GXSetZMode(GX_ENABLE, GX_LEQUAL, GX_ENABLE);
+    } else {
+        GXSetZMode(GX_DISABLE, GX_LEQUAL, GX_DISABLE);
+    }
+
+    GXSetBlendMode(GX_BM_BLEND, GX_BL_SRC_ALPHA, GX_BL_INV_SRC_ALPHA, GX_LO_CLEAR);
+    GXSetAlphaCompare(GX_ALWAYS, 0, GX_AOP_OR, GX_ALWAYS, 0);
+    GXSetCullMode(GX_CULL_NONE);
+    GXSetClipMode(GX_CLIP_ENABLE);
+    GXSetPointSize(mLineWidth, GX_TO_ZERO);
+
+    GXLoadPosMtxImm(j3dSys.getViewMtx(), 0);
+    GXSetCurrentMtx(0);
+
+    GXBegin(GX_POINTS, GX_VTXFMT0, 1);
+    GXPosition3f32(mPosition.x, mPosition.y, mPosition.z);
+    GXEnd();
+
+    j3dSys.reinitGX();
+    J3DShape::resetVcdVatCache();
+}
+
+mDoExt_circlePacket::mDoExt_circlePacket(cXyz& i_position, f32 i_radius, const GXColor& i_color, u8 i_clipZ, u8 i_lineWidth) {
+    mPosition = i_position;
+    mRadius = i_radius;
+    mColor = i_color;
+    mClipZ = i_clipZ;
+    mLineWidth = i_lineWidth;
+}
+
+void mDoExt_circlePacket::draw() {
+    GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_POS, GX_POS_XYZ, GX_F32, 0);
+    GXClearVtxDesc();
+    GXSetVtxDesc(GX_VA_POS, GX_DIRECT);
+    GXSetNumChans(1);
+    GXSetChanCtrl(GX_COLOR0, GX_DISABLE, GX_SRC_REG, GX_SRC_REG, GX_LIGHT_NULL, GX_DF_CLAMP, GX_AF_NONE);
+    GXSetNumTexGens(0);
+    GXSetNumTevStages(1);
+    GXSetTevColor(GX_TEVREG0, mColor);
+    GXSetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD_NULL, GX_TEXMAP_NULL, GX_COLOR0A0);
+    GXSetTevColorIn(GX_TEVSTAGE0, GX_CC_ZERO, GX_CC_ZERO, GX_CC_ZERO, GX_CC_C0);
+    GXSetTevColorOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_ENABLE, GX_TEVPREV);
+    GXSetTevAlphaIn(GX_TEVSTAGE0, GX_CA_ZERO, GX_CA_ZERO, GX_CA_ZERO, GX_CA_A0);
+    GXSetTevAlphaOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_ENABLE, GX_TEVPREV);
+
+    if (mClipZ) {
+        GXSetZMode(GX_ENABLE, GX_LEQUAL, GX_ENABLE);
+    } else {
+        GXSetZMode(GX_DISABLE, GX_LEQUAL, GX_DISABLE);
+    }
+
+    GXSetBlendMode(GX_BM_BLEND, GX_BL_SRC_ALPHA, GX_BL_INV_SRC_ALPHA, GX_LO_CLEAR);
+    GXSetAlphaCompare(GX_ALWAYS, 0, GX_AOP_OR, GX_ALWAYS, 0);
+    GXSetCullMode(GX_CULL_NONE);
+    GXSetClipMode(GX_CLIP_ENABLE);
+    GXSetLineWidth(mLineWidth, GX_TO_ZERO);
+    GXLoadPosMtxImm(j3dSys.getViewMtx(), 0);
+    GXSetCurrentMtx(0);
+
+    cXyz sp38;
+    cXyz sp44;
+    int numEdges = 36;
+    sp38.y = sp44.y = mPosition.y;
+    
+    GXBegin(GX_LINES, GX_VTXFMT0, numEdges * 2);
+    for (int i = 0; i < numEdges; i++) {
+        sp38.x = cM_fcos((i * 6.2831855f) / numEdges) * mRadius;
+        sp38.z = cM_fsin((i * 6.2831855f) / numEdges) * mRadius;
+
+        sp44.x = cM_fcos(((i + 1) * 6.2831855f) / numEdges) * mRadius;
+        sp44.z = cM_fsin(((i + 1) * 6.2831855f) / numEdges) * mRadius;
+
+        sp38.x += mPosition.x;
+        sp38.z += mPosition.z;
+        sp44.x += mPosition.x;
+        sp44.z += mPosition.z;
+        GXPosition3f32(sp38.x, sp38.y, sp38.z);
+        GXPosition3f32(sp44.x, sp44.y, sp44.z);
+    }
+    GXEnd();
+}
+
+mDoExt_spherePacket::mDoExt_spherePacket(cXyz& i_position, f32 i_size, const GXColor& i_color, u8 i_clipZ) {
+    mPosition = i_position;
+    mSize = i_size;
+    mColor = i_color;
+    mClipZ = i_clipZ;
+}
+
+void mDoExt_spherePacket::draw() {
+    GXSetNumChans(1);
+    GXSetChanCtrl(GX_COLOR0, GX_ENABLE, GX_SRC_REG, GX_SRC_REG, GX_LIGHT0, GX_DF_CLAMP, GX_AF_NONE);
+    GXSetNumTexGens(0);
+    GXSetNumTevStages(1);
+    GXSetTevColor(GX_TEVREG0, mColor);
+    GXSetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD_NULL, GX_TEXMAP_NULL, GX_COLOR0A0);
+    GXSetTevColorIn(GX_TEVSTAGE0, GX_CC_ZERO, GX_CC_RASC, GX_CC_C0, GX_CC_ZERO);
+    GXSetTevColorOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_ENABLE, GX_TEVPREV);
+    GXSetTevAlphaIn(GX_TEVSTAGE0, GX_CA_ZERO, GX_CA_ZERO, GX_CA_ZERO, GX_CA_A0);
+    GXSetTevAlphaOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_ENABLE, GX_TEVPREV);
+
+    if (mClipZ) {
+        GXSetZMode(GX_ENABLE, GX_LEQUAL, GX_ENABLE);
+    } else {
+        GXSetZMode(GX_DISABLE, GX_LEQUAL, GX_DISABLE);
+    }
+
+    GXSetBlendMode(GX_BM_BLEND, GX_BL_SRC_ALPHA, GX_BL_INV_SRC_ALPHA, GX_LO_CLEAR);
+    GXSetAlphaCompare(GX_ALWAYS, 0, GX_AOP_OR, GX_ALWAYS, 0);
+    GXSetCullMode(GX_CULL_BACK);
+    GXSetClipMode(GX_CLIP_ENABLE);
+
+    mDoMtx_stack_c::copy(j3dSys.getViewMtx());
+    mDoMtx_stack_c::transM(mPosition.x, mPosition.y, mPosition.z);
+    mDoMtx_stack_c::scaleM(mSize, mSize, mSize);
+
+    GXLoadPosMtxImm(mDoMtx_stack_c::get(), 0);
+    mDoMtx_stack_c::inverseTranspose();
+
+    GXLoadNrmMtxImm(mDoMtx_stack_c::get(), 0);
+    GXSetCurrentMtx(0);
+
+    GXDrawSphere(8, 8);
+}
+
+mDoExt_cylinderPacket::mDoExt_cylinderPacket(cXyz& i_position, f32 i_radius, f32 i_height, const GXColor& i_color, u8 i_clipZ) {
+    mPosition = i_position;
+    mRadius = i_radius;
+    mHeight = i_height;
+    mColor = i_color;
+    mClipZ = i_clipZ;
+}
+
+void mDoExt_cylinderPacket::draw() {
+    GXSetNumChans(1);
+    GXSetChanCtrl(GX_COLOR0, GX_ENABLE, GX_SRC_REG, GX_SRC_REG, 1, GX_DF_CLAMP, GX_AF_NONE);
+    GXSetNumTexGens(0);
+    GXSetNumTevStages(1);
+    GXSetTevColor(GX_TEVREG0, mColor);
+    GXSetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD_NULL, GX_TEXMAP_NULL, GX_COLOR0A0);
+    GXSetTevColorIn(GX_TEVSTAGE0, GX_CC_ZERO, GX_CC_RASC, GX_CC_C0, GX_CC_ZERO);
+    GXSetTevColorOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_TRUE, GX_TEVPREV);
+    GXSetTevAlphaIn(GX_TEVSTAGE0, GX_CA_ZERO, GX_CA_ZERO, GX_CA_ZERO, GX_CA_A0);
+    GXSetTevAlphaOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_TRUE, GX_TEVPREV);
+
+    if (mClipZ) {
+        GXSetZMode(GX_ENABLE, GX_LEQUAL, GX_ENABLE);
+    } else {
+        GXSetZMode(GX_DISABLE, GX_LEQUAL, GX_DISABLE);
+    }
+
+    GXSetBlendMode(GX_BM_BLEND, GX_BL_SRC_ALPHA, GX_BL_INV_SRC_ALPHA, GX_LO_CLEAR);
+    GXSetAlphaCompare(GX_ALWAYS, 0, GX_AOP_OR, GX_ALWAYS, 0);
+    GXSetCullMode(GX_CULL_BACK);
+    GXSetClipMode(GX_CLIP_ENABLE);
+
+    f32 var_f31 = mHeight * 0.5f;
+
+    mDoMtx_stack_c::copy(j3dSys.getViewMtx());
+    mDoMtx_stack_c::transM(mPosition.x, mPosition.y + var_f31, mPosition.z);
+    mDoMtx_stack_c::scaleM(mRadius, var_f31, mRadius);
+    mDoMtx_stack_c::XrotM(0x4000);
+
+    GXLoadPosMtxImm(mDoMtx_stack_c::get(), 0);
+    mDoMtx_stack_c::inverseTranspose();
+
+    GXLoadNrmMtxImm(mDoMtx_stack_c::get(), 0);
+    GXSetCurrentMtx(0);
+    GXDrawCylinder(8);
+}
+
+mDoExt_cylinderMPacket::mDoExt_cylinderMPacket(Mtx i_mtx, const GXColor& i_color, u8 i_clipZ) {
+    cMtx_copy(i_mtx, mMatrix);
+    mColor = i_color;
+    mClipZ = i_clipZ;
+}
+
+void mDoExt_cylinderMPacket::draw() {
+    GXSetNumChans(1);
+    GXSetChanCtrl(GX_COLOR0, GX_ENABLE, GX_SRC_REG, GX_SRC_REG, GX_LIGHT0, GX_DF_CLAMP, GX_AF_NONE);
+    GXSetNumTexGens(0);
+    GXSetNumTevStages(1);
+    GXSetTevColor(GX_TEVREG0, mColor);
+    GXSetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD_NULL, GX_TEXMAP_NULL, GX_COLOR0A0);
+    GXSetTevColorIn(GX_TEVSTAGE0, GX_CC_ZERO, GX_CC_RASC, GX_CC_C0, GX_CC_ZERO);
+    GXSetTevColorOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_ENABLE, GX_TEVPREV);
+    GXSetTevAlphaIn(GX_TEVSTAGE0, GX_CA_ZERO, GX_CA_ZERO, GX_CA_ZERO, GX_CA_A0);
+    GXSetTevAlphaOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_ENABLE, GX_TEVPREV);
+
+    if (mClipZ) {
+        GXSetZMode(GX_ENABLE, GX_LEQUAL, GX_ENABLE);
+    } else {
+        GXSetZMode(GX_DISABLE, GX_LEQUAL, GX_DISABLE);
+    }
+
+    GXSetBlendMode(GX_BM_BLEND, GX_BL_SRC_ALPHA, GX_BL_INV_SRC_ALPHA, GX_LO_CLEAR);
+    GXSetAlphaCompare(GX_ALWAYS, 0, GX_AOP_OR, GX_ALWAYS, 0);
+    GXSetCullMode(GX_CULL_BACK);
+    GXSetClipMode(GX_CLIP_ENABLE);
+
+    cMtx_concat(j3dSys.getViewMtx(), mMatrix, mMatrix);
+
+    GXLoadPosMtxImm(mMatrix, 0);
+    cMtx_inverseTranspose(mMatrix, mMatrix);
+
+    GXLoadNrmMtxImm(mMatrix, 0);
+    GXSetCurrentMtx(0);
+
+    GXDrawCylinder(8);
+}
+#endif
+
 /* 800165E4-8001683C       .text mDoExt_initFontCommon__FPP7JUTFontPP7ResFONTP7JKRHeapPCcP10JKRArchiveUcUlUl */
 void mDoExt_initFontCommon(JUTFont** p_font, ResFONT** p_resfont, JKRHeap* p_heap, const char* param_4,
                            JKRArchive* p_archive, u8 param_6, u32 param_7, u32 param_8) {


### PR DESCRIPTION
This copies several debug-only TUs from TP decomp (mostly debug drawing code) and links them when building with the `--debug` flag.

This helps reduce some of the fake diffs shown when running `debug_map_diff.py` as the debug build is now a bit closer to matching. Eventually it might allow actually using the debug draw code ingame, but for now the debug build still crashes on boot.