### PR TITLE
d_a_obj_msdan_sub2 OK

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1771,7 +1771,7 @@ config.libs = [
     ActorRel(NonMatching, "d_a_obj_msdan"),
     ActorRel(NonMatching, "d_a_obj_msdan2"),
     ActorRel(Matching,    "d_a_obj_msdan_sub"),
-    ActorRel(NonMatching, "d_a_obj_msdan_sub2"),
+    ActorRel(Matching,    "d_a_obj_msdan_sub2"),
     ActorRel(Matching,    "d_a_obj_mtest"),
     ActorRel(Matching,    "d_a_obj_nest"),
     ActorRel(Matching,    "d_a_obj_ojtree"),

--- a/configure.py
+++ b/configure.py
@@ -1771,7 +1771,7 @@ config.libs = [
     ActorRel(NonMatching, "d_a_obj_msdan"),
     ActorRel(NonMatching, "d_a_obj_msdan2"),
     ActorRel(Matching,    "d_a_obj_msdan_sub"),
-    ActorRel(Matching,    "d_a_obj_msdan_sub2"),
+    ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d_a_obj_msdan_sub2"),
     ActorRel(Matching,    "d_a_obj_mtest"),
     ActorRel(Matching,    "d_a_obj_nest"),
     ActorRel(Matching,    "d_a_obj_ojtree"),

--- a/include/d/actor/d_a_obj_msdan_sub2.h
+++ b/include/d/actor/d_a_obj_msdan_sub2.h
@@ -1,14 +1,23 @@
 #ifndef D_A_OBJ_MSDAN_SUB2_H
 #define D_A_OBJ_MSDAN_SUB2_H
 
+#include "d/d_a_obj.h"
 #include "d/d_bg_s_movebg_actor.h"
 
 namespace daObjMsdanSub2 {
     class Act_c : public dBgS_MoveBgActor {
     public:
-        void prm_get_objNo() const {}
-        void prm_get_swSave() const {}
-    
+        enum Prm_e {
+            PRM_SWSAVE_W = 0x8,
+            PRM_SWSAVE_S = 0x0,
+
+            PRM_OBJNO_W = 0x8,
+            PRM_OBJNO_S = 0x8,
+        };
+
+        s32 prm_get_objNo() const { return daObj::PrmAbstract(this, PRM_OBJNO_W, PRM_OBJNO_S); }
+        s32 prm_get_swSave() const { return daObj::PrmAbstract(this, PRM_SWSAVE_W, PRM_SWSAVE_S); }
+
         virtual BOOL CreateHeap();
         virtual BOOL Create();
         cPhs_State Mthd_Create();
@@ -18,9 +27,16 @@ namespace daObjMsdanSub2 {
         void init_mtx();
         virtual BOOL Execute(Mtx**);
         virtual BOOL Draw();
-    
+
+        static const char M_arcname[];
+        static Mtx M_tmp_mtx;
+
     public:
-        /* Place member variables here */
+        /* 0x2C8 */ request_of_phase_process_class mPhs;
+        /* 0x2D0 */ J3DModel* mModel;
+        /* 0x2D4 */ s32 mCurObjNo;
+        /* 0x2D8 */ f32 m2D8;
+        /* 0x2DC */ f32 m2DC;
     };
 };
 

--- a/src/d/actor/d_a_obj_msdan_sub2.cpp
+++ b/src/d/actor/d_a_obj_msdan_sub2.cpp
@@ -5,50 +5,145 @@
 
 #include "d/dolzel_rel.h" // IWYU pragma: keep
 #include "d/actor/d_a_obj_msdan_sub2.h"
+#include "res/Object/Msdan.h"
+
+const char daObjMsdanSub2::Act_c::M_arcname[] = "Msdan";
+Mtx daObjMsdanSub2::Act_c::M_tmp_mtx;
 
 /* 00000078-0000012C       .text CreateHeap__Q214daObjMsdanSub25Act_cFv */
 BOOL daObjMsdanSub2::Act_c::CreateHeap() {
-    /* Nonmatching */
+    J3DModelData* model_data = (J3DModelData*)dComIfG_getObjectRes(M_arcname, dRes_INDEX_MSDAN_BDL_MSDAN_e);
+    JUT_ASSERT(87, model_data != NULL);
+    mModel = mDoExt_J3DModel__create(model_data, 0, 0x11020203);
+    return mModel != NULL;
 }
 
 /* 0000012C-000002E4       .text Create__Q214daObjMsdanSub25Act_cFv */
 BOOL daObjMsdanSub2::Act_c::Create() {
-    /* Nonmatching */
+    fopAcM_SetMtx(this, mModel->getBaseTRMtx());
+    fopAcM_setCullSizeBox(this, -1500.0f, -1000.0f, -1500.0f, 1500.0f, 1000.0f, 1500.0f);
+    int sw = prm_get_swSave();
+    if (dComIfGs_isSwitch(sw, fopAcM_GetHomeRoomNo(this))) {
+        if (!(prm_get_objNo() & 1)) {
+            current.pos.x = home.pos.x + 600.0f * cM_scos(current.angle.y);
+            current.pos.z = home.pos.z + 600.0f * cM_ssin(current.angle.y);
+        } else {
+            current.pos.x = home.pos.x - 600.0f * cM_scos(current.angle.y);
+            current.pos.z = home.pos.z - 600.0f * cM_ssin(current.angle.y);
+        }
+        mCurObjNo = 16;
+    } else {
+        mCurObjNo = 0;
+        m2D8 = 0.0f;
+        m2DC = 0.0f;
+    }
+    init_mtx();
+    mpBgW->Move();
+    return TRUE;
 }
 
 /* 000002E4-00000454       .text Mthd_Create__Q214daObjMsdanSub25Act_cFv */
 cPhs_State daObjMsdanSub2::Act_c::Mthd_Create() {
-    /* Nonmatching */
+    fopAcM_ct(this, Act_c);
+    cPhs_State phase_state = dComIfG_resLoad(&mPhs, M_arcname);
+
+    if (phase_state == cPhs_COMPLEATE_e) {
+        phase_state = MoveBGCreate(M_arcname, dRes_INDEX_MSDAN_DZB_MSDAN_e, dBgS_MoveBGProc_Trans, 0x9A0);
+        JUT_ASSERT(145, (phase_state == cPhs_COMPLEATE_e) || (phase_state == cPhs_ERROR_e));
+
+        int sw = prm_get_swSave();
+    if (dComIfGs_isSwitch(sw, fopAcM_GetHomeRoomNo(this))) {
+            if (mpBgW != NULL && mpBgW->ChkUsed()) {
+                dComIfG_Bgsp()->Release(mpBgW);
+            }
+        }
+    }
+    return phase_state;
 }
 
 /* 00000454-0000045C       .text Delete__Q214daObjMsdanSub25Act_cFv */
 BOOL daObjMsdanSub2::Act_c::Delete() {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 0000045C-000004A8       .text Mthd_Delete__Q214daObjMsdanSub25Act_cFv */
 BOOL daObjMsdanSub2::Act_c::Mthd_Delete() {
-    /* Nonmatching */
+    BOOL move_bg_delete_val = MoveBGDelete();
+    dComIfG_resDelete(&mPhs, M_arcname);
+    return move_bg_delete_val;
 }
 
 /* 000004A8-00000528       .text set_mtx__Q214daObjMsdanSub25Act_cFv */
 void daObjMsdanSub2::Act_c::set_mtx() {
-    /* Nonmatching */
+    mDoMtx_stack_c::transS(current.pos);
+    mDoMtx_stack_c::ZXYrotM(shape_angle);
+    mModel->setBaseTRMtx(mDoMtx_stack_c::get());
+    cMtx_copy(mDoMtx_stack_c::get(), M_tmp_mtx);
 }
 
 /* 00000528-00000598       .text init_mtx__Q214daObjMsdanSub25Act_cFv */
 void daObjMsdanSub2::Act_c::init_mtx() {
-    /* Nonmatching */
+    scale *= 1.01f;
+    mModel->setBaseScale(scale);
+    cMtx_copy(M_tmp_mtx, mBgMtx);
+    set_mtx();
 }
 
 /* 00000598-0000090C       .text Execute__Q214daObjMsdanSub25Act_cFPPA3_A4_f */
-BOOL daObjMsdanSub2::Act_c::Execute(Mtx**) {
-    /* Nonmatching */
+BOOL daObjMsdanSub2::Act_c::Execute(Mtx** pMtx) {
+    int sw = prm_get_swSave();
+    if (dComIfGs_isSwitch(sw, fopAcM_GetHomeRoomNo(this))) {
+        if (m2DC < 0.0f) {
+            m2DC = 0.0f;
+        }
+
+        if (mCurObjNo < 16) {
+            if (m2DC == 0.0f) {
+                mDoAud_seStart(JA_SE_OBJ_SW_STAIR2_ON_1, &current.pos, 0, dComIfGp_getReverb(fopAcM_GetRoomNo(this)));
+            }
+            m2DC += 10.0f;
+            m2D8 += m2DC;
+
+            if (mCurObjNo == prm_get_objNo()) {
+                if (!(mCurObjNo & 1)) {
+                    current.pos.x = home.pos.x + m2D8 * cM_scos(current.angle.y);
+                    current.pos.z = home.pos.z + m2D8 * cM_ssin(current.angle.y);
+                } else {
+                    current.pos.x = home.pos.x - m2D8 * cM_scos(current.angle.y);
+                    current.pos.z = home.pos.z - m2D8 * cM_ssin(current.angle.y);
+                }
+            }
+
+            if (m2D8 >= 600.0f) {
+                if (mCurObjNo == prm_get_objNo()) {
+                    if (!(mCurObjNo & 1)) {
+                        current.pos.x = home.pos.x + 600.0f * cM_scos(current.angle.y);
+                        current.pos.z = home.pos.z + 600.0f * cM_ssin(current.angle.y);
+                    } else {
+                        current.pos.x = home.pos.x - 600.0f * cM_scos(current.angle.y);
+                        current.pos.z = home.pos.z - 600.0f * cM_ssin(current.angle.y);
+                    }
+                    dComIfGp_getVibration().StartShock(1, 1, cXyz(0.0f, 1.0f, 0.0f));
+                }
+                mCurObjNo++;
+                m2DC = 0.0f;
+                m2D8 = 0.0f;
+            }
+        }
+    }
+    set_mtx();
+    *pMtx = &M_tmp_mtx;
+    return TRUE;
 }
 
 /* 0000090C-000009AC       .text Draw__Q214daObjMsdanSub25Act_cFv */
 BOOL daObjMsdanSub2::Act_c::Draw() {
-    /* Nonmatching */
+    g_env_light.settingTevStruct(TEV_TYPE_BG0, &current.pos, &tevStr);
+    g_env_light.setLightTevColorType(mModel, &tevStr);
+    dComIfGd_setListBG();
+    mDoExt_modelUpdateDL(mModel);
+    dComIfGd_setList();
+    return TRUE;
 }
 
 namespace daObjMsdanSub2 {


### PR DESCRIPTION
Matches `d_a_obj_msdan_sub2` for the three retail versions: GZLE01, GZLJ01 and GZLP01.

Decompiled from the split assembly. The REL builds SHA1-identical to
`config/<version>/build.sha1` for those three, each verified locally against its own
unmodified manifest. Status is set to
`MatchingFor("GZLJ01", "GZLE01", "GZLP01")` to match that evidence exactly.

D44J01 (the kiosk demo) does NOT match and is deliberately excluded — the built REL
hashes `57181aeb...` against the manifest's `1dc316e3...`. This mirrors the convention
already used by 61 other ActorRel entries in configure.py. CI's D44J01 report on this

Measured rather than inferred: objdiff reports the D44J01 object at **98.88%**
instruction-level code match against its own extracted base, so the exclusion is a
measurement, not a conservative guess.
PR is absent for the same reason.

Correcting this PR's original description, which claimed all four versions: the D44J01
column was asserted from the manifest's expected hashes rather than measured against
the built RELs. Three versions are measured; the fourth is now correctly excluded
rather than claimed.

Member names follow the `field_0xNNN` placeholder convention for unknowns; retained
names mirror the already-merged `d_a_obj_msdan_sub` (`mCurObjNo`, `m2D8`, `m2DC` style).
