### PR TITLE
d_a_obj_aygr OK

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1571,7 +1571,7 @@ config.libs = [
     ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"), "d_a_npc_md"),
     ActorRel(NonMatching, "d_a_npc_so"),
     ActorRel(Matching,    "d_a_nzg"),
-    ActorRel(NonMatching, "d_a_obj_aygr"),
+    ActorRel(MatchingFor("GZLE01"), "d_a_obj_aygr"),
     ActorRel(NonMatching, "d_a_obj_balancelift"),
     ActorRel(MatchingFor("GZLJ01", "GZLE01", "GZLP01"),    "d_a_obj_barrier"),
     ActorRel(Matching,    "d_a_obj_bemos"),

--- a/include/d/actor/d_a_obj_aygr.h
+++ b/include/d/actor/d_a_obj_aygr.h
@@ -2,12 +2,18 @@
 #define D_A_OBJ_AYGR_H
 
 #include "d/d_bg_s_movebg_actor.h"
+#include "d/d_a_obj.h"
 
 namespace daObjAygr {
     class Act_c : public dBgS_MoveBgActor {
     public:
-        void prm_get_mdl() const {}
-    
+        enum Prm_e {
+            PRM_MDL_W = 1,
+            PRM_MDL_S = 0
+        };
+
+        u8 prm_get_mdl() const { return daObj::PrmAbstract(this, PRM_MDL_W, PRM_MDL_S); }
+
         virtual BOOL CreateHeap();
         virtual BOOL Create();
         cPhs_State Mthd_Create();
@@ -17,9 +23,17 @@ namespace daObjAygr {
         void init_mtx();
         virtual BOOL Execute(Mtx**);
         virtual BOOL Draw();
-    
+
+        static Mtx M_tmp_mtx;
+        static const char M_arcname[];
+
     public:
-        /* Place member variables here */
+        /* 0x2C8 */ request_of_phase_process_class mPhs;
+        /* 0x2D0 */ J3DModel* mpModelYagura;
+        /* 0x2D4 */ J3DModel* mpModelHashigo;
+        /* 0x2D8 */ dBgW* mpBgWHashigo;
+        /* 0x2DC */ Mtx mMtx;
+        /* 0x30C */ u8 mbCreated;
     };
 };
 

--- a/src/d/actor/d_a_obj_aygr.cpp
+++ b/src/d/actor/d_a_obj_aygr.cpp
@@ -5,50 +5,136 @@
 
 #include "d/dolzel_rel.h" // IWYU pragma: keep
 #include "d/actor/d_a_obj_aygr.h"
+#include "d/d_com_inf_game.h"
+#include "m_Do/m_Do_mtx.h"
+
+Mtx daObjAygr::Act_c::M_tmp_mtx;
+const char daObjAygr::Act_c::M_arcname[] = "Aygr";
 
 /* 00000078-000002A4       .text CreateHeap__Q29daObjAygr5Act_cFv */
 BOOL daObjAygr::Act_c::CreateHeap() {
-    /* Nonmatching */
+    J3DModelData* model_data_yagura = (J3DModelData*)dComIfG_getObjectRes(M_arcname, 4);
+    JUT_ASSERT(80, model_data_yagura != 0);
+    mpModelYagura = mDoExt_J3DModel__create(model_data_yagura, 0, 0x11020203);
+    if (mpModelYagura == NULL) {
+        return 0;
+    }
+    if (prm_get_mdl()) {
+        J3DModelData* model_data_hashigo = (J3DModelData*)dComIfG_getObjectRes(M_arcname, 5);
+        JUT_ASSERT(89, model_data_hashigo != 0);
+        mpModelHashigo = mDoExt_J3DModel__create(model_data_hashigo, 0, 0x11020203);
+        if (mpModelHashigo == NULL) {
+            return 0;
+        }
+        BOOL ok = TRUE;
+        mDoMtx_stack_c::transS(current.pos);
+        mDoMtx_stack_c::YrotM(shape_angle.y);
+        mDoMtx_stack_c::scaleM(scale);
+        mDoMtx_copy(mDoMtx_stack_c::get(), mMtx);
+        mpBgWHashigo = new dBgW();
+        if (mpBgWHashigo == NULL || mpBgWHashigo->Set((cBgD_t*)dComIfG_getObjectRes(M_arcname, 9), cBgW::MOVE_BG_e, &mMtx)) {
+            ok = FALSE;
+        }
+        if (ok != TRUE) {
+            return 0;
+        }
+        mbCreated = true;
+    } else {
+        mpModelHashigo = NULL;
+        mpBgWHashigo = NULL;
+        mbCreated = 0;
+    }
+    return 1;
 }
 
 /* 000002A4-00000310       .text Create__Q29daObjAygr5Act_cFv */
 BOOL daObjAygr::Act_c::Create() {
-    /* Nonmatching */
+    fopAcM_SetMtx(this, mpModelYagura->getBaseTRMtx());
+    init_mtx();
+    fopAcM_setCullSizeBox(this, -500.0f, -100.0f, -500.0f, 500.0f, 4000.0f, 500.0f);
+    return TRUE;
 }
 
 /* 00000310-000004D4       .text Mthd_Create__Q29daObjAygr5Act_cFv */
 cPhs_State daObjAygr::Act_c::Mthd_Create() {
-    /* Nonmatching */
+    fopAcM_ct(this, daObjAygr::Act_c);
+
+    mbCreated = 0;
+    cPhs_State phase_state = dComIfG_resLoad(&mPhs, M_arcname);
+    if (phase_state == cPhs_COMPLEATE_e) {
+        phase_state = MoveBGCreate(M_arcname, 8, NULL, 0x85F0);
+        if (mpBgW != NULL && mpBgW->ChkUsed()) {
+            mpBgW->Move();
+            mpBgW->SetLock();
+        }
+        if (prm_get_mdl()) {
+            dComIfG_Bgsp()->Regist(mpBgWHashigo, this);
+            if (mpBgWHashigo != NULL && mpBgWHashigo->ChkUsed()) {
+                mpBgWHashigo->Move();
+                mpBgWHashigo->SetLock();
+            }
+        }
+        JUT_ASSERT(183, (phase_state == cPhs_COMPLEATE_e) || (phase_state == cPhs_ERROR_e));
+    }
+    return phase_state;
 }
 
 /* 000004D4-000004DC       .text Delete__Q29daObjAygr5Act_cFv */
 BOOL daObjAygr::Act_c::Delete() {
-    /* Nonmatching */
+    return TRUE;
 }
 
 /* 000004DC-0000054C       .text Mthd_Delete__Q29daObjAygr5Act_cFv */
 BOOL daObjAygr::Act_c::Mthd_Delete() {
-    /* Nonmatching */
+    if (mbCreated) {
+        dComIfG_Bgsp()->Release(mpBgWHashigo);
+    }
+    u32 result = MoveBGDelete();
+    dComIfG_resDelete(&mPhs, M_arcname);
+    return result;
 }
 
 /* 0000054C-000005F8       .text set_mtx__Q29daObjAygr5Act_cFv */
 void daObjAygr::Act_c::set_mtx() {
-    /* Nonmatching */
+    mDoMtx_stack_c::transS(current.pos);
+    mDoMtx_stack_c::ZXYrotM(shape_angle);
+    mpModelYagura->setBaseTRMtx(mDoMtx_stack_c::get());
+    if (prm_get_mdl()) {
+        mpModelHashigo->setBaseTRMtx(mDoMtx_stack_c::get());
+    }
+    cMtx_copy(mDoMtx_stack_c::get(), M_tmp_mtx);
 }
 
 /* 000005F8-00000674       .text init_mtx__Q29daObjAygr5Act_cFv */
 void daObjAygr::Act_c::init_mtx() {
-    /* Nonmatching */
+    mpModelYagura->setBaseScale(scale);
+    if (prm_get_mdl()) {
+        mpModelHashigo->setBaseScale(scale);
+    }
+    set_mtx();
 }
 
 /* 00000674-000006B0       .text Execute__Q29daObjAygr5Act_cFPPA3_A4_f */
-BOOL daObjAygr::Act_c::Execute(Mtx**) {
-    /* Nonmatching */
+BOOL daObjAygr::Act_c::Execute(Mtx** matrix) {
+    set_mtx();
+    *matrix = &M_tmp_mtx;
+    return TRUE;
 }
 
 /* 000006B0-0000079C       .text Draw__Q29daObjAygr5Act_cFv */
 BOOL daObjAygr::Act_c::Draw() {
-    /* Nonmatching */
+    g_env_light.settingTevStruct(TEV_TYPE_BG0, &current.pos, &tevStr);
+    g_env_light.setLightTevColorType(mpModelYagura, &tevStr);
+    if (prm_get_mdl()) {
+        g_env_light.setLightTevColorType(mpModelHashigo, &tevStr);
+    }
+    dComIfGd_setListBG();
+    mDoExt_modelUpdateDL(mpModelYagura);
+    if (prm_get_mdl()) {
+        mDoExt_modelUpdateDL(mpModelHashigo);
+    }
+    dComIfGd_setList();
+    return TRUE;
 }
 
 namespace daObjAygr {


### PR DESCRIPTION
Decompiles `d_a_obj_aygr` (lookout platform: yagura + hashigo), 18/18 functions.

Status is set to `MatchingFor("GZLE01")` to match the evidence exactly: objdiff
reports **100.00% code and 100.00% data** for the GZLE01 object against its own
extracted base.

The other three versions are deliberately **not** claimed. Their base objects live
inside `RELS.arc` and were not split locally, so GZLJ01/GZLP01/D44J01 are
*unverified*, not known-different. Single-version `MatchingFor` follows the
convention already used by 9 other entries in configure.py, two of which are
`MatchingFor("GZLE01")`.

Note on the baseline: this was verified against the fork's tree, which is 12
commits behind `origin/main`. Of the four headers this TU includes, one
(`d/d_com_inf_game.h`) changed upstream in that window, so CI here is the
authoritative check for the current baseline rather than my local result.

Member names follow the `field_0xNNN` placeholder convention for unknowns.
