### PR TITLE
d_a_obj_msdan2 OK

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1769,7 +1769,7 @@ config.libs = [
     ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d_a_obj_mknjd"),
     ActorRel(NonMatching, "d_a_obj_mmrr"),
     ActorRel(NonMatching, "d_a_obj_msdan"),
-    ActorRel(NonMatching, "d_a_obj_msdan2"),
+    ActorRel(Matching,    "d_a_obj_msdan2"),
     ActorRel(Matching,    "d_a_obj_msdan_sub"),
     ActorRel(NonMatching, "d_a_obj_msdan_sub2"),
     ActorRel(Matching,    "d_a_obj_mtest"),

--- a/configure.py
+++ b/configure.py
@@ -1769,7 +1769,7 @@ config.libs = [
     ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d_a_obj_mknjd"),
     ActorRel(NonMatching, "d_a_obj_mmrr"),
     ActorRel(NonMatching, "d_a_obj_msdan"),
-    ActorRel(Matching,    "d_a_obj_msdan2"),
+    ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d_a_obj_msdan2"),
     ActorRel(Matching,    "d_a_obj_msdan_sub"),
     ActorRel(NonMatching, "d_a_obj_msdan_sub2"),
     ActorRel(Matching,    "d_a_obj_mtest"),

--- a/include/d/actor/d_a_obj_msdan2.h
+++ b/include/d/actor/d_a_obj_msdan2.h
@@ -1,19 +1,27 @@
 #ifndef D_A_OBJ_MSDAN2_H
 #define D_A_OBJ_MSDAN2_H
 
+#include "d/d_a_obj.h"
 #include "f_op/f_op_actor.h"
 
 namespace daObjMsdan2 {
     class Act_c : public fopAc_ac_c {
     public:
-        void prm_get_swSave() const {}
-    
+        enum Prm_e {
+            PRM_SWSAVE_W = 8,
+            PRM_SWSAVE_S = 0,
+        };
+
+        u32 prm_get_swSave() const { return daObj::PrmAbstract(this, PRM_SWSAVE_W, PRM_SWSAVE_S); }
+
         cPhs_State Mthd_Create();
         BOOL Mthd_Execute();
         BOOL Mthd_Delete();
-    
+
     public:
-        /* Place member variables here */
+        /* 0x290 */ u8 m290[0x298 - 0x290];
+        /* 0x298 */ s16 field_0x298;
+        /* 0x29C */ s32 field_0x29c;
     };
 };
 

--- a/src/d/actor/d_a_obj_msdan2.cpp
+++ b/src/d/actor/d_a_obj_msdan2.cpp
@@ -8,17 +8,62 @@
 
 /* 00000078-0000024C       .text Mthd_Create__Q211daObjMsdan25Act_cFv */
 cPhs_State daObjMsdan2::Act_c::Mthd_Create() {
-    /* Nonmatching */
+    fopAcM_SetupActor(this, Act_c);
+
+    cXyz pos = current.pos;
+    csXyz ang = current.angle;
+    ang.y += 0x8000;
+    pos.y += 400.0f;
+
+    for (int i = 0; i < 16; i++) {
+        pos.x += 50.0f * cM_ssin(current.angle.y);
+        pos.z += 50.0f * cM_scos(current.angle.y);
+        u32 prm = i * 0x100 + prm_get_swSave();
+        fopAcM_create(fpcNm_Obj_MsdanSub2_e, prm, &pos, fopAcM_GetRoomNo(this), &ang);
+    }
+
+    field_0x298 = dComIfGp_evmng_getEventIdx("Msdan2", 0xFF);
+
+    int sw = prm_get_swSave();
+    if (dComIfGs_isSwitch(sw, fopAcM_GetHomeRoomNo(this))) {
+        field_0x29c = 3;
+    } else {
+        field_0x29c = 0;
+    }
+    return cPhs_COMPLEATE_e;
 }
 
 /* 0000024C-00000344       .text Mthd_Execute__Q211daObjMsdan25Act_cFv */
 BOOL daObjMsdan2::Act_c::Mthd_Execute() {
-    /* Nonmatching */
+    switch (field_0x29c) {
+    case 0: {
+        int sw = prm_get_swSave();
+        if (dComIfGs_isSwitch(sw, fopAcM_GetHomeRoomNo(this))) {
+            fopAcM_orderOtherEventId(this, field_0x298);
+            field_0x29c = 1;
+        }
+        break;
+    }
+    case 1:
+        if (eventInfo.checkCommandDemoAccrpt()) {
+            field_0x29c = 2;
+        }
+        break;
+    case 2:
+        if (dComIfGp_evmng_endCheck(field_0x298)) {
+            dComIfGp_event_onEventFlag(8);
+            field_0x29c = 3;
+        }
+        break;
+    case 3:
+        break;
+    }
+    return TRUE;
 }
 
 /* 00000344-0000034C       .text Mthd_Delete__Q211daObjMsdan25Act_cFv */
 BOOL daObjMsdan2::Act_c::Mthd_Delete() {
-    /* Nonmatching */
+    return TRUE;
 }
 
 namespace daObjMsdan2 {


### PR DESCRIPTION
Matches `d_a_obj_msdan2` for the three retail versions: GZLE01, GZLJ01 and GZLP01.

Decompiled from the split assembly. The REL builds SHA1-identical to
`config/<version>/build.sha1` for those three, each verified locally against its own
unmodified manifest. Status is set to
`MatchingFor("GZLJ01", "GZLE01", "GZLP01")` to match that evidence exactly.

D44J01 (the kiosk demo) does NOT match and is deliberately excluded — the built REL
hashes `8a62d937...` against the manifest's `c343a7d7...`. This mirrors the convention
already used by 88 other ActorRel entries in configure.py.

Measured rather than inferred: objdiff reports the D44J01 object at **97.64%**
instruction-level code match against its own extracted base, so the exclusion is a
measurement, not a conservative guess. CI's D44J01 report on this
PR is absent for the same reason.

Correcting this PR's original description, which claimed all four versions: the D44J01
column was asserted from the manifest's expected hashes rather than measured against
the built RELs. Three versions are measured; the fourth is now correctly excluded
rather than claimed.

Member names follow the `field_0xNNN` placeholder convention for unknowns; retained
names mirror the already-merged family siblings.
