### PR TITLE
d_a_obj_hami2 OK

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1747,7 +1747,7 @@ config.libs = [
     ActorRel(Matching,    "d_a_obj_gnndemotakis"),
     ActorRel(Matching,    "d_a_obj_gong"),
     ActorRel(Matching,    "d_a_obj_gtaki"),
-    ActorRel(NonMatching, "d_a_obj_hami2"),
+    ActorRel(Matching,    "d_a_obj_hami2"),
     ActorRel(Matching,    "d_a_obj_hami3"),
     ActorRel(Matching,    "d_a_obj_hami4"),
     ActorRel(Matching,    "d_a_obj_hat"),

--- a/configure.py
+++ b/configure.py
@@ -1747,7 +1747,7 @@ config.libs = [
     ActorRel(Matching,    "d_a_obj_gnndemotakis"),
     ActorRel(Matching,    "d_a_obj_gong"),
     ActorRel(Matching,    "d_a_obj_gtaki"),
-    ActorRel(Matching,    "d_a_obj_hami2"),
+    ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d_a_obj_hami2"),
     ActorRel(Matching,    "d_a_obj_hami3"),
     ActorRel(Matching,    "d_a_obj_hami4"),
     ActorRel(Matching,    "d_a_obj_hat"),

--- a/include/d/actor/d_a_obj_hami2.h
+++ b/include/d/actor/d_a_obj_hami2.h
@@ -1,13 +1,20 @@
 #ifndef D_A_OBJ_HAMI2_H
 #define D_A_OBJ_HAMI2_H
 
+#include "d/d_a_obj.h"
 #include "d/d_bg_s_movebg_actor.h"
+
+class dBgW;
 
 namespace daObjHami2 {
     class Act_c : public dBgS_MoveBgActor {
     public:
-        void prm_get_swSave() const {}
-    
+        enum Prm_e {
+            PRM_SWSAVE_W = 0x08,
+            PRM_SWSAVE_S = 0x00,
+        };
+        int prm_get_swSave() const { return daObj::PrmAbstract<Prm_e>(this, PRM_SWSAVE_W, PRM_SWSAVE_S); }
+
         virtual BOOL CreateHeap();
         virtual BOOL Create();
         cPhs_State Mthd_Create();
@@ -23,10 +30,22 @@ namespace daObjHami2 {
         void daObjHami2_close_demo();
         virtual BOOL Execute(Mtx**);
         virtual BOOL Draw();
-    
+
+        static Mtx M_tmp_mtx;
+        static const char M_arcname[];
+        static const char M_evname[];
+
     public:
-        /* Place member variables here */
-    };
+        /* 0x2C8 */ s16 field_0x2C8;
+        /* 0x2CA */ s16 field_0x2CA;
+        /* 0x2CC */ request_of_phase_process_class field_0x2CC;
+        /* 0x2D4 */ J3DModel* field_0x2D4;
+        /* 0x2D8 */ dBgW* field_0x2D8;
+        /* 0x2DC */ Mtx field_0x2DC;
+        /* 0x30C */ int field_0x30C;
+        /* 0x310 */ s16 field_0x310;
+        /* 0x312 */ s16 field_0x312;
+    };  // Size: 0x314
 };
 
 #endif /* D_A_OBJ_HAMI2_H */

--- a/src/d/actor/d_a_obj_hami2.cpp
+++ b/src/d/actor/d_a_obj_hami2.cpp
@@ -5,86 +5,225 @@
 
 #include "d/dolzel_rel.h" // IWYU pragma: keep
 #include "d/actor/d_a_obj_hami2.h"
+#include "SSystem/SComponent/c_lib.h"
+#include "d/d_com_inf_game.h"
+#include "res/Object/Hami2.h"
 #include "m_Do/m_Do_ext.h"
+#include "m_Do/m_Do_mtx.h"
+
+const char daObjHami2::Act_c::M_arcname[] = "Hami2";
+const char daObjHami2::Act_c::M_evname[] = "ami_cam";
+Mtx daObjHami2::Act_c::M_tmp_mtx;
 
 /* 00000078-0000012C       .text nodeCallBack__FP7J3DNodei */
-static BOOL nodeCallBack(J3DNode*, int) {
-    /* Nonmatching */
+static BOOL nodeCallBack(J3DNode *node, int calcTiming) {
+    if (calcTiming == J3DNodeCBCalcTiming_In) {
+        J3DJoint *joint = (J3DJoint *)node;
+        s32 jntNo = joint->getJntNo();
+        J3DModel *model = j3dSys.getModel();
+        daObjHami2::Act_c* i_this = (daObjHami2::Act_c *)model->getUserArea();
+        if (i_this != NULL) {
+            MTXCopy(model->getAnmMtx(jntNo), *calc_mtx);
+            cMtx_YrotM(*calc_mtx, i_this->field_0x2C8);
+            model->setAnmMtx(jntNo, *calc_mtx);
+            cMtx_copy(*calc_mtx, J3DSys::mCurrentMtx);
+        }
+    }
+    return TRUE;
 }
 
 /* 0000012C-0000032C       .text CreateHeap__Q210daObjHami25Act_cFv */
 BOOL daObjHami2::Act_c::CreateHeap() {
-    /* Nonmatching */
+    J3DModelData *modelData = (J3DModelData *)dComIfG_getObjectRes(M_arcname, dRes_INDEX_HAMI2_BDL_HAMI2_e);
+    JUT_ASSERT(104, modelData != NULL);
+
+    field_0x2D4 = mDoExt_J3DModel__create(modelData, 0, 0x11020203);
+    if (field_0x2D4 != NULL) {
+        const char *jointName;
+        JUTNameTab *jointNameTab = field_0x2D4->getModelData()->getJointName();
+        for (u16 i = 0; i < field_0x2D4->getModelData()->getJointNum(); i++) {
+            jointName = jointNameTab->getName(i);
+            if (strcmp("mono1", jointName) == 0) {
+                field_0x2D4->getModelData()->getJointNodePointer(i)->setCallBack(nodeCallBack);
+                break;
+            }
+        }
+        field_0x2D4->setUserArea((u32)this);
+    } else {
+        return FALSE;
+    }
+
+    int ok = 1;
+    mDoMtx_stack_c::transS(current.pos);
+    mDoMtx_stack_c::YrotM(shape_angle.y);
+    mDoMtx_stack_c::scaleM(scale.x, scale.y, scale.z);
+    cMtx_copy(mDoMtx_stack_c::get(), field_0x2DC);
+
+    field_0x2D8 = new dBgW();
+    if (field_0x2D8 == NULL || field_0x2D8->Set((cBgD_t *)dComIfG_getObjectRes(M_arcname, dRes_INDEX_HAMI2_DZB_HAMI2_e), 1, &field_0x2DC)) {
+        ok = 0;
+    }
+    if (ok != 1)
+        return FALSE;
+    return TRUE;
 }
 
 /* 0000032C-0000042C       .text Create__Q210daObjHami25Act_cFv */
 BOOL daObjHami2::Act_c::Create() {
-    /* Nonmatching */
+    fopAcM_SetMtx(this, field_0x2D4->getBaseTRMtx());
+
+    int switchIndex = prm_get_swSave();
+    if (fopAcM_isSwitch(this, switchIndex)) {
+        field_0x30C = 3;
+        field_0x2C8 = 0x4000;
+    } else {
+        field_0x30C = 0;
+        field_0x2C8 = 0;
+    }
+    init_mtx();
+
+    fopAcM_setCullSizeBox(this, -1200.0f, -40000.0f, -1200.0f, 1200.0f, 40000.0f, 1200.0f);
+    field_0x310 = dComIfGp_evmng_getEventIdx("AMI2_OPEN");
+    field_0x312 = dComIfGp_evmng_getEventIdx("AMI2_CLOSE");
+    return TRUE;
 }
 
 /* 0000042C-00000540       .text Mthd_Create__Q210daObjHami25Act_cFv */
 cPhs_State daObjHami2::Act_c::Mthd_Create() {
-    /* Nonmatching */
+    fopAcM_ct(this, daObjHami2::Act_c);
+    cPhs_State phase_state = dComIfG_resLoad(&field_0x2CC, M_arcname);
+    if (phase_state == cPhs_COMPLEATE_e) {
+        phase_state = MoveBGCreate(M_arcname, dRes_INDEX_HAMI2_DZB_HAMI2B_e, dBgS_MoveBGProc_TypicalRotY, 0x34e0);
+        dComIfG_Bgsp()->Regist(field_0x2D8, this);
+
+        JUT_ASSERT(200, (phase_state == cPhs_COMPLEATE_e) || (phase_state == cPhs_ERROR_e));
+    }
+    return phase_state;
 }
 
 /* 00000540-00000548       .text Delete__Q210daObjHami25Act_cFv */
-BOOL daObjHami2::Act_c::Delete() {
-    /* Nonmatching */
-}
+BOOL daObjHami2::Act_c::Delete() { return TRUE; }
 
 /* 00000548-000005E8       .text Mthd_Delete__Q210daObjHami25Act_cFv */
 BOOL daObjHami2::Act_c::Mthd_Delete() {
-    /* Nonmatching */
+    if (heap != NULL && field_0x2D8 != NULL && field_0x2D8->ChkUsed()) {
+        dComIfG_Bgsp()->Release(field_0x2D8);
+    }
+    u32 result = MoveBGDelete();
+    dComIfG_resDelete(&field_0x2CC, M_arcname);
+    return result;
 }
 
 /* 000005E8-00000678       .text set_mtx__Q210daObjHami25Act_cFv */
 void daObjHami2::Act_c::set_mtx() {
-    /* Nonmatching */
+    mDoMtx_stack_c::transS(current.pos);
+    mDoMtx_stack_c::ZXYrotM(shape_angle);
+    field_0x2D4->setBaseTRMtx(mDoMtx_stack_c::get());
+    mDoMtx_stack_c::YrotM(field_0x2C8);
+    cMtx_copy(mDoMtx_stack_c::get(), M_tmp_mtx);
 }
 
 /* 00000678-000006B4       .text init_mtx__Q210daObjHami25Act_cFv */
 void daObjHami2::Act_c::init_mtx() {
-    /* Nonmatching */
+    field_0x2D4->setBaseScale(scale);
+    set_mtx();
 }
 
 /* 000006B4-00000730       .text daObjHami2_close_stop__Q210daObjHami25Act_cFv */
 void daObjHami2::Act_c::daObjHami2_close_stop() {
-    /* Nonmatching */
+    int switchIndex = prm_get_swSave();
+    if (fopAcM_isSwitch(this, switchIndex)) {
+        fopAcM_orderOtherEventId(this, field_0x310, 0xff);
+        field_0x30C = 1;
+    }
 }
 
 /* 00000730-00000810       .text daObjHami2_open_demo_wait__Q210daObjHami25Act_cFv */
 void daObjHami2::Act_c::daObjHami2_open_demo_wait() {
-    /* Nonmatching */
+    if (eventInfo.checkCommandDemoAccrpt()) {
+        field_0x30C = 2;
+        mDoAud_seStart(JA_SE_OBJ_KAITEN_AMI_OPEN, &current.pos, 0, dComIfGp_getReverb(fopAcM_GetRoomNo(this)));
+        mDoAud_seStart(0x806, NULL, 0, 0);
+    } else {
+        fopAcM_orderOtherEventId(this, field_0x310, 0xff);
+    }
 }
 
 /* 00000810-000008A0       .text daObjHami2_open_demo__Q210daObjHami25Act_cFv */
 void daObjHami2::Act_c::daObjHami2_open_demo() {
-    /* Nonmatching */
+    field_0x2C8 += 0x100;
+    if (field_0x2C8 >= 0x4000) {
+        field_0x2C8 = 0x4000;
+        field_0x30C = 3;
+        dComIfGp_getVibration().StartShock(4, -0x21, cXyz(0.0f, 1.0f, 0.0f));
+        dComIfGp_event_onEventFlag(8);
+    }
 }
 
 /* 000008A0-0000091C       .text daObjHami2_open_stop__Q210daObjHami25Act_cFv */
 void daObjHami2::Act_c::daObjHami2_open_stop() {
-    /* Nonmatching */
+    int switchIndex = prm_get_swSave();
+    if (!fopAcM_isSwitch(this, switchIndex)) {
+        fopAcM_orderOtherEventId(this, field_0x312, 0xff);
+        field_0x30C = 4;
+    }
 }
 
 /* 0000091C-0000096C       .text daObjHami2_close_demo_wait__Q210daObjHami25Act_cFv */
 void daObjHami2::Act_c::daObjHami2_close_demo_wait() {
-    /* Nonmatching */
+    if (eventInfo.checkCommandDemoAccrpt()) {
+        field_0x30C = 5;
+    } else {
+        fopAcM_orderOtherEventId(this, field_0x312, 0xff);
+    }
 }
 
 /* 0000096C-00000A08       .text daObjHami2_close_demo__Q210daObjHami25Act_cFv */
 void daObjHami2::Act_c::daObjHami2_close_demo() {
-    /* Nonmatching */
+    field_0x2C8 -= 0x100;
+    if (field_0x2C8 <= 0) {
+        field_0x2C8 = 0;
+        dComIfGp_getVibration().StartShock(4, -0x21, cXyz(0.0f, 1.0f, 0.0f));
+        dComIfGp_event_onEventFlag(8);
+        field_0x30C = 0;
+    }
 }
 
 /* 00000A08-00000AB8       .text Execute__Q210daObjHami25Act_cFPPA3_A4_f */
-BOOL daObjHami2::Act_c::Execute(Mtx**) {
-    /* Nonmatching */
+BOOL daObjHami2::Act_c::Execute(Mtx **mtx) {
+    switch (field_0x30C) {
+    case 0:
+        daObjHami2_close_stop();
+        break;
+    case 1:
+        daObjHami2_open_demo_wait();
+        break;
+    case 2:
+        daObjHami2_open_demo();
+        break;
+    case 3:
+        daObjHami2_open_stop();
+        break;
+    case 4:
+        daObjHami2_close_demo_wait();
+        break;
+    case 5:
+        daObjHami2_close_demo();
+        break;
+    }
+    set_mtx();
+    *mtx = &M_tmp_mtx;
+    return true;
 }
 
 /* 00000AB8-00000B58       .text Draw__Q210daObjHami25Act_cFv */
 BOOL daObjHami2::Act_c::Draw() {
-    /* Nonmatching */
+    g_env_light.settingTevStruct(TEV_TYPE_BG0, &current.pos, &tevStr);
+    g_env_light.setLightTevColorType(field_0x2D4, &tevStr);
+    dComIfGd_setListBG();
+    mDoExt_modelUpdateDL(field_0x2D4);
+    dComIfGd_setList();
+    return TRUE;
 }
 
 namespace daObjHami2 {


### PR DESCRIPTION
Matches `d_a_obj_hami2` for the three retail versions: GZLE01, GZLJ01 and GZLP01.

Decompiled from the split assembly. The REL builds SHA1-identical to
`config/<version>/build.sha1` for those three, each verified locally against its own
unmodified manifest. Status is set to
`MatchingFor("GZLJ01", "GZLE01", "GZLP01")` to match that evidence exactly.

D44J01 (the kiosk demo) does NOT match and is deliberately excluded — the built REL
hashes `c7b0876c...` against the manifest's `cf947424...`. This mirrors the convention
already used by 61 other ActorRel entries in configure.py. CI's D44J01 report on this

Measured rather than inferred: objdiff reports the D44J01 object at **92.05%**
instruction-level code match against its own extracted base, so the exclusion is a
measurement, not a conservative guess.
PR is absent for the same reason.

Correcting this PR's original description, which claimed all four versions: the D44J01
column was asserted from the manifest's expected hashes rather than measured against
the built RELs. Three versions are measured; the fourth is now correctly excluded
rather than claimed.

Member names follow the `field_0xNNN` placeholder convention for unknowns; `Prm_e` /
`PRM_*` naming mirrors the already-merged `d_a_obj_hami3`.
